### PR TITLE
feat: Support live objects enumeration for GC

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -155,8 +155,9 @@ void JeandleAssembler::patch_call_vm(int inst_offset, address target) {
 }
 
 int JeandleAssembler::fixup_call_inst_offset(int offset) {
-  assert(offset >= 0, "invalid offset")
-  return offset;
+  assert(offset >= 0, "invalid offset");
+  // point to the end of call instruction
+  return offset + NativeInstruction::instruction_size;
 }
 
 bool JeandleAssembler::is_oop_reloc_kind(LinkKind kind) {

--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -33,7 +33,7 @@
 void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
   assert(call->type() == JeandleJavaCall::STATIC_CALL, "illegal call type");
   const int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::STATIC_CALL);
-  address call_pc = __ addr_at(call->inst_offset() - call_site_size);
+  address call_address = __ addr_at(call->pc_offset() - call_site_size);
 
   // same as C1 call_stub_size()
   const int stub_size = 13 * NativeInstruction::instruction_size;
@@ -45,7 +45,7 @@ void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
 
   int start = __ offset();
 
-  __ relocate(static_stub_Relocation::spec(call_pc));
+  __ relocate(static_stub_Relocation::spec(call_address));
   __ isb();
   __ mov_metadata(rmethod, nullptr);
   __ movptr(rscratch1, 0);
@@ -58,10 +58,10 @@ void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
 void JeandleAssembler::patch_static_call_site(CallSiteInfo* call) {
   assert(call->type() == JeandleJavaCall::STATIC_CALL, "illegal call type");
   const int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::STATIC_CALL);
-  address call_pc = __ addr_at(call->inst_offset() - call_site_size);
+  address call_address = __ addr_at(call->pc_offset() - call_site_size);
 
   address insts_end = __ code()->insts_end();
-  __ code()->set_insts_end(call_pc);
+  __ code()->set_insts_end(call_address);
 
   Address call_addr = Address(call->target(), relocInfo::static_call_type);
   // emit trampoline call for patch
@@ -72,7 +72,7 @@ void JeandleAssembler::patch_static_call_site(CallSiteInfo* call) {
 void JeandleAssembler::patch_vm_call_site(CallSiteInfo* call) {
   assert(call->type() == JeandleJavaCall::VM_CALL, "illegal call type");
   const int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::VM_CALL);
-  address patch_pc = __ addr_at(call->inst_offset() - call_site_size);
+  address patch_pc = __ addr_at(call->pc_offset() - call_site_size);
 
   address insts_end = __ code()->insts_end();
   __ code()->set_insts_end(patch_pc);
@@ -89,15 +89,15 @@ void JeandleAssembler::patch_vm_call_site(CallSiteInfo* call) {
 }
 
 void JeandleAssembler::patch_ic_call_site(CallSiteInfo* call) {
-  assert(call->inst_offset() != 0, "invalid call instruction address");
+  assert(call->pc_offset() != 0, "invalid call instruction address");
   assert(call->type() == JeandleJavaCall::DYNAMIC_CALL, "illegal call type");
 
   const int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::DYNAMIC_CALL);
-  address call_pc = __ addr_at(call->inst_offset() - call_site_size);
+  address call_address = __ addr_at(call->pc_offset() - call_site_size);
 
   // Set insts_end to where to patch
   address insts_end = __ code()->insts_end();
-  __ code()->set_insts_end(call_pc);
+  __ code()->set_insts_end(call_address);
 
   // Patch
   __ ic_call(call->target());
@@ -145,8 +145,8 @@ void JeandleAssembler::emit_oop_reloc(uint32_t offset, jobject oop_handle) {
   __ code_section()->relocate(at_addr, rspec);
 }
 
-void JeandleAssembler::patch_call_vm(uint32_t operand_offset, address target) {
-  address call_pc = __ addr_at(operand_offset);
+void JeandleAssembler::patch_call_vm(uint32_t inst_offset, address target) {
+  address call_pc = __ addr_at(inst_offset);
 
   // Set insts_end to where to patch
   address insts_end = __ code()->insts_end();

--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -30,10 +30,9 @@
 
 #define __ _masm->
 
-void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
+void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
   assert(call->type() == JeandleJavaCall::STATIC_CALL, "illegal call type");
-  const int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::STATIC_CALL);
-  address call_address = __ addr_at(call->pc_offset() - call_site_size);
+  address call_address = __ addr_at(inst_offset);
 
   // same as C1 call_stub_size()
   const int stub_size = 13 * NativeInstruction::instruction_size;
@@ -55,10 +54,9 @@ void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
   __ end_a_stub();
 }
 
-void JeandleAssembler::patch_static_call_site(CallSiteInfo* call) {
+void JeandleAssembler::patch_static_call_site(int inst_offset, CallSiteInfo* call) {
   assert(call->type() == JeandleJavaCall::STATIC_CALL, "illegal call type");
-  const int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::STATIC_CALL);
-  address call_address = __ addr_at(call->pc_offset() - call_site_size);
+  address call_address = __ addr_at(inst_offset);
 
   address insts_end = __ code()->insts_end();
   __ code()->set_insts_end(call_address);
@@ -69,10 +67,9 @@ void JeandleAssembler::patch_static_call_site(CallSiteInfo* call) {
   __ code()->set_insts_end(insts_end);
 }
 
-void JeandleAssembler::patch_vm_call_site(CallSiteInfo* call) {
+void JeandleAssembler::patch_vm_call_site(int inst_offset, CallSiteInfo* call) {
   assert(call->type() == JeandleJavaCall::VM_CALL, "illegal call type");
-  const int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::VM_CALL);
-  address patch_pc = __ addr_at(call->pc_offset() - call_site_size);
+  address patch_pc = __ addr_at(inst_offset);
 
   address insts_end = __ code()->insts_end();
   __ code()->set_insts_end(patch_pc);
@@ -88,12 +85,11 @@ void JeandleAssembler::patch_vm_call_site(CallSiteInfo* call) {
   __ code()->set_insts_end(insts_end);
 }
 
-void JeandleAssembler::patch_ic_call_site(CallSiteInfo* call) {
-  assert(call->pc_offset() != 0, "invalid call instruction address");
+void JeandleAssembler::patch_ic_call_site(int inst_offset, CallSiteInfo* call) {
+  assert(inst_offset >= 0, "invalid call instruction address");
   assert(call->type() == JeandleJavaCall::DYNAMIC_CALL, "illegal call type");
 
-  const int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::DYNAMIC_CALL);
-  address call_address = __ addr_at(call->pc_offset() - call_site_size);
+  address call_address = __ addr_at(inst_offset);
 
   // Set insts_end to where to patch
   address insts_end = __ code()->insts_end();
@@ -125,8 +121,8 @@ void JeandleAssembler::emit_ic_check() {
 
 using LinkKind_aarch64 = llvm::jitlink::aarch64::EdgeKind_aarch64;
 
-void JeandleAssembler::emit_const_reloc(uint32_t operand_offset, LinkKind kind, int64_t addend, address target) {
-  assert(operand_offset != 0, "invalid operand address");
+void JeandleAssembler::emit_const_reloc(int operand_offset, LinkKind kind, int64_t addend, address target) {
+  assert(operand_offset >= 0, "invalid operand address");
   assert(kind == LinkKind_aarch64::Page21 ||
          kind == LinkKind_aarch64::PageOffset12,
          "unexpected link kind: %d", kind);
@@ -138,14 +134,14 @@ void JeandleAssembler::emit_const_reloc(uint32_t operand_offset, LinkKind kind, 
   __ code_section()->relocate(at_addr, rspec);
 }
 
-void JeandleAssembler::emit_oop_reloc(uint32_t offset, jobject oop_handle) {
+void JeandleAssembler::emit_oop_reloc(int offset, jobject oop_handle) {
   address at_addr = __ code()->insts_begin() + offset;
   int index = __ oop_recorder()->find_index(oop_handle);
   RelocationHolder rspec = jeandle_oop_Relocation::spec(index);
   __ code_section()->relocate(at_addr, rspec);
 }
 
-void JeandleAssembler::patch_call_vm(uint32_t inst_offset, address target) {
+void JeandleAssembler::patch_call_vm(int inst_offset, address target) {
   address call_pc = __ addr_at(inst_offset);
 
   // Set insts_end to where to patch
@@ -158,7 +154,8 @@ void JeandleAssembler::patch_call_vm(uint32_t inst_offset, address target) {
   __ code()->set_insts_end(insts_end);
 }
 
-uint32_t JeandleAssembler::fixup_call_inst_offset(uint32_t offset) {
+int JeandleAssembler::fixup_call_inst_offset(int offset) {
+  assert(offset >= 0, "invalid offset")
   return offset;
 }
 

--- a/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
@@ -36,18 +36,20 @@ public:
   }
 
   static const bool is_stack_pointer(Register reg) {
-    Unimplemented();
-    return false;
+    return reg == sp;
   }
 
   static const Register decode_dwarf_register(int dwarf_encoding) {
-    Unimplemented();
-    return noreg;
+    assert(dwarf_encoding >=0 && dwarf_encoding < Register::number_of_registers, "invalid dwarf register number");
+    return _dwarf_registers[dwarf_encoding];
   }
 
 private:
   static constexpr const Register _dwarf_registers[Register::number_of_registers] = {
-    /* Unimplemented */
+    r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10,
+    r11, r12, r13, r14, r15, r16, r17, r18_tls, r19, r20,
+    r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+    sp
   };
 };
 

--- a/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
@@ -34,6 +34,21 @@ public:
     // rthread is x28 on aarch64
     return "x28";
   }
+
+  static const bool is_stack_pointer(Register reg) {
+    Unimplemented();
+    return false;
+  }
+
+  static const Register decode_dwarf_register(int dwarf_encoding) {
+    Unimplemented();
+    return noreg;
+  }
+
+private:
+  static constexpr const Register all_DwarfRegisters[Register::number_of_registers] = {
+    /* Unimplemented */
+  };
 };
 
 #endif // CPU_AARCH64_JEANDLEREGISTER_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
@@ -46,7 +46,7 @@ public:
   }
 
 private:
-  static constexpr const Register all_DwarfRegisters[Register::number_of_registers] = {
+  static constexpr const Register _dwarf_registers[Register::number_of_registers] = {
     /* Unimplemented */
   };
 };

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -31,9 +31,9 @@
 #define __ _masm->
 
 void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
-  assert(call->inst_offset() != 0, "invalid call instruction address");
+  assert(call->pc_offset() != 0, "invalid call instruction address");
   assert(call->type() == JeandleJavaCall::Type::STATIC_CALL, "legal call type");
-  address call_pc = __ addr_at(call->inst_offset() - JeandleJavaCall::call_site_size(JeandleJavaCall::Type::STATIC_CALL));
+  address call_address = __ addr_at(call->pc_offset() - JeandleJavaCall::call_site_size(JeandleJavaCall::Type::STATIC_CALL));
 
   int stub_size = 28;
   address stub = __ start_a_stub(stub_size);
@@ -46,7 +46,7 @@ void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
 
   // FIXME: Whether we need alignment here?
   __ align(BytesPerWord, __ offset() + NativeMovConstReg::instruction_size + NativeCall::displacement_offset);
-  __ relocate(static_stub_Relocation::spec(call_pc));
+  __ relocate(static_stub_Relocation::spec(call_address));
   __ mov_metadata(rbx, (Metadata*)nullptr);
   assert(((__ offset() + 1) % BytesPerWord) == 0, "must be aligned");
   __ jump(RuntimeAddress(__ pc()));
@@ -56,13 +56,13 @@ void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
 }
 
 void JeandleAssembler::patch_static_call_site(CallSiteInfo* call) {
-  assert(call->inst_offset() != 0, "invalid call instruction address");
+  assert(call->pc_offset() != 0, "invalid call instruction address");
   assert(call->type() == JeandleJavaCall::Type::STATIC_CALL, "legal call type");
-  address call_pc =  __ addr_at(call->inst_offset() - JeandleJavaCall::call_site_size(JeandleJavaCall::Type::STATIC_CALL));
+  address call_address =  __ addr_at(call->pc_offset() - JeandleJavaCall::call_site_size(JeandleJavaCall::Type::STATIC_CALL));
 
   // Set insts_end to where to patch.
   address insts_end = __ code()->insts_end();
-  __ code()->set_insts_end(call_pc);
+  __ code()->set_insts_end(call_address);
 
   // Patch.
   __ call(AddressLiteral(call->target(), relocInfo::static_call_type));
@@ -77,15 +77,15 @@ void JeandleAssembler::patch_vm_call_site(CallSiteInfo* call) {
 }
 
 void JeandleAssembler::patch_ic_call_site(CallSiteInfo* call) {
-  assert(call->inst_offset() != 0, "invalid call instruction address");
+  assert(call->pc_offset() != 0, "invalid call instruction address");
   assert(call->type() == JeandleJavaCall::Type::DYNAMIC_CALL, "legal call type");
 
   int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::Type::DYNAMIC_CALL);
-  address call_pc =  __ addr_at(call->inst_offset() - call_site_size);
+  address call_address =  __ addr_at(call->pc_offset() - call_site_size);
 
   // Set insts_end to where to patch.
   address insts_end = __ code()->insts_end();
-  __ code()->set_insts_end(call_pc);
+  __ code()->set_insts_end(call_address);
 
   // Patch.
   __ ic_call(call->target());
@@ -132,14 +132,14 @@ void JeandleAssembler::emit_oop_reloc(uint32_t offset, jobject oop_handle) {
   __ code_section()->relocate(at_address, rspec, __ disp32_operand);
 }
 
-void JeandleAssembler::patch_call_vm(uint32_t operand_offset, address target) {
-  assert(operand_offset != 0, "invalid operand address");
+void JeandleAssembler::patch_call_vm(uint32_t inst_offset, address target) {
+  assert(inst_offset != 0, "invalid operand address");
 
-  address call_pc = __ addr_at(operand_offset - 1);
+  address call_address = __ addr_at(inst_offset);
 
   // Set insts_end to where to patch.
   address insts_end = __ code()->insts_end();
-  __ code()->set_insts_end(call_pc);
+  __ code()->set_insts_end(call_address);
 
   // Patch.
   __ call(AddressLiteral(target, relocInfo::runtime_call_type));

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -30,10 +30,10 @@
 
 #define __ _masm->
 
-void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
-  assert(call->pc_offset() != 0, "invalid call instruction address");
+void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
+  assert(inst_offset >= 0, "invalid call instruction address");
   assert(call->type() == JeandleJavaCall::Type::STATIC_CALL, "legal call type");
-  address call_address = __ addr_at(call->pc_offset() - JeandleJavaCall::call_site_size(JeandleJavaCall::Type::STATIC_CALL));
+  address call_address = __ addr_at(inst_offset);
 
   int stub_size = 28;
   address stub = __ start_a_stub(stub_size);
@@ -55,10 +55,10 @@ void JeandleAssembler::emit_static_call_stub(CallSiteInfo* call) {
   __ end_a_stub();
 }
 
-void JeandleAssembler::patch_static_call_site(CallSiteInfo* call) {
-  assert(call->pc_offset() != 0, "invalid call instruction address");
+void JeandleAssembler::patch_static_call_site(int inst_offset, CallSiteInfo* call) {
+  assert(inst_offset >= 0, "invalid call instruction address");
   assert(call->type() == JeandleJavaCall::Type::STATIC_CALL, "legal call type");
-  address call_address =  __ addr_at(call->pc_offset() - JeandleJavaCall::call_site_size(JeandleJavaCall::Type::STATIC_CALL));
+  address call_address =  __ addr_at(inst_offset);
 
   // Set insts_end to where to patch.
   address insts_end = __ code()->insts_end();
@@ -72,16 +72,15 @@ void JeandleAssembler::patch_static_call_site(CallSiteInfo* call) {
   __ code()->set_insts_end(insts_end);
 }
 
-void JeandleAssembler::patch_vm_call_site(CallSiteInfo* call) {
+void JeandleAssembler::patch_vm_call_site(int inst_offset, CallSiteInfo* call) {
   // No need to patch vm call site on x86.
 }
 
-void JeandleAssembler::patch_ic_call_site(CallSiteInfo* call) {
-  assert(call->pc_offset() != 0, "invalid call instruction address");
+void JeandleAssembler::patch_ic_call_site(int inst_offset, CallSiteInfo* call) {
+  assert(inst_offset >= 0, "invalid call instruction address");
   assert(call->type() == JeandleJavaCall::Type::DYNAMIC_CALL, "legal call type");
 
-  int call_site_size = JeandleJavaCall::call_site_size(JeandleJavaCall::Type::DYNAMIC_CALL);
-  address call_address =  __ addr_at(call->pc_offset() - call_site_size);
+  address call_address =  __ addr_at(inst_offset);
 
   // Set insts_end to where to patch.
   address insts_end = __ code()->insts_end();
@@ -114,8 +113,8 @@ void JeandleAssembler::emit_ic_check() {
 
 using LinkKind_x86_64 = llvm::jitlink::x86_64::EdgeKind_x86_64;
 
-void JeandleAssembler::emit_const_reloc(uint32_t operand_offset, LinkKind kind, int64_t addend, address target) {
-  assert(operand_offset != 0, "invalid operand address");
+void JeandleAssembler::emit_const_reloc(int operand_offset, LinkKind kind, int64_t addend, address target) {
+  assert(operand_offset >= 0, "invalid operand address");
   assert(kind == LinkKind_x86_64::Delta32, "invalid link kind");
 
   address at_address = __ code()->insts_begin() + operand_offset;
@@ -125,15 +124,15 @@ void JeandleAssembler::emit_const_reloc(uint32_t operand_offset, LinkKind kind, 
   __ code_section()->relocate(at_address, rspec, __ disp32_operand);
 }
 
-void JeandleAssembler::emit_oop_reloc(uint32_t offset, jobject oop_handle) {
+void JeandleAssembler::emit_oop_reloc(int offset, jobject oop_handle) {
   int index = __ oop_recorder()->find_index(oop_handle);
   RelocationHolder rspec = jeandle_oop_Relocation::spec(index);
   address at_address = __ code()->insts_begin() + offset;
   __ code_section()->relocate(at_address, rspec, __ disp32_operand);
 }
 
-void JeandleAssembler::patch_call_vm(uint32_t inst_offset, address target) {
-  assert(inst_offset != 0, "invalid operand address");
+void JeandleAssembler::patch_call_vm(int inst_offset, address target) {
+  assert(inst_offset >= 0, "invalid operand address");
 
   address call_address = __ addr_at(inst_offset);
 
@@ -148,7 +147,8 @@ void JeandleAssembler::patch_call_vm(uint32_t inst_offset, address target) {
   __ code()->set_insts_end(insts_end);
 }
 
-uint32_t JeandleAssembler::fixup_call_inst_offset(uint32_t offset) {
+int JeandleAssembler::fixup_call_inst_offset(int offset) {
+  assert(offset >= 0, "invalid offset");
   return offset + 4;
 }
 

--- a/src/hotspot/cpu/x86/jeandleRegister_x86.hpp
+++ b/src/hotspot/cpu/x86/jeandleRegister_x86.hpp
@@ -34,6 +34,24 @@ public:
   static const char* get_current_thread_pointer() {
     return r15->name();
   }
+
+  static const bool is_stack_pointer(Register reg) {
+    return reg == rsp;
+  }
+
+  static const Register decode_dwarf_register(int dwarf_encoding) {
+    return all_DwarfRegisters[dwarf_encoding];
+  }
+
+private:
+  static constexpr const Register all_DwarfRegisters[Register::number_of_registers] = {
+#ifdef _LP64
+    rax, rdx, rcx, rbx, rsi, rdi, rbp, rsp,
+    r8, r9, r10, r11, r12, r13, r14, r15
+#else
+    rax, rdx, rcx, rbx, rsi, rdi, rbp, rsp
+#endif // _LP_64
+  };
 };
 #endif // _LP64
 

--- a/src/hotspot/cpu/x86/jeandleRegister_x86.hpp
+++ b/src/hotspot/cpu/x86/jeandleRegister_x86.hpp
@@ -40,17 +40,14 @@ public:
   }
 
   static const Register decode_dwarf_register(int dwarf_encoding) {
-    return all_DwarfRegisters[dwarf_encoding];
+    assert(dwarf_encoding >=0 && dwarf_encoding < Register::number_of_registers, "invalid dwarf register number");
+    return _dwarf_registers[dwarf_encoding];
   }
 
 private:
-  static constexpr const Register all_DwarfRegisters[Register::number_of_registers] = {
-#ifdef _LP64
+  static constexpr const Register _dwarf_registers[Register::number_of_registers] = {
     rax, rdx, rcx, rbx, rsi, rdi, rbp, rsp,
     r8, r9, r10, r11, r12, r13, r14, r15
-#else
-    rax, rdx, rcx, rbx, rsi, rdi, rbp, rsp
-#endif // _LP_64
   };
 };
 #endif // _LP64

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -644,7 +644,7 @@ void CompileBroker::compilation_init_phase1(JavaThread* THREAD) {
   }
 #endif // COMPILER1
 
-#ifdef COMPILER2_OR_JEANDLE
+#if COMPILER2_OR_JEANDLE
   if (true JVMCI_ONLY( && !UseJVMCICompiler)) {
     if (_c2_count > 0) {
 #ifdef JEANDLE

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -568,7 +568,7 @@ bool CompilerConfig::check_args_consistency(bool status) {
 }
 
 void CompilerConfig::ergo_initialize() {
-#if !COMPILER1_OR_COMPILER2
+#if !COMPILER1_OR_COMPILER2 && !COMPILER2_OR_JEANDLE
   return;
 #endif
 
@@ -641,5 +641,15 @@ void CompilerConfig::ergo_initialize() {
     LoopStripMiningIterShortLoop = LoopStripMiningIter / 10;
   }
 #endif // COMPILER2
+
+#ifdef JEANDLE
+  // TODO: Support compressed oops later.
+  if (UseJeandleCompiler) {
+    if (FLAG_IS_CMDLINE(UseCompressedOops) && UseCompressedOops) {
+      warning("UseCompressedOops is disabled until jeandle supports compressed oops.");
+    }
+    UseCompressedOops = false;
+  }
+#endif // JEANDLE
 }
 

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -568,7 +568,7 @@ bool CompilerConfig::check_args_consistency(bool status) {
 }
 
 void CompilerConfig::ergo_initialize() {
-#if !COMPILER1_OR_COMPILER2 && !COMPILER2_OR_JEANDLE
+#if !COMPILER1_OR_COMPILER2 && !defined(JEANDLE)
   return;
 #endif
 

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -35,13 +35,13 @@ class JeandleAssembler : public StackObj {
  public:
   JeandleAssembler(MacroAssembler* masm) : _masm(masm) {}
 
-  void emit_static_call_stub(CallSiteInfo* call);
+  void emit_static_call_stub(int inst_offset, CallSiteInfo* call);
 
-  void patch_static_call_site(CallSiteInfo* call);
+  void patch_static_call_site(int inst_offset, CallSiteInfo* call);
 
-  void patch_vm_call_site(CallSiteInfo* call);
+  void patch_vm_call_site(int inst_offset, CallSiteInfo* call);
 
-  void patch_ic_call_site(CallSiteInfo* call);
+  void patch_ic_call_site(int inst_offset, CallSiteInfo* call);
 
   void emit_ic_check();
 
@@ -49,14 +49,14 @@ class JeandleAssembler : public StackObj {
 
   void emit_consts(address consts_start, uint64_t consts_size);
 
-  void emit_const_reloc(uint32_t offset, LinkKind kind, int64_t addend, address target);
+  void emit_const_reloc(int offset, LinkKind kind, int64_t addend, address target);
 
-  void emit_oop_reloc(uint32_t offset, jobject oop_handle);
+  void emit_oop_reloc(int offset, jobject oop_handle);
 
-  void patch_call_vm(uint32_t offset, address target);
+  void patch_call_vm(int offset, address target);
 
   // Redirect an offset from the displacement to the end of the call instruction
-  static uint32_t fixup_call_inst_offset(uint32_t offset);
+  static int fixup_call_inst_offset(int offset);
 
   static bool is_oop_reloc_kind(LinkKind kind);
 

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -158,7 +158,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                                   _code.code_buffer(),
                                                   CodeOffsets::frame_never_safe,
                                                   _code.frame_size(),
-                                                  nullptr, //TODO: generate oopmaps for runtime_stub.
+                                                  _env->debug_info()->_oopmaps,
                                                   false);
   assert(rs != nullptr && rs->is_runtime_stub(), "sanity check");
   _code.set_stub_entry(rs->entry_point());

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -158,7 +158,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                                   _code.code_buffer(),
                                                   CodeOffsets::frame_never_safe,
                                                   _code.frame_size(),
-                                                  _env->debug_info()->_oopmaps,
+                                                  nullptr, //TODO: generate oopmaps for runtime_stub.
                                                   false);
   assert(rs != nullptr && rs->is_runtime_stub(), "sanity check");
   _code.set_stub_entry(rs->entry_point());

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -30,6 +30,7 @@
 #include "utilities/debug.hpp"
 #include "asm/macroAssembler.hpp"
 #include "ci/ciEnv.hpp"
+#include "code/vmreg.inline.hpp"
 
 namespace {
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -92,11 +92,11 @@ class JeandleConstReloc : public JeandleReloc {
 
 class JeandleSafepointReloc : public JeandleReloc {
  public:
-  JeandleSafepointReloc(int pc_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
-    JeandleReloc(pc_offset - JeandleJavaCall::call_site_size(call->type())/* beginning offset of a call instruction */),
+  JeandleSafepointReloc(int inst_end_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
+    JeandleReloc(inst_end_offset - JeandleJavaCall::call_site_size(call->type())/* beginning offset of a call instruction */),
     _env(env), _method(method), _oop_map(oop_map), _call(call) {}
 
-  int pc_offset() {
+  int inst_end_offset() {
     return offset() + JeandleJavaCall::call_site_size(_call->type());
   }
 
@@ -113,8 +113,8 @@ class JeandleSafepointReloc : public JeandleReloc {
 
 class JeandleCallVMReloc : public JeandleSafepointReloc {
  public:
-  JeandleCallVMReloc(int pc_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
-    JeandleSafepointReloc(pc_offset, env, method, oop_map, call) {}
+  JeandleCallVMReloc(int inst_end_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
+    JeandleSafepointReloc(inst_end_offset, env, method, oop_map, call) {}
 
   void emit_reloc(JeandleAssembler& assembler) override {
     process_oop_map();
@@ -124,8 +124,8 @@ class JeandleCallVMReloc : public JeandleSafepointReloc {
 
 class JeandleCallReloc : public JeandleSafepointReloc {
  public:
-  JeandleCallReloc(int pc_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
-    JeandleSafepointReloc(pc_offset, env, method, oop_map, call) {}
+  JeandleCallReloc(int inst_end_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
+    JeandleSafepointReloc(inst_end_offset, env, method, oop_map, call) {}
 
   void emit_reloc(JeandleAssembler& assembler) override {
     process_oop_map();
@@ -161,10 +161,10 @@ class JeandleOopReloc : public JeandleReloc {
 
 void JeandleSafepointReloc::process_oop_map() {
   assert(_oop_map != nullptr, "oopmap must be initialized");
-  assert(pc_offset() >= 0, "pc offset must be initialized");
+  assert(inst_end_offset() >= 0, "pc offset must be initialized");
   assert(_fixed_up, "offset must be fixed up");
 
-  int safepoint_pc_offset = pc_offset();
+  int safepoint_pc_offset = inst_end_offset();
 
   DebugInformationRecorder* recorder = _env->debug_info();
   recorder->add_safepoint(safepoint_pc_offset, _oop_map);
@@ -297,10 +297,10 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         // Call VM relocations.
         address target_addr = JeandleRuntimeRoutine::get_stub_entry(*target.getName());
 
-        int call_pc_offset = JeandleAssembler::fixup_call_inst_offset(static_cast<int>(block->getAddress().getValue() + edge.getOffset()));
+        int inst_end_offset = JeandleAssembler::fixup_call_inst_offset(static_cast<int>(block->getAddress().getValue() + edge.getOffset()));
 
         // TODO: Set the right bci.
-        _safepoints[call_pc_offset] = new CallSiteInfo(0/* statepoint_id */, JeandleJavaCall::STATIC_CALL, target_addr, -1/* bci */);
+        _vm_call_sites[inst_end_offset] = new CallSiteInfo(0/* statepoint_id */, JeandleJavaCall::STATIC_CALL, target_addr, -1/* bci */);
       } else if (target.isDefined() && JeandleAssembler::is_const_reloc_kind(edge.getKind())) {
         // Const relocations.
         assert(target.getSection().getName().starts_with(".rodata"), "invalid const section");
@@ -327,13 +327,13 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
     for (auto record = stackmaps.records_begin(); record != stackmaps.records_end(); ++record) {
       assert(_prolog_length != -1, "prolog length must be initialized");
 
-      int pc_offset = static_cast<int>(record->getInstructionOffset());
-      assert(pc_offset >=0, "invalid pc offset");
+      int inst_end_offset = static_cast<int>(record->getInstructionOffset());
+      assert(inst_end_offset >=0, "invalid pc offset");
 
       if (CallSiteInfo* call = _call_sites.lookup(record->getID())) {
-        relocs.push_back(new JeandleCallReloc(pc_offset, _env, _method, build_oop_map(record), call));
-      } else if (CallSiteInfo* safepoint = _safepoints[pc_offset]) {
-        relocs.push_back(new JeandleCallVMReloc(pc_offset, _env, _method, build_oop_map(record), safepoint));
+        relocs.push_back(new JeandleCallReloc(inst_end_offset, _env, _method, build_oop_map(record), call));
+      } else if (CallSiteInfo* vm_call = _vm_call_sites[inst_end_offset]) {
+        relocs.push_back(new JeandleCallVMReloc(inst_end_offset, _env, _method, build_oop_map(record), vm_call));
       }
     }
   }

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -35,11 +35,20 @@ namespace {
 
 class JeandleReloc {
  public:
-  JeandleReloc(JeandleCompiledCode& code, uint32_t raw_offset) : _code(code), _offset(raw_offset + code.prolog_length()) {}
+  JeandleReloc(int offset) : _offset(offset) {
+    assert(_offset >= 0, "invalid offset");
+  }
 
-  uint32_t offset() const { return _offset; }
+  int offset() const { return _offset; }
 
   virtual void emit_reloc(JeandleAssembler& assembler) = 0;
+
+  virtual void fixup_offset(int prolog_length) {
+    _offset += prolog_length;
+#ifdef ASSERT
+    _fixed_up = true;
+#endif
+  }
 
   // JeandleReloc should be allocated by arena. Independent from JeandleCompilationResourceObj
   // to avoid ambiguous behavior during template specialization.
@@ -53,19 +62,20 @@ class JeandleReloc {
 
   void  operator delete(void* p) {} // nothing to do
 
+#ifdef ASSERT
  protected:
-  JeandleCompiledCode& code() const { return _code; }
+  bool _fixed_up = false;
+#endif
 
  private:
-  JeandleCompiledCode& _code;
-  // Added with the prolog length.
-  uint32_t _offset;
+  // Need fixing up with the prolog length.
+  int _offset;
 };
 
 class JeandleConstReloc : public JeandleReloc {
  public:
-  JeandleConstReloc(JeandleCompiledCode& code, LinkBlock& block, LinkEdge& edge, address target) :
-    JeandleReloc(code, block.getAddress().getValue() + edge.getOffset()),
+  JeandleConstReloc(LinkBlock& block, LinkEdge& edge, address target) :
+    JeandleReloc(static_cast<int>(block.getAddress().getValue() + edge.getOffset())),
     _kind(edge.getKind()),
     _addend(edge.getAddend()),
     _target(target) {}
@@ -82,62 +92,63 @@ class JeandleConstReloc : public JeandleReloc {
 
 class JeandleSafepointReloc : public JeandleReloc {
  public:
-  JeandleSafepointReloc(JeandleCompiledCode& code, uint32_t raw_pc_offset, OopMap* oop_map, CallSiteInfo* call) :
-    JeandleReloc(code, raw_pc_offset - JeandleJavaCall::call_site_size(call->type())/* beginning offset of a call instruction */),
-    _oop_map(oop_map), _call(call) {
-    // Prolog length should be included, which is calculated in JeandleReloc.
-    _call->set_pc_offset(offset() + JeandleJavaCall::call_site_size(call->type()));
+  JeandleSafepointReloc(int pc_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
+    JeandleReloc(pc_offset - JeandleJavaCall::call_site_size(call->type())/* beginning offset of a call instruction */),
+    _env(env), _method(method), _oop_map(oop_map), _call(call) {}
 
-    process_oop_map();
+  int pc_offset() {
+    return offset() + JeandleJavaCall::call_site_size(_call->type());
   }
 
  protected:
   CallSiteInfo* call() const { return _call; }
-
- private:
   void process_oop_map();
 
+ private:
+  ciEnv* _env;
+  ciMethod* _method;
   OopMap* _oop_map;
   CallSiteInfo* _call;
 };
 
 class JeandleCallVMReloc : public JeandleSafepointReloc {
  public:
-  JeandleCallVMReloc(JeandleCompiledCode& code, uint32_t raw_pc_offset, OopMap* oop_map, CallSiteInfo* call) :
-    JeandleSafepointReloc(code, raw_pc_offset, oop_map, call) {}
+  JeandleCallVMReloc(int pc_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
+    JeandleSafepointReloc(pc_offset, env, method, oop_map, call) {}
 
   void emit_reloc(JeandleAssembler& assembler) override {
+    process_oop_map();
     assembler.patch_call_vm(offset(), call()->target());
   }
 };
 
 class JeandleCallReloc : public JeandleSafepointReloc {
  public:
-  JeandleCallReloc(JeandleCompiledCode& code, uint32_t raw_pc_offset, OopMap* oop_map, CallSiteInfo* call) :
-    JeandleSafepointReloc(code, raw_pc_offset, oop_map, call) {}
+  JeandleCallReloc(int pc_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
+    JeandleSafepointReloc(pc_offset, env, method, oop_map, call) {}
 
   void emit_reloc(JeandleAssembler& assembler) override {
-    assert(call()->pc_offset() != 0, "pc offset must be initialized");
+    process_oop_map();
 
     if (call()->type() == JeandleJavaCall::Type::STATIC_CALL) {
-      assembler.emit_static_call_stub(call());
-      assembler.patch_static_call_site(call());
+      assembler.emit_static_call_stub(offset(), call());
+      assembler.patch_static_call_site(offset(), call());
     }
 
     if (call()->type() == JeandleJavaCall::Type::VM_CALL) {
-      assembler.patch_vm_call_site(call());
+      assembler.patch_vm_call_site(offset(), call());
     }
 
     if (call()->type() == JeandleJavaCall::Type::DYNAMIC_CALL) {
-      assembler.patch_ic_call_site(call());
+      assembler.patch_ic_call_site(offset(), call());
     }
   }
 };
 
 class JeandleOopReloc : public JeandleReloc {
  public:
-  JeandleOopReloc(JeandleCompiledCode& code, uint32_t raw_offset, jobject oop_handle) :
-    JeandleReloc(code, raw_offset),
+  JeandleOopReloc(int offset, jobject oop_handle) :
+    JeandleReloc(offset),
     _oop_handle(oop_handle) {}
 
   void emit_reloc(JeandleAssembler& assembler) override {
@@ -150,12 +161,13 @@ class JeandleOopReloc : public JeandleReloc {
 
 void JeandleSafepointReloc::process_oop_map() {
   assert(_oop_map != nullptr, "oopmap must be initialized");
-  assert(call()->pc_offset() != 0, "pc offset must be initialized");
+  assert(pc_offset() >= 0, "pc offset must be initialized");
+  assert(_fixed_up, "offset must be fixed up");
 
-  uint32_t pc_offset = call()->pc_offset();
+  int safepoint_pc_offset = pc_offset();
 
-  DebugInformationRecorder* recorder = code().env()->debug_info();
-  recorder->add_safepoint(pc_offset, _oop_map);
+  DebugInformationRecorder* recorder = _env->debug_info();
+  recorder->add_safepoint(safepoint_pc_offset, _oop_map);
 
   // No deopt support now.
   GrowableArray<ScopeValue*> *locarray = new GrowableArray<ScopeValue*>(0);
@@ -171,12 +183,12 @@ void JeandleSafepointReloc::process_oop_map() {
 #ifdef ASSERT
   if (call()->type() != JeandleJavaCall::VM_CALL) {
     // If we are not compiling a call vm stub, there must be a valid Java method.
-    assert(code().method(), "invalid Java method");
+    assert(_method, "invalid Java method");
   }
 #endif
-  recorder->describe_scope(pc_offset,
+  recorder->describe_scope(safepoint_pc_offset,
                            methodHandle(),
-                           code().method(),
+                           _method,
                            _call->bci(),
                            false,
                            false,
@@ -188,7 +200,7 @@ void JeandleSafepointReloc::process_oop_map() {
                            expvals,
                            monvals);
 
-  recorder->end_safepoint(pc_offset);
+  recorder->end_safepoint(safepoint_pc_offset);
 }
 
 } // anonymous namespace
@@ -285,7 +297,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         // Call VM relocations.
         address target_addr = JeandleRuntimeRoutine::get_stub_entry(*target.getName());
 
-        uint32_t call_pc_offset = JeandleAssembler::fixup_call_inst_offset(block->getAddress().getValue() + edge.getOffset());
+        int call_pc_offset = JeandleAssembler::fixup_call_inst_offset(static_cast<int>(block->getAddress().getValue() + edge.getOffset()));
 
         // TODO: Set the right bci.
         _safepoints[call_pc_offset] = new CallSiteInfo(0/* statepoint_id */, JeandleJavaCall::STATIC_CALL, target_addr, -1/* bci */);
@@ -296,11 +308,11 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         if (target_addr == nullptr) {
           return;
         }
-        relocs.push_back(new JeandleConstReloc(*this, *block, edge, target_addr));
+        relocs.push_back(new JeandleConstReloc(*block, edge, target_addr));
       } else if (!target.isDefined() && JeandleAssembler::is_oop_reloc_kind(edge.getKind())) {
         // Oop relocations.
         assert((*(target.getName())).starts_with("oop_handle"), "invalid oop relocation name");
-        relocs.push_back(new JeandleOopReloc(*this, block->getAddress().getValue() + edge.getOffset(), _oop_handles[(*(target.getName()))]));
+        relocs.push_back(new JeandleOopReloc(static_cast<int>(block->getAddress().getValue() + edge.getOffset()), _oop_handles[(*(target.getName()))]));
       } else {
         // Unhandled relocations
         ShouldNotReachHere();
@@ -314,10 +326,14 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
     StackMapParser stackmaps(llvm::ArrayRef(((uint8_t*)object_start()) + section_info._offset, section_info._size));
     for (auto record = stackmaps.records_begin(); record != stackmaps.records_end(); ++record) {
       assert(_prolog_length != -1, "prolog length must be initialized");
+
+      int pc_offset = static_cast<int>(record->getInstructionOffset());
+      assert(pc_offset >=0, "invalid pc offset");
+
       if (CallSiteInfo* call = _call_sites.lookup(record->getID())) {
-        relocs.push_back(new JeandleCallReloc(*this, record->getInstructionOffset(), build_oop_map(record), call));
-      } else if (CallSiteInfo* safepoint = _safepoints[record->getInstructionOffset()]) {
-        relocs.push_back(new JeandleCallVMReloc(*this, record->getInstructionOffset(), build_oop_map(record), safepoint));
+        relocs.push_back(new JeandleCallReloc(pc_offset, _env, _method, build_oop_map(record), call));
+      } else if (CallSiteInfo* safepoint = _safepoints[pc_offset]) {
+        relocs.push_back(new JeandleCallVMReloc(pc_offset, _env, _method, build_oop_map(record), safepoint));
       }
     }
   }
@@ -329,6 +345,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
 
   // Step 4: Emit jeandle relocs.
   for (JeandleReloc* reloc : relocs) {
+    reloc->fixup_offset(_prolog_length);
     reloc->emit_reloc(assembler);
   }
 }
@@ -383,9 +400,10 @@ static VMReg resolve_vmreg(const StackMapParser::LocationAccessor& location, Sta
     int oop_slot = offset / VMRegImpl::stack_slot_size;
 
     return VMRegImpl::stack2reg(oop_slot);
-  } else {
-    ShouldNotReachHere();
   }
+
+  ShouldNotReachHere();
+  return nullptr;
 }
 
 OopMap* JeandleCompiledCode::build_oop_map(StackMapParser::record_iterator& record) {

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -19,12 +19,12 @@
  */
 
 #include <cassert>
-#include "llvm/Object/StackMapParser.h"
 #include "llvm/Support/DataExtractor.h"
 
 #include "jeandle/jeandleAssembler.hpp"
 #include "jeandle/jeandleCompilation.hpp"
 #include "jeandle/jeandleCompiledCode.hpp"
+#include "jeandle/jeandleRegister.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 
 #include "utilities/debug.hpp"
@@ -179,6 +179,8 @@ void JeandleCompiledCode::finalize() {
   _prolog_length = masm->offset();
   assembler.emit_insts(((address) _obj->getBufferStart()) + offset, code_size);
 
+  setup_frame_size();
+
   resolve_reloc_info(assembler);
 
   // generate shared trampoline stubs
@@ -186,8 +188,6 @@ void JeandleCompiledCode::finalize() {
     JeandleCompilation::report_jeandle_error("code cache full");
     return;
   }
-
-  setup_frame_size();
 
   // No deopt support now.
   _offsets.set_value(CodeOffsets::Deopt, 0);
@@ -251,8 +251,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
   // Step 2: Resolve stackmaps.
   SectionInfo section_info(".llvm_stackmaps");
   if (ReadELF::findSection(*_elf, section_info)) {
-    llvm::StackMapParser<ELFT::Endianness> stackmaps(llvm::ArrayRef(((uint8_t*)object_start()) +
-                                                     section_info._offset, section_info._size));
+    StackMapParser stackmaps(llvm::ArrayRef(((uint8_t*)object_start()) + section_info._offset, section_info._size));
     for (auto record = stackmaps.records_begin(); record != stackmaps.records_end(); ++record) {
       if (CallSiteInfo* call = _call_sites.lookup(record->getID())) {
         assert(_prolog_length != -1, "prolog length must be initialized");
@@ -262,7 +261,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         relocs.push_back(new JeandleCallReloc(call));
 
         // No GC support now.
-        _env->debug_info()->add_safepoint(inst_offset, new OopMap(stackmaps.getFunction(0).getStackSize(), 0));
+        _env->debug_info()->add_safepoint(inst_offset, build_oop_map(record));
 
         // No deopt support now.
         GrowableArray<ScopeValue*> *locarray = new GrowableArray<ScopeValue*>(0);
@@ -345,4 +344,64 @@ address JeandleCompiledCode::resolve_const_edge(LinkBlock& block, LinkEdge& edge
   uint64_t offset_in_section = target.getAddress() - range.getFirstBlock()->getAddress();
 
   return target_base + offset_in_section;
+}
+
+static VMReg resolve_vmreg(const StackMapParser::LocationAccessor& location, StackMapParser::LocationKind kind) {
+  if (kind == StackMapParser::LocationKind::Register) {
+    Register reg = JeandleRegister::decode_dwarf_register(location.getDwarfRegNum());
+    return reg->as_VMReg();
+  } else if (kind == StackMapParser::LocationKind::Indirect) {
+#ifdef ASSERT
+    Register reg = JeandleRegister::decode_dwarf_register(location.getDwarfRegNum());
+    assert(JeandleRegister::is_stack_pointer(reg), "register of indirect kind must be stack pointer");
+#endif
+    int offset = location.getOffset();
+
+    assert(offset % VMRegImpl::stack_slot_size == 0, "misaligned stack offset");
+    int oop_slot = offset / VMRegImpl::stack_slot_size;
+
+    return VMRegImpl::stack2reg(oop_slot);
+  } else {
+    ShouldNotReachHere();
+  }
+}
+
+OopMap* JeandleCompiledCode::build_oop_map(StackMapParser::record_iterator& record) {
+  assert(_frame_size > 0, "frame size must be greater than zero");
+  OopMap* oop_map = new OopMap(frame_size_in_slots(), 0);
+
+  for (auto location = record->location_begin(); location != record->location_end(); location++) {
+    // Extract location of base pointer.
+    auto base_location = *location;
+    StackMapParser::LocationKind base_kind = base_location.getKind();
+
+    if (base_kind != StackMapParser::LocationKind::Register &&
+        base_kind != StackMapParser::LocationKind::Indirect) {
+          continue;
+    }
+
+    // Extract location of derived pointer.
+    location++;
+    auto derived_location = *location;
+    StackMapParser::LocationKind derived_kind = derived_location.getKind();
+
+    assert(base_kind == derived_kind, "locations must be in pairs");
+    assert(base_kind != StackMapParser::LocationKind::Direct, "invalid location kind");
+
+    VMReg reg_base = resolve_vmreg(base_location, base_kind);
+    VMReg reg_derived = resolve_vmreg(derived_location, derived_kind);
+
+    if(reg_base == reg_derived) {
+      // No derived pointer.
+      oop_map->set_oop(reg_base);
+    } else {
+      // Derived pointer.
+      Unimplemented();
+    }
+  }
+  return oop_map;
+}
+
+int JeandleCompiledCode::frame_size_in_slots() {
+  return _frame_size * sizeof(intptr_t) / VMRegImpl::stack_slot_size;
 }

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -35,7 +35,7 @@ namespace {
 
 class JeandleReloc {
  public:
-  JeandleReloc(uint32_t offset) : _offset(offset) {}
+  JeandleReloc(JeandleCompiledCode& code, uint32_t raw_offset) : _code(code), _offset(raw_offset + code.prolog_length()) {}
 
   uint32_t offset() const { return _offset; }
 
@@ -53,14 +53,19 @@ class JeandleReloc {
 
   void  operator delete(void* p) {} // nothing to do
 
+ protected:
+  JeandleCompiledCode& code() const { return _code; }
+
  private:
+  JeandleCompiledCode& _code;
+  // Added with the prolog length.
   uint32_t _offset;
 };
 
 class JeandleConstReloc : public JeandleReloc {
  public:
-  JeandleConstReloc(LinkBlock& block, LinkEdge& edge, address target) :
-    JeandleReloc(block.getAddress().getValue() + edge.getOffset()),
+  JeandleConstReloc(JeandleCompiledCode& code, LinkBlock& block, LinkEdge& edge, address target) :
+    JeandleReloc(code, block.getAddress().getValue() + edge.getOffset()),
     _kind(edge.getKind()),
     _addend(edge.getAddend()),
     _target(target) {}
@@ -75,49 +80,64 @@ class JeandleConstReloc : public JeandleReloc {
   address _target;
 };
 
-class JeandleCallVMReloc : public JeandleReloc {
+class JeandleSafepointReloc : public JeandleReloc {
  public:
-  JeandleCallVMReloc(LinkBlock& block, LinkEdge& edge, address target) :
-    JeandleReloc(block.getAddress().getValue() + edge.getOffset()),
-    _target(target) {}
+  JeandleSafepointReloc(JeandleCompiledCode& code, uint32_t raw_pc_offset, OopMap* oop_map, CallSiteInfo* call) :
+    JeandleReloc(code, raw_pc_offset - JeandleJavaCall::call_site_size(call->type())/* beginning offset of a call instruction */),
+    _oop_map(oop_map), _call(call) {
+    // Prolog length should be included, which is calculated in JeandleReloc.
+    _call->set_pc_offset(offset() + JeandleJavaCall::call_site_size(call->type()));
 
-  void emit_reloc(JeandleAssembler& assembler) override {
-    assembler.patch_call_vm(offset(), _target);
+    process_oop_map();
   }
 
+ protected:
+  CallSiteInfo* call() const { return _call; }
+
  private:
-  address _target;
+  void process_oop_map();
+
+  OopMap* _oop_map;
+  CallSiteInfo* _call;
 };
 
-class JeandleCallReloc : public JeandleReloc {
+class JeandleCallVMReloc : public JeandleSafepointReloc {
  public:
-  JeandleCallReloc(CallSiteInfo* call) :
-    JeandleReloc(call->inst_offset() - JeandleJavaCall::call_site_size(call->type())),
-    _call(call) {}
+  JeandleCallVMReloc(JeandleCompiledCode& code, uint32_t raw_pc_offset, OopMap* oop_map, CallSiteInfo* call) :
+    JeandleSafepointReloc(code, raw_pc_offset, oop_map, call) {}
 
   void emit_reloc(JeandleAssembler& assembler) override {
-    if (_call->type() == JeandleJavaCall::Type::STATIC_CALL) {
-      assembler.emit_static_call_stub(_call);
-      assembler.patch_static_call_site(_call);
+    assembler.patch_call_vm(offset(), call()->target());
+  }
+};
+
+class JeandleCallReloc : public JeandleSafepointReloc {
+ public:
+  JeandleCallReloc(JeandleCompiledCode& code, uint32_t raw_pc_offset, OopMap* oop_map, CallSiteInfo* call) :
+    JeandleSafepointReloc(code, raw_pc_offset, oop_map, call) {}
+
+  void emit_reloc(JeandleAssembler& assembler) override {
+    assert(call()->pc_offset() != 0, "pc offset must be initialized");
+
+    if (call()->type() == JeandleJavaCall::Type::STATIC_CALL) {
+      assembler.emit_static_call_stub(call());
+      assembler.patch_static_call_site(call());
     }
 
-    if (_call->type() == JeandleJavaCall::Type::VM_CALL) {
-      assembler.patch_vm_call_site(_call);
+    if (call()->type() == JeandleJavaCall::Type::VM_CALL) {
+      assembler.patch_vm_call_site(call());
     }
 
-    if (_call->type() == JeandleJavaCall::Type::DYNAMIC_CALL) {
-      assembler.patch_ic_call_site(_call);
+    if (call()->type() == JeandleJavaCall::Type::DYNAMIC_CALL) {
+      assembler.patch_ic_call_site(call());
     }
   }
-
- private:
-  CallSiteInfo* _call;
 };
 
 class JeandleOopReloc : public JeandleReloc {
  public:
-  JeandleOopReloc(uint32_t offset, jobject oop_handle) :
-    JeandleReloc(offset),
+  JeandleOopReloc(JeandleCompiledCode& code, uint32_t raw_offset, jobject oop_handle) :
+    JeandleReloc(code, raw_offset),
     _oop_handle(oop_handle) {}
 
   void emit_reloc(JeandleAssembler& assembler) override {
@@ -127,6 +147,49 @@ class JeandleOopReloc : public JeandleReloc {
  private:
   jobject _oop_handle;
 };
+
+void JeandleSafepointReloc::process_oop_map() {
+  assert(_oop_map != nullptr, "oopmap must be initialized");
+  assert(call()->pc_offset() != 0, "pc offset must be initialized");
+
+  uint32_t pc_offset = call()->pc_offset();
+
+  DebugInformationRecorder* recorder = code().env()->debug_info();
+  recorder->add_safepoint(pc_offset, _oop_map);
+
+  // No deopt support now.
+  GrowableArray<ScopeValue*> *locarray = new GrowableArray<ScopeValue*>(0);
+  GrowableArray<ScopeValue*> *exparray = new GrowableArray<ScopeValue*>(0);
+
+  // No monitor support now.
+  GrowableArray<MonitorValue*> *monarray = new GrowableArray<MonitorValue*>(0);
+
+  DebugToken *locvals = recorder->create_scope_values(locarray);
+  DebugToken *expvals = recorder->create_scope_values(exparray);
+  DebugToken *monvals = recorder->create_monitor_values(monarray);
+
+#ifdef ASSERT
+  if (call()->type() != JeandleJavaCall::VM_CALL) {
+    // If we are not compiling a call vm stub, there must be a valid Java method.
+    assert(code().method(), "invalid Java method");
+  }
+#endif
+  recorder->describe_scope(pc_offset,
+                           methodHandle(),
+                           code().method(),
+                           _call->bci(),
+                           false,
+                           false,
+                           false,
+                           false,
+                           false,
+                           false,
+                           locvals,
+                           expvals,
+                           monvals);
+
+  recorder->end_safepoint(pc_offset);
+}
 
 } // anonymous namespace
 
@@ -221,14 +284,11 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
       if (!target.isDefined() && JeandleAssembler::is_call_vm_reloc_kind(edge.getKind())) {
         // Call VM relocations.
         address target_addr = JeandleRuntimeRoutine::get_stub_entry(*target.getName());
-        JeandleCallVMReloc* call_vm_reloc = new JeandleCallVMReloc(*block, edge, target_addr);
 
-        uint32_t call_inst_offset = JeandleAssembler::fixup_call_inst_offset(call_vm_reloc->offset());
+        uint32_t call_pc_offset = JeandleAssembler::fixup_call_inst_offset(block->getAddress().getValue() + edge.getOffset());
 
         // TODO: Set the right bci.
-        _safepoints[call_inst_offset] = new CallSiteInfo(0/* statepoint_id */, JeandleJavaCall::STATIC_CALL, target_addr, 0/* bci */);
-        relocs.push_back(call_vm_reloc);
-
+        _safepoints[call_pc_offset] = new CallSiteInfo(0/* statepoint_id */, JeandleJavaCall::STATIC_CALL, target_addr, -1/* bci */);
       } else if (target.isDefined() && JeandleAssembler::is_const_reloc_kind(edge.getKind())) {
         // Const relocations.
         assert(target.getSection().getName().starts_with(".rodata"), "invalid const section");
@@ -236,11 +296,11 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         if (target_addr == nullptr) {
           return;
         }
-        relocs.push_back(new JeandleConstReloc(*block, edge, target_addr));
+        relocs.push_back(new JeandleConstReloc(*this, *block, edge, target_addr));
       } else if (!target.isDefined() && JeandleAssembler::is_oop_reloc_kind(edge.getKind())) {
         // Oop relocations.
         assert((*(target.getName())).starts_with("oop_handle"), "invalid oop relocation name");
-        relocs.push_back(new JeandleOopReloc(block->getAddress().getValue() + edge.getOffset(), _oop_handles[(*(target.getName()))]));
+        relocs.push_back(new JeandleOopReloc(*this, block->getAddress().getValue() + edge.getOffset(), _oop_handles[(*(target.getName()))]));
       } else {
         // Unhandled relocations
         ShouldNotReachHere();
@@ -253,49 +313,11 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
   if (ReadELF::findSection(*_elf, section_info)) {
     StackMapParser stackmaps(llvm::ArrayRef(((uint8_t*)object_start()) + section_info._offset, section_info._size));
     for (auto record = stackmaps.records_begin(); record != stackmaps.records_end(); ++record) {
+      assert(_prolog_length != -1, "prolog length must be initialized");
       if (CallSiteInfo* call = _call_sites.lookup(record->getID())) {
-        assert(_prolog_length != -1, "prolog length must be initialized");
-        uint32_t inst_offset = record->getInstructionOffset() + _prolog_length;
-        call->set_inst_offset(inst_offset);
-
-        relocs.push_back(new JeandleCallReloc(call));
-
-        // No GC support now.
-        _env->debug_info()->add_safepoint(inst_offset, build_oop_map(record));
-
-        // No deopt support now.
-        GrowableArray<ScopeValue*> *locarray = new GrowableArray<ScopeValue*>(0);
-        GrowableArray<ScopeValue*> *exparray = new GrowableArray<ScopeValue*>(0);
-
-        // No monitor support now.
-        GrowableArray<MonitorValue*> *monarray = new GrowableArray<MonitorValue*>(0);
-
-        DebugToken *locvals = _env->debug_info()->create_scope_values(locarray);
-        DebugToken *expvals = _env->debug_info()->create_scope_values(exparray);
-        DebugToken *monvals = _env->debug_info()->create_monitor_values(monarray);
-        
-        if (call->type() != JeandleJavaCall::VM_CALL) {
-          // If we are not compiling a call vm stub, there must be a valid Java method.
-          assert(_method, "invalid Java method");
-        }
-        _env->debug_info()->describe_scope(inst_offset,
-                                          methodHandle(),
-                                          _method,
-                                          call->bci(),
-                                          false,
-                                          false,
-                                          false,
-                                          false,
-                                          false,
-                                          false,
-                                          locvals,
-                                          expvals,
-                                          monvals);
-
-        _env->debug_info()->end_safepoint(inst_offset);
-
+        relocs.push_back(new JeandleCallReloc(*this, record->getInstructionOffset(), build_oop_map(record), call));
       } else if (CallSiteInfo* safepoint = _safepoints[record->getInstructionOffset()]) {
-        _env->debug_info()->add_safepoint(record->getInstructionOffset(), build_oop_map(record));
+        relocs.push_back(new JeandleCallVMReloc(*this, record->getInstructionOffset(), build_oop_map(record), safepoint));
       }
     }
   }

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -295,7 +295,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         _env->debug_info()->end_safepoint(inst_offset);
 
       } else if (CallSiteInfo* safepoint = _safepoints[record->getInstructionOffset()]) {
-        // TODO: Add debug information for safepoints.
+        _env->debug_info()->add_safepoint(record->getInstructionOffset(), build_oop_map(record));
       }
     }
   }

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -93,7 +93,7 @@ class JeandleConstReloc : public JeandleReloc {
 class JeandleSafepointReloc : public JeandleReloc {
  public:
   JeandleSafepointReloc(int inst_end_offset, ciEnv* env, ciMethod* method, OopMap* oop_map, CallSiteInfo* call) :
-    JeandleReloc(inst_end_offset - JeandleJavaCall::call_site_size(call->type())/* beginning offset of a call instruction */),
+    JeandleReloc(inst_end_offset - JeandleJavaCall::call_site_size(call->type())/* beginning of a call instruction */),
     _env(env), _method(method), _oop_map(oop_map), _call(call) {}
 
   int inst_end_offset() {
@@ -164,10 +164,10 @@ void JeandleSafepointReloc::process_oop_map() {
   assert(inst_end_offset() >= 0, "pc offset must be initialized");
   assert(_fixed_up, "offset must be fixed up");
 
-  int safepoint_pc_offset = inst_end_offset();
+  int safepoint_offset = inst_end_offset();
 
   DebugInformationRecorder* recorder = _env->debug_info();
-  recorder->add_safepoint(safepoint_pc_offset, _oop_map);
+  recorder->add_safepoint(safepoint_offset, _oop_map);
 
   // No deopt support now.
   GrowableArray<ScopeValue*> *locarray = new GrowableArray<ScopeValue*>(0);
@@ -186,7 +186,7 @@ void JeandleSafepointReloc::process_oop_map() {
     assert(_method, "invalid Java method");
   }
 #endif
-  recorder->describe_scope(safepoint_pc_offset,
+  recorder->describe_scope(safepoint_offset,
                            methodHandle(),
                            _method,
                            _call->bci(),
@@ -200,7 +200,7 @@ void JeandleSafepointReloc::process_oop_map() {
                            expvals,
                            monvals);
 
-  recorder->end_safepoint(safepoint_pc_offset);
+  recorder->end_safepoint(safepoint_offset);
 }
 
 } // anonymous namespace

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -48,23 +48,18 @@ class CallSiteInfo : public JeandleCompilationResourceObj {
                _statepoint_id(statepoint_id),
                _type(type),
                _target(target),
-               _bci(bci),
-               _pc_offset(0) {}
+               _bci(bci) {}
 
   JeandleJavaCall::Type type() const { return _type; }
   uint32_t statepoint_id() const { return _statepoint_id; }
   address target() const { return _target; }
   int bci() const { return _bci; }
 
-  uint32_t pc_offset() const { return _pc_offset; }
-  void set_pc_offset(uint32_t offset) { _pc_offset = offset; }
-
  private:
   uint32_t _statepoint_id; // Used to distinguish each call site in stackmaps.
   JeandleJavaCall::Type _type;
   address _target;
   int _bci;
-  uint32_t _pc_offset; // Instruction offset (from the start of the containing function).
 };
 
 using ObjectBuffer = llvm::MemoryBuffer;
@@ -119,12 +114,6 @@ class JeandleCompiledCode : public StackObj {
 
   int frame_size() const { return _frame_size; }
 
-  int prolog_length() const { return _prolog_length; }
-
-  ciEnv* env() const { return _env; }
-
-  ciMethod* method() const { return _method; }
-
   address stub_entry() const { return _stub_entry; }
   void set_stub_entry(address entry) { _stub_entry = entry; }
 
@@ -136,7 +125,7 @@ class JeandleCompiledCode : public StackObj {
   std::unique_ptr<ELFObject> _elf;
   CodeBuffer _code_buffer; // Relocations and stubs.
   llvm::DenseMap<uint32_t, CallSiteInfo*> _call_sites;
-  llvm::DenseMap<uint32_t, CallSiteInfo*> _safepoints;
+  llvm::DenseMap<int, CallSiteInfo*> _safepoints;
   llvm::StringMap<address> _const_sections;
   llvm::StringMap<jobject> _oop_handles;
   CodeOffsets _offsets;

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -125,7 +125,7 @@ class JeandleCompiledCode : public StackObj {
   std::unique_ptr<ELFObject> _elf;
   CodeBuffer _code_buffer; // Relocations and stubs.
   llvm::DenseMap<uint32_t, CallSiteInfo*> _call_sites;
-  llvm::DenseMap<int, CallSiteInfo*> _safepoints;
+  llvm::DenseMap<int, CallSiteInfo*> _vm_call_sites;
   llvm::StringMap<address> _const_sections;
   llvm::StringMap<jobject> _oop_handles;
   CodeOffsets _offsets;

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -24,8 +24,9 @@
 #include <cassert>
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
-#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Object/StackMapParser.h"
+#include "llvm/Support/MemoryBuffer.h"
 
 #include "jeandle/jeandleJavaCall.hpp"
 #include "jeandle/jeandleReadELF.hpp"
@@ -69,6 +70,7 @@ class CallSiteInfo : public JeandleCompilationResourceObj {
 using ObjectBuffer = llvm::MemoryBuffer;
 using LinkBlock   = llvm::jitlink::Block;
 using LinkEdge    = llvm::jitlink::Edge;
+using StackMapParser = llvm::StackMapParser<ELFT::Endianness>;
 
 class JeandleAssembler;
 class JeandleCompiledCode : public StackObj {
@@ -148,6 +150,10 @@ class JeandleCompiledCode : public StackObj {
   // Lookup address of const section in CodeBuffer.
   address lookup_const_section(llvm::StringRef name, JeandleAssembler& assmebler);
   address resolve_const_edge(LinkBlock& block, LinkEdge& edge, JeandleAssembler& assmebler);
+
+  OopMap* build_oop_map(StackMapParser::record_iterator& record);
+
+  int frame_size_in_slots();
 };
 
 #endif // SHARE_JEANDLE_COMPILED_CODE_HPP

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -49,22 +49,22 @@ class CallSiteInfo : public JeandleCompilationResourceObj {
                _type(type),
                _target(target),
                _bci(bci),
-               _inst_offset(0) {}
+               _pc_offset(0) {}
 
   JeandleJavaCall::Type type() const { return _type; }
   uint32_t statepoint_id() const { return _statepoint_id; }
   address target() const { return _target; }
   int bci() const { return _bci; }
 
-  uint32_t inst_offset() const { return _inst_offset; }
-  void set_inst_offset(uint32_t offset) { _inst_offset = offset; }
+  uint32_t pc_offset() const { return _pc_offset; }
+  void set_pc_offset(uint32_t offset) { _pc_offset = offset; }
 
  private:
   uint32_t _statepoint_id; // Used to distinguish each call site in stackmaps.
   JeandleJavaCall::Type _type;
   address _target;
   int _bci;
-  uint32_t _inst_offset; // Instruction offset (from the start of the containing function).
+  uint32_t _pc_offset; // Instruction offset (from the start of the containing function).
 };
 
 using ObjectBuffer = llvm::MemoryBuffer;
@@ -118,6 +118,12 @@ class JeandleCompiledCode : public StackObj {
   ImplicitExceptionTable* implicit_exception_table() { return &_implicit_exception_table; }
 
   int frame_size() const { return _frame_size; }
+
+  int prolog_length() const { return _prolog_length; }
+
+  ciEnv* env() const { return _env; }
+
+  ciMethod* method() const { return _method; }
 
   address stub_entry() const { return _stub_entry; }
   void set_stub_entry(address entry) { _stub_entry = entry; }

--- a/test/hotspot/jtreg/compiler/jeandle/TestDAbs.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestDAbs.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/**
+ * @test
+ * @library /test/lib
+ * @run main/othervm -Xbatch -Xcomp -XX:-TieredCompilation -XX:+UseJeandleCompiler -XX:CompileCommand=compileonly,TestDAbs::main TestDAbs
+ */
+
+import java.lang.Math;
+
+import jdk.test.lib.Asserts;
+
+public class TestDAbs {
+    public static void main(String[] args) {
+        double r=0.0;
+
+        for (int i=0;i<10;i++ ) {
+            double v = (double)i;
+            r += Math.abs(v);
+        }
+
+        Asserts.assertEquals(r, 45.0);
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/TestDAbs.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestDAbs.java
@@ -20,6 +20,8 @@
 
 /**
  * @test
+ * @summary Fix incorrent inst offset for duplicated statepoints.
+ *  issue: https://github.com/jeandle/jeandle-jdk/issues/64
  * @library /test/lib
  * @run main/othervm -Xbatch -Xcomp -XX:-TieredCompilation -XX:+UseJeandleCompiler -XX:CompileCommand=compileonly,TestDAbs::main TestDAbs
  */

--- a/test/hotspot/jtreg/compiler/jeandle/TestSafepointPoll.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestSafepointPoll.java
@@ -20,6 +20,8 @@
 
 /**
  * @test
+ * @summary Support the safepoint poll and related to a issue about incorrect alignment of patch address
+ *  issue: https://github.com/jeandle/jeandle-jdk/issues/63
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/jeandle/TestSafepointPoll.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestSafepointPoll.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
 /**
  * @test
  * @library /test/lib
@@ -28,7 +48,7 @@ public class TestSafepointPoll {
 
         Thread.sleep(100);
 
-        wb.forceSafepoint();
+        wb.fullGC();
 
         stop = true;
     }

--- a/test/hotspot/jtreg/compiler/jeandle/TestSimpleFGC.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestSimpleFGC.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/**
+ * @test
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:CompileCommand=compileonly,TestSimpleFGC::test0
+ *      -XX:CompileCommand=compileonly,TestSimpleFGC::test1
+ *      -XX:CompileCommand=compileonly,TestSimpleFGC::test2
+ *      -Xcomp -XX:-TieredCompilation -XX:+UseJeandleCompiler TestSimpleFGC
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+public class TestSimpleFGC {
+    private final static WhiteBox wb = WhiteBox.getWhiteBox();
+
+    private static int sa = 10;
+
+    public static void main(String[] args) {
+        MyClass a = new MyClass();
+        test0(a);
+        test1(a);
+        test2();
+    }
+
+    static MyClass createObj() {
+        return new MyClass();
+    }
+
+    static void triggerGC() {
+        wb.fullGC();
+    }
+
+    static void test0(MyClass a) {
+        triggerGC();
+        Asserts.assertEquals(a.getA(), 1);
+    }
+
+    static void test1(MyClass a) {
+        a.b = 3;
+        triggerGC();
+        Asserts.assertEquals(a.b, 3);
+        a.b = 4;
+        Asserts.assertEquals(a.b, 4);
+    }
+
+    static void test2() {
+        sa = 12;
+        Asserts.assertEquals(sa, 12);
+        sa= 13;
+        triggerGC();
+        Asserts.assertEquals(sa, 13);
+    }
+}
+
+class MyClass {
+    int a = 1;
+    int getA() {return a;}
+    public int b = 2;
+}

--- a/test/hotspot/jtreg/compiler/jeandle/TestSimpleFGC.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestSimpleFGC.java
@@ -24,11 +24,11 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *      -XX:CompileCommand=compileonly,TestSimpleFGC::test0
- *      -XX:CompileCommand=compileonly,TestSimpleFGC::test1
- *      -XX:CompileCommand=compileonly,TestSimpleFGC::test2
+ *      -XX:CompileCommand=compileonly,TestSimpleFGC::test*
  *      -Xcomp -XX:-TieredCompilation -XX:+UseJeandleCompiler TestSimpleFGC
  */
+
+import java.lang.reflect.Method;
 
 import jdk.test.lib.Asserts;
 import jdk.test.whitebox.WhiteBox;
@@ -38,29 +38,46 @@ public class TestSimpleFGC {
 
     private static int sa = 10;
 
-    public static void main(String[] args) {
+    private static volatile boolean stop = false;
+
+    public static void main(String[] args) throws Exception {
         MyClass a = new MyClass();
         test0(a);
         test1(a);
         test2();
+
+        {
+            new Thread(() -> {
+                test3(a);
+            }).start();
+
+            Method method = TestSimpleFGC.class.getDeclaredMethod("test3", MyClass.class);
+            while (!wb.isMethodCompiled(method)) {
+                Thread.yield();
+            }
+
+            Thread.sleep(100);
+
+            wb.fullGC();
+
+            Thread.sleep(100);
+
+            stop = true;
+        }
     }
 
     static MyClass createObj() {
         return new MyClass();
     }
 
-    static void triggerGC() {
-        wb.fullGC();
-    }
-
     static void test0(MyClass a) {
-        triggerGC();
+        wb.fullGC();
         Asserts.assertEquals(a.getA(), 1);
     }
 
     static void test1(MyClass a) {
         a.b = 3;
-        triggerGC();
+        wb.fullGC();
         Asserts.assertEquals(a.b, 3);
         a.b = 4;
         Asserts.assertEquals(a.b, 4);
@@ -70,8 +87,14 @@ public class TestSimpleFGC {
         sa = 12;
         Asserts.assertEquals(sa, 12);
         sa= 13;
-        triggerGC();
+        wb.fullGC();
         Asserts.assertEquals(sa, 13);
+    }
+
+    static void test3(MyClass a) {
+        while (!stop) {
+            Asserts.assertEquals(a.getA(), 1);
+        }
     }
 }
 

--- a/test/hotspot/jtreg/compiler/jeandle/relocation/TestRelocation.java
+++ b/test/hotspot/jtreg/compiler/jeandle/relocation/TestRelocation.java
@@ -33,12 +33,21 @@ import jdk.test.lib.Asserts;
 
 public class TestRelocation {
     public static void main(String[] args) {
-        Asserts.assertEquals(20.0f, test1(1.0f));
-        Asserts.assertEquals(24.0f, test2(1.0f));
-        Asserts.assertEquals(29.0f, test3(1.0f));
-        Asserts.assertEquals(32.0f, test4(1.0f));
-        Asserts.assertEquals(37.0f, test5(1.0f));
-        Asserts.assertEquals(47.0f, test6(1.0f));
+        Asserts.assertEquals(20.0f, testStatic1(1.0f));
+        Asserts.assertEquals(24.0f, testStatic2(1.0f));
+        Asserts.assertEquals(29.0f, testStatic3(1.0f));
+        Asserts.assertEquals(32.0f, testStatic4(1.0f));
+        Asserts.assertEquals(37.0f, testStatic5(1.0f));
+        Asserts.assertEquals(47.0f, testStatic6(1.0f));
+
+        // Test dynamic call
+        TestRelocation instance = new TestRelocation();
+        Asserts.assertEquals(20.0f, instance.testDynamic1(1.0f));
+        Asserts.assertEquals(24.0f, instance.testDynamic2(1.0f));
+        Asserts.assertEquals(29.0f, instance.testDynamic3(1.0f));
+        Asserts.assertEquals(32.0f, instance.testDynamic4(1.0f));
+        Asserts.assertEquals(37.0f, instance.testDynamic5(1.0f));
+        Asserts.assertEquals(47.0f, instance.testDynamic6(1.0f));
     }
     private static float callee1(float a) {
       return a += 2.0f;
@@ -48,42 +57,85 @@ public class TestRelocation {
       return a += 3.0f;
     }
 
-    private static float test1(float n) {
+    private static float testStatic1(float n) {
         n += callee1(n);
         n += callee2(n);
         n += 4.0f;
         n += 5.0f;
         return n;
     }
-    private static float test2(float n) {
+    private static float testStatic2(float n) {
         n += callee1(n);
         n += 4.0f;
         n += callee2(n);
         n += 5.0f;
         return n;
     }
-    private static float test3(float n) {
+    private static float testStatic3(float n) {
         n += callee1(n);
         n += 4.0f;
         n += 5.0f;
         n += callee2(n);
         return n;
     }
-    private static float test4(float n) {
+    private static float testStatic4(float n) {
         n += 4.0f;
         n += callee1(n);
         n += callee2(n);
         n += 5.0f;
         return n;
     }
-    private static float test5(float n) {
+    private static float testStatic5(float n) {
         n += 4.0f;
         n += callee1(n);
         n += 5.0f;
         n += callee2(n);
         return n;
     }
-    private static float test6(float n) {
+    private static float testStatic6(float n) {
+        n += 4.0f;
+        n += 5.0f;
+        n += callee1(n);
+        n += callee2(n);
+        return n;
+    }
+
+    private float testDynamic1(float n) {
+        n += callee1(n);
+        n += callee2(n);
+        n += 4.0f;
+        n += 5.0f;
+        return n;
+    }
+    private float testDynamic2(float n) {
+        n += callee1(n);
+        n += 4.0f;
+        n += callee2(n);
+        n += 5.0f;
+        return n;
+    }
+    private float testDynamic3(float n) {
+        n += callee1(n);
+        n += 4.0f;
+        n += 5.0f;
+        n += callee2(n);
+        return n;
+    }
+    private float testDynamic4(float n) {
+        n += 4.0f;
+        n += callee1(n);
+        n += callee2(n);
+        n += 5.0f;
+        return n;
+    }
+    private float testDynamic5(float n) {
+        n += 4.0f;
+        n += callee1(n);
+        n += 5.0f;
+        n += callee2(n);
+        return n;
+    }
+    private float testDynamic6(float n) {
         n += 4.0f;
         n += 5.0f;
         n += callee1(n);


### PR DESCRIPTION
## Related issue(s):

issue #8 ,  #63,  #64

## What this PR does / why we need it:
1. Translate stackmaps to oopmaps.
2. Refactor `JeandleReloc` and fix come bugs. 
    2.1. fixup all `inst_offset` with `prolog_length`; 
    2.2. Remove offset field from `CallSiteInfo`, it will be overwritten when statepoint is duplicated. Loop Unrolling may lead to this issue, #64 . Now, all `inst_offsets`  are put in `JeandleReloc`.
3. Both X86_64 and Aarch64 are supported.