### PR TITLE
feat: Support safepoint poll

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -126,7 +126,26 @@ void JeandleAssembler::emit_oop_reloc(uint32_t offset, jobject oop_handle) {
   __ code_section()->relocate(at_addr, rspec);
 }
 
+void JeandleAssembler::patch_call_vm(uint32_t operand_offset, address target) {
+  Unimplemented();
+}
+
+uint32_t JeandleAssembler::fixup_call_inst_offset(uint32_t offset) {
+  Unimplemented();
+  return 0;
+}
+
 bool JeandleAssembler::is_oop_reloc_kind(LinkKind kind) {
   return kind == LinkKind_aarch64::RequestGOTAndTransformToPage21 ||
          kind == LinkKind_aarch64::RequestGOTAndTransformToPageOffset12;
+}
+
+bool JeandleAssembler::is_call_vm_reloc_kind(LinkKind kind) {
+  Unimplemented();
+  return false;
+}
+
+bool JeandleAssembler::is_const_reloc_kind(LinkKind kind) {
+  Unimplemented();
+  return false;
 }

--- a/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
@@ -18,23 +18,23 @@
  *
  */
 
-#ifndef CPU_X86_JEANDLEREGISTER_X86_HPP
-#define CPU_X86_JEANDLEREGISTER_X86_HPP
+#ifndef CPU_AARCH64_JEANDLEREGISTER_AARCH64_HPP
+#define CPU_AARCH64_JEANDLEREGISTER_AARCH64_HPP
 
+#include "memory/allStatic.hpp"
 #include "utilities/debug.hpp"
-#include "register_x86.hpp"
 
-#ifdef _LP64
 class JeandleRegister : public AllStatic {
 public:
   static const char* get_stack_pointer() {
-    return rsp->name();
+    Unimplemented();
+    return nullptr;
   }
 
   static const char* get_current_thread_pointer() {
-    return r15->name();
+    Unimplemented();
+    return nullptr;
   }
 };
-#endif // _LP64
 
-#endif // CPU_X86_JEANDLEREGISTER_X86_HPP
+#endif // CPU_AARCH64_JEANDLEREGISTER_AARCH64_HPP

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -152,10 +152,10 @@ bool JeandleAssembler::is_oop_reloc_kind(LinkKind kind) {
   return kind == LinkKind_x86_64::RequestGOTAndTransformToPCRel32GOTLoadREXRelaxable;
 }
 
-bool JeandleAssembler::is_call_vm_link_kind(LinkKind kind) {
+bool JeandleAssembler::is_call_vm_reloc_kind(LinkKind kind) {
   return kind == LinkKind_x86_64::BranchPCRel32;
 }
 
-bool JeandleAssembler::is_const_link_kind(LinkKind kind) {
+bool JeandleAssembler::is_const_reloc_kind(LinkKind kind) {
   return kind == LinkKind_x86_64::Delta32;
 }

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -148,14 +148,14 @@ uint32_t JeandleAssembler::fixup_call_inst_offset(uint32_t offset) {
   return offset + 4;
 }
 
-LinkKind JeandleAssembler::get_oop_reloc_kind() {
-  return LinkKind_x86_64::RequestGOTAndTransformToPCRel32GOTLoadREXRelaxable;
+bool JeandleAssembler::is_oop_reloc_kind(LinkKind kind) {
+  return kind == LinkKind_x86_64::RequestGOTAndTransformToPCRel32GOTLoadREXRelaxable;
 }
 
-LinkKind JeandleAssembler::get_call_vm_link_kind() {
-  return LinkKind_x86_64::BranchPCRel32;
+bool JeandleAssembler::is_call_vm_link_kind(LinkKind kind) {
+  return kind == LinkKind_x86_64::BranchPCRel32;
 }
 
-LinkKind JeandleAssembler::get_const_link_kind() {
-  return LinkKind_x86_64::Delta32;
+bool JeandleAssembler::is_const_link_kind(LinkKind kind) {
+  return kind == LinkKind_x86_64::Delta32;
 }

--- a/src/hotspot/cpu/x86/jeandleRegister_x86.hpp
+++ b/src/hotspot/cpu/x86/jeandleRegister_x86.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef CPU_X86_JEANDLEREGISTER_X86_HPP
+#define CPU_X86_JEANDLEREGISTER_X86_HPP
+
+#include "utilities/debug.hpp"
+#include "register_x86.hpp"
+
+class JeandleRegister : public AllStatic {
+public:
+  static const char* get_stack_pointer() {
+#ifdef _LP64
+    return rsp->name();
+#else
+    Unimplemented();
+    return nullptr;
+#endif // _LP64
+  }
+
+  static const char* get_current_thread_pointer() {
+#ifdef _LP64
+    return r15->name();
+#else
+    Unimplemented();
+    return nullptr;
+#endif // _LP64
+  }
+};
+
+#endif // CPU_X86_JEANDLEREGISTER_X86_HPP

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -648,7 +648,6 @@ void CompileBroker::compilation_init_phase1(JavaThread* THREAD) {
       if (UseJeandleCompiler) {
         llvm::InitializeNativeTarget();
         llvm::InitializeNativeTargetAsmPrinter();
-        llvm::InitializeNativeTargetAsmParser();
         _compilers[1] = JeandleCompiler::create();
       } else
 #endif // JEANDLE

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -201,9 +201,8 @@ class BasicBlockBuilder : public JeandleCompilationResourceObj {
 class JeandleAbstractInterpreter : public StackObj {
  public:
   JeandleAbstractInterpreter(ciMethod* method,
-                             llvm::Function* llvm_func,
                              int entry_bci,
-                             llvm::Module& module,
+                             llvm::Module& target_module,
                              JeandleCompiledCode& code);
 
  private:
@@ -230,7 +229,7 @@ class JeandleAbstractInterpreter : public StackObj {
   // Contains all blocks to interpret. Sorted by reverse-post-order.
   std::vector<JeandleBasicBlock*> _work_list;
 
-  void initialize_jvm_tracker();
+  void initialize_VM_state();
   void interpret();
   void interpret_block(JeandleBasicBlock* block);
 
@@ -242,12 +241,17 @@ class JeandleAbstractInterpreter : public StackObj {
   void if_zero(llvm::CmpInst::Predicate p);
   void if_icmp(llvm::CmpInst::Predicate p);
   void if_lcmp();
+  void goto_bci(int bci);
   void lookup_switch();
   void invoke();
   void stack_op(Bytecodes::Code code);
   void shift_op(BasicType type, Bytecodes::Code code);
   void instanceof(int klass_index);
   void arith_op(BasicType type, Bytecodes::Code code);
+
+  llvm::CallInst* call_java_op(llvm::StringRef java_op, llvm::ArrayRef<llvm::Value*> args);
+
+  void add_safepoint_poll();
 
   llvm::DenseMap<int, JeandleBasicBlock*>& bci2block() { return _block_builder->bci2block(); }
 

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -51,7 +51,16 @@ class JeandleAssembler : public StackObj {
 
   void emit_oop_reloc(uint32_t offset, jobject oop_handle);
 
+  void patch_call_vm(uint32_t offset, address target);
+
+  // Redirect an offset from the displacement to the end of the call instruction
+  static uint32_t fixup_call_inst_offset(uint32_t offset);
+
   static LinkKind get_oop_reloc_kind();
+  
+  static LinkKind get_call_vm_link_kind();
+
+  static LinkKind get_const_link_kind();
 
  private:
   MacroAssembler* _masm;

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -56,11 +56,11 @@ class JeandleAssembler : public StackObj {
   // Redirect an offset from the displacement to the end of the call instruction
   static uint32_t fixup_call_inst_offset(uint32_t offset);
 
-  static LinkKind get_oop_reloc_kind();
-  
-  static LinkKind get_call_vm_link_kind();
+  static bool is_oop_reloc_kind(LinkKind kind);
 
-  static LinkKind get_const_link_kind();
+  static bool is_call_vm_link_kind(LinkKind kind);
+
+  static bool is_const_link_kind(LinkKind kind);
 
  private:
   MacroAssembler* _masm;

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -58,9 +58,9 @@ class JeandleAssembler : public StackObj {
 
   static bool is_oop_reloc_kind(LinkKind kind);
 
-  static bool is_call_vm_link_kind(LinkKind kind);
+  static bool is_call_vm_reloc_kind(LinkKind kind);
 
-  static bool is_const_link_kind(LinkKind kind);
+  static bool is_const_reloc_kind(LinkKind kind);
 
  private:
   MacroAssembler* _masm;

--- a/src/hotspot/share/jeandle/jeandleCallVM.cpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <cassert>
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Jeandle/Metadata.h"
+
+#include "jeandle/jeandleUtils.hpp"
+#include "jeandle/jeandleCallVM.hpp"
+#include CPU_HEADER(jeandleRegister)
+
+void JeandleCallVM::generate_call_VM(const char* name, address c_func, llvm::FunctionType* func_type, llvm::Module& target_module) {
+  llvm::Function* llvm_func = llvm::Function::Create(func_type,
+                                                     llvm::Function::ExternalLinkage,
+                                                     name,
+                                                     target_module);
+  llvm_func->setCallingConv(llvm::CallingConv::Hotspot_JIT);
+  llvm::LLVMContext& context = target_module.getContext();
+
+  // Add needed metadatas.
+  llvm::MDNode* thread_register = llvm::MDNode::get(context, {llvm::MDString::get(context, JeandleRegister::get_current_thread_pointer())});
+  llvm::NamedMDNode* metadata_node = target_module.getOrInsertNamedMetadata(llvm::jeandle::Metadata::CurrentThread);
+  metadata_node->addOperand(thread_register);
+
+  llvm::BasicBlock* entry_block = llvm::BasicBlock::Create(context, "entry", llvm_func);
+  llvm::IRBuilder<> ir_builder(entry_block);
+  llvm::Type* intptr_type = ir_builder.getIntPtrTy(target_module.getDataLayout());
+
+  // Set the last_Java_sp to enable stack unwind.
+  llvm::Value* last_Java_sp_ptr = ir_builder.CreateIntToPtr(ir_builder.getInt64((uint64_t)JavaThread::last_Java_sp_offset()),
+                                                            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::TLSAddrSpace));
+  llvm::MDNode* sp_register = llvm::MDNode::get(context, {llvm::MDString::get(context, JeandleRegister::get_stack_pointer())});
+  llvm::Value* read_sp_args[] = {llvm::MetadataAsValue::get(context, sp_register)};
+  llvm::CallInst* sp_value = ir_builder.CreateIntrinsic(llvm::Intrinsic::read_register,
+                                                        intptr_type,
+                                                        read_sp_args);
+  ir_builder.CreateStore(sp_value, last_Java_sp_ptr);
+
+  // Make arguments.
+  llvm::SmallVector<llvm::Value*> args;
+  for (llvm::Value& arg : llvm_func->args()) {
+    args.push_back(&arg);
+  }
+
+  // Call to the C function.
+  llvm::PointerType* c_func_ptr_type = llvm::PointerType::get(func_type, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::Value* c_func_addr = ir_builder.getInt64((intptr_t)c_func);
+  llvm::Value* c_func_ptr = ir_builder.CreateIntToPtr(c_func_addr, c_func_ptr_type);
+  llvm::CallInst* call_c_func = ir_builder.CreateCall(func_type, c_func_ptr, args);
+  call_c_func->setCallingConv(llvm::CallingConv::C);
+
+  // TODO: Check exceptions.
+
+  // Clear the last_Java_sp.
+  ir_builder.CreateStore(ir_builder.getInt64((intptr_t)nullptr), last_Java_sp_ptr);
+
+  // Clear the last_Java_pc.
+  llvm::Value* last_Java_pc_ptr = ir_builder.CreateIntToPtr(ir_builder.getInt64((uint64_t)JavaThread::last_Java_pc_offset()),
+                                                            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::TLSAddrSpace));
+  ir_builder.CreateStore(ir_builder.getInt64((intptr_t)nullptr), last_Java_pc_ptr);
+
+  // Return.
+  ir_builder.CreateRetVoid();
+}

--- a/src/hotspot/share/jeandle/jeandleCallVM.cpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.cpp
@@ -24,7 +24,7 @@
 
 #include "jeandle/jeandleUtils.hpp"
 #include "jeandle/jeandleCallVM.hpp"
-#include CPU_HEADER(jeandleRegister)
+#include "jeandle/jeandleRegister.hpp"
 
 void JeandleCallVM::generate_call_VM(const char* name, address c_func, llvm::FunctionType* func_type, llvm::Module& target_module) {
   llvm::Function* llvm_func = llvm::Function::Create(func_type,

--- a/src/hotspot/share/jeandle/jeandleCallVM.hpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.hpp
@@ -18,38 +18,21 @@
  *
  */
 
-#ifndef SHARE_JEANDLE_JAVA_CALL_HPP
-#define SHARE_JEANDLE_JAVA_CALL_HPP
+#ifndef SHARE_JEANDLE_CALL_VM_HPP
+#define SHARE_JEANDLE_CALL_VM_HPP
 
 #include <cassert>
+#include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/Type.h"
+#include "llvm/IR/LLVMContext.h"
 
 #include "utilities/debug.hpp"
-#include "ci/ciMethod.hpp"
-#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
-class JeandleJavaCall : public AllStatic {
+class JeandleCallVM : public AllStatic {
  public:
-
-  enum Type {
-    // Static calls dispatch directly to the verified entry point of a method and
-    // are used for static calls and non−inlined virtual calls that have only one receiver.
-    STATIC_CALL,
-
-    // Dynamic calls dispatch to the unverified entry point of a method and are
-    // preceded by an instruction that places an inline cache holder in a register.
-    DYNAMIC_CALL,
-
-    NOT_A_CALL,
-  };
-
-  static llvm::FunctionCallee callee(llvm::Module& target_module,
-                                     ciMethod* target,
-                                     llvm::Type* return_type,
-                                     std::vector<llvm::Type*>& args_type);
-
-  static int call_site_size(Type call_type);
+  // Generate stubs that call JeandleRuntimeRoutine.
+  static void generate_call_VM(const char* name, address c_func, llvm::FunctionType* func_type, llvm::Module& target_module);
 };
 
-#endif // SHARE_JEANDLE_JAVA_CALL_HPP
+#endif // SHARE_JEANDLE_CALL_VM_HPP

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -25,6 +25,7 @@
 #include "jeandle/jeandleAssembler.hpp"
 #include "jeandle/jeandleCompilation.hpp"
 #include "jeandle/jeandleCompiledCode.hpp"
+#include "jeandle/jeandleRuntimeRoutine.hpp"
 
 #include "utilities/debug.hpp"
 #include "asm/macroAssembler.hpp"
@@ -71,6 +72,20 @@ class JeandleConstReloc : public JeandleReloc {
  private:
   LinkKind _kind;
   int64_t _addend;
+  address _target;
+};
+
+class JeandleCallVMReloc : public JeandleReloc {
+ public:
+  JeandleCallVMReloc(LinkBlock& block, LinkEdge& edge, address target) :
+    JeandleReloc(block.getAddress().getValue() + edge.getOffset()),
+    _target(target) {}
+
+  void emit_reloc(JeandleAssembler& assembler) override {
+    assembler.patch_call_vm(offset(), _target);
+  }
+
+ private:
   address _target;
 };
 
@@ -130,7 +145,7 @@ void JeandleCompiledCode::finalize() {
   uint64_t align;
   uint64_t offset;
   uint64_t code_size;
-  if (!ReadELF::findFunc(*_elf, FuncSigAnalyze::method_name(_method), align, offset, code_size)) {
+  if (!ReadELF::findFunc(*_elf, _func_name, align, offset, code_size)) {
     JeandleCompilation::report_jeandle_error("compiled function is not found in the ELF file");
     return;
   }
@@ -149,8 +164,10 @@ void JeandleCompiledCode::finalize() {
   masm->set_oop_recorder(_env->oop_recorder());
   JeandleAssembler assembler(masm);
 
-  if (!_method->is_static())
+  if (_method && !_method->is_static()) {
+    // For Java method finalization.
     assembler.emit_ic_check();
+  }
 
   // TODO: NativeJump::patch_verified_entry requires the first instruction of verified entry >= 5 bytes.
   _offsets.set_value(CodeOffsets::Verified_Entry, masm->offset());
@@ -188,7 +205,7 @@ void JeandleCompiledCode::setup_frame_size() {
 void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
   llvm::SmallVector<JeandleReloc*> relocs;
 
-  // Step1: Resolve LinkGraph.
+  // Step 1: Resolve LinkGraph.
   auto ssp = std::make_shared<llvm::orc::SymbolStringPool>();
 
   auto graph_on_err = llvm::jitlink::createLinkGraphFromObject(_elf->getMemoryBufferRef(), ssp);
@@ -200,11 +217,27 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
   auto link_graph = std::move(*graph_on_err);
 
   for (auto *block : link_graph->blocks()) {
+    // Only resolve relocations for instructions in the compiled method.
+    if (block->getSection().getName().compare(".text") != 0) {
+      continue;
+    }
     for (auto& edge : block->edges()) {
       auto& target = edge.getTarget();
 
-      if (target.isDefined() && target.getSection().getName().starts_with(".rodata")) {
-        // Const relocatinos.
+      if (!target.isDefined() && edge.getKind() == JeandleAssembler::get_call_vm_link_kind()) {
+        // Call VM relocations.
+        address target_addr = JeandleRuntimeRoutine::get_stub_entry(*target.getName());
+        JeandleCallVMReloc* call_vm_reloc = new JeandleCallVMReloc(*block, edge, target_addr);
+
+        uint32_t call_inst_offset = JeandleAssembler::fixup_call_inst_offset(call_vm_reloc->offset());
+
+        // TODO: Set the right bci.
+        _safepoints[call_inst_offset] = new CallSiteInfo(0/* statepoint_id */, JeandleJavaCall::STATIC_CALL, target_addr, 0/* bci */);
+        relocs.push_back(call_vm_reloc);
+
+      } else if (target.isDefined() && edge.getKind() == JeandleAssembler::get_const_link_kind()) {
+        // Const relocations.
+        assert(target.getSection().getName().starts_with(".rodata"), "invalid const section");
         address target_addr = resolve_const_edge(*block, edge, assembler);
         if (target_addr == nullptr) {
           return;
@@ -218,7 +251,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
     }
   }
 
-  // Step2: Resolve stackmaps.
+  // Step 2: Resolve stackmaps.
   SectionInfo section_info(".llvm_stackmaps");
   if (ReadELF::findSection(*_elf, section_info)) {
     llvm::StackMapParser<ELFT::Endianness> stackmaps(llvm::ArrayRef(((uint8_t*)object_start()) +
@@ -245,6 +278,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         DebugToken *expvals = _env->debug_info()->create_scope_values(exparray);
         DebugToken *monvals = _env->debug_info()->create_monitor_values(monarray);
 
+        assert(_method, "invalid Java method");
         _env->debug_info()->describe_scope(inst_offset,
                                           methodHandle(),
                                           _method,
@@ -260,16 +294,19 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
                                           monvals);
 
         _env->debug_info()->end_safepoint(inst_offset);
+
+      } else if (CallSiteInfo* safepoint = _safepoints[record->getInstructionOffset()]) {
+        // TODO: Add debug information for safepoints.
       }
     }
   }
 
-  // Step3: Sort jeandle relocs.
+  // Step 3: Sort jeandle relocs.
   llvm::sort(relocs.begin(), relocs.end(), [](const JeandleReloc* lhs, const JeandleReloc* rhs) {
       return lhs->offset() < rhs->offset();
   });
 
-  // Step4: Emit jeandle relocs.
+  // Step 4: Emit jeandle relocs.
   for (JeandleReloc* reloc : relocs) {
     reloc->emit_reloc(assembler);
   }

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -247,6 +247,9 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         // Oop relocations.
         assert((*(target.getName())).starts_with("oop_handle"), "invalid oop relocation name");
         relocs.push_back(new JeandleOopReloc(block->getAddress().getValue() + edge.getOffset(), _oop_handles[(*(target.getName()))]));
+      } else {
+        // Unhandled relocations
+        ShouldNotReachHere();
       }
     }
   }

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -208,7 +208,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
     for (auto& edge : block->edges()) {
       auto& target = edge.getTarget();
 
-      if (!target.isDefined() && JeandleAssembler::is_call_vm_link_kind(edge.getKind())) {
+      if (!target.isDefined() && JeandleAssembler::is_call_vm_reloc_kind(edge.getKind())) {
         // Call VM relocations.
         address target_addr = JeandleRuntimeRoutine::get_stub_entry(*target.getName());
         JeandleCallVMReloc* call_vm_reloc = new JeandleCallVMReloc(*block, edge, target_addr);
@@ -219,7 +219,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         _safepoints[call_inst_offset] = new CallSiteInfo(0/* statepoint_id */, JeandleJavaCall::STATIC_CALL, target_addr, 0/* bci */);
         relocs.push_back(call_vm_reloc);
 
-      } else if (target.isDefined() && JeandleAssembler::is_const_link_kind(edge.getKind())) {
+      } else if (target.isDefined() && JeandleAssembler::is_const_reloc_kind(edge.getKind())) {
         // Const relocations.
         assert(target.getSection().getName().starts_with(".rodata"), "invalid const section");
         address target_addr = resolve_const_edge(*block, edge, assembler);

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -224,7 +224,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
     for (auto& edge : block->edges()) {
       auto& target = edge.getTarget();
 
-      if (!target.isDefined() && edge.getKind() == JeandleAssembler::get_call_vm_link_kind()) {
+      if (!target.isDefined() && JeandleAssembler::is_call_vm_link_kind(edge.getKind())) {
         // Call VM relocations.
         address target_addr = JeandleRuntimeRoutine::get_stub_entry(*target.getName());
         JeandleCallVMReloc* call_vm_reloc = new JeandleCallVMReloc(*block, edge, target_addr);
@@ -235,7 +235,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
         _safepoints[call_inst_offset] = new CallSiteInfo(0/* statepoint_id */, JeandleJavaCall::STATIC_CALL, target_addr, 0/* bci */);
         relocs.push_back(call_vm_reloc);
 
-      } else if (target.isDefined() && edge.getKind() == JeandleAssembler::get_const_link_kind()) {
+      } else if (target.isDefined() && JeandleAssembler::is_const_link_kind(edge.getKind())) {
         // Const relocations.
         assert(target.getSection().getName().starts_with(".rodata"), "invalid const section");
         address target_addr = resolve_const_edge(*block, edge, assembler);
@@ -243,7 +243,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
           return;
         }
         relocs.push_back(new JeandleConstReloc(*block, edge, target_addr));
-      } else if (!target.isDefined() && edge.getKind() == assembler.get_oop_reloc_kind()) {
+      } else if (!target.isDefined() && JeandleAssembler::is_oop_reloc_kind(edge.getKind())) {
         // Oop relocations.
         assert((*(target.getName())).starts_with("oop_handle"), "invalid oop relocation name");
         relocs.push_back(new JeandleOopReloc(block->getAddress().getValue() + edge.getOffset(), _oop_handles[(*(target.getName()))]));

--- a/src/hotspot/share/jeandle/jeandleCompiler.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiler.hpp
@@ -60,7 +60,7 @@ class JeandleCompiler : public AbstractCompiler {
   // Read the template file into a global read-only memory buffer to ensure thread safety.
   std::unique_ptr<llvm::MemoryBuffer> _template_buffer;
 
-  void initialize_template_buffer();
+  bool initialize_template_buffer();
 };
 
 #endif // SHARE_JEANDLE_COMPILER_HPP

--- a/src/hotspot/share/jeandle/jeandleJavaCall.cpp
+++ b/src/hotspot/share/jeandle/jeandleJavaCall.cpp
@@ -19,23 +19,26 @@
  */
 
 #include <cassert>
+#include "llvm/IR/Jeandle/GCStrategy.h"
 #include "llvm/IR/Type.h"
 
 #include "jeandle/jeandleJavaCall.hpp"
 #include "jeandle/jeandleCompilation.hpp"
+#include "jeandle/jeandleUtils.hpp"
 
 #include "utilities/debug.hpp"
 #include "code/nativeInst.hpp"
 
-llvm::FunctionCallee JeandleJavaCall::callee(llvm::Module& module,
+llvm::FunctionCallee JeandleJavaCall::callee(llvm::Module& target_module,
                                              ciMethod* target,
                                              llvm::Type* return_type,
                                              std::vector<llvm::Type*>& args_type) {
   llvm::FunctionType* func_type = llvm::FunctionType::get(return_type, args_type, false);
-  llvm::FunctionCallee callee = module.getOrInsertFunction(FuncSigAnalyze::method_name(target), func_type);
+  llvm::FunctionCallee callee = target_module.getOrInsertFunction(JeandleFuncSig::method_name(target), func_type);
 
   llvm::Function* func = llvm::cast<llvm::Function>(callee.getCallee());
-  FuncSigAnalyze::setup_description(func);
+  func->setCallingConv(llvm::CallingConv::Hotspot_JIT);
+  func->setGC(llvm::jeandle::JeandleGC);
 
   return callee;
 }

--- a/src/hotspot/share/jeandle/jeandleRegister.hpp
+++ b/src/hotspot/share/jeandle/jeandleRegister.hpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef SHARE_JEANDLE_REGISTER_HPP
+#define SHARE_JEANDLE_REGISTER_HPP
+
+#include "utilities/macros.hpp"
+#include CPU_HEADER(jeandleRegister)
+
+#endif // SHARE_JEANDLE_REGISTER_HPP

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.cpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "jeandle/jeandleCompilation.hpp"
+#include "jeandle/jeandleRuntimeRoutine.hpp"
+
+#include "utilities/debug.hpp"
+#include "runtime/frame.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/safepoint.hpp"
+
+#define GEN_ROUTINE_STUB(c_func, return_type, args_type)                                       \
+  {                                                                                            \
+    std::unique_ptr<llvm::LLVMContext> context_ptr = std::make_unique<llvm::LLVMContext>();    \
+    llvm::LLVMContext& context = *context_ptr;                                                 \
+    llvm::FunctionType* func_type = llvm::FunctionType::get(return_type, args_type, false);    \
+    ResourceMark rm;                                                                           \
+    JeandleCompilation compilation(target_machine,                                             \
+                                   data_layout,                                                \
+                                   CompilerThread::current()->env(),                           \
+                                   std::move(context_ptr),                                     \
+                                   #c_func,                                                    \
+                                   CAST_FROM_FN_PTR(address, c_func),                          \
+                                   func_type);                                                 \
+    if (compilation.error_occurred()) { return false; }                                        \
+    _stub_entry.insert({llvm::StringRef(#c_func), compilation.compiled_code()->stub_entry()}); \
+  }
+
+llvm::StringMap<address> JeandleRuntimeRoutine::_stub_entry;
+
+bool JeandleRuntimeRoutine::generate(llvm::TargetMachine* target_machine, llvm::DataLayout* data_layout) {
+  ALL_JEANDLE_ROUTINES(GEN_ROUTINE_STUB);
+  return true;
+}
+
+//=============================================================================
+//                        Jeandle Runtime Routines
+//=============================================================================
+
+JRT_ENTRY(void, JeandleRuntimeRoutine::safepoint_handler(JavaThread* current))
+  RegisterMap r_map(current,
+                    RegisterMap::UpdateMap::skip,
+                    RegisterMap::ProcessFrames::include,
+                    RegisterMap::WalkContinuation::skip);
+  frame trap_frame = current->last_frame().sender(&r_map);
+  CodeBlob* trap_cb = trap_frame.cb();
+  guarantee(trap_cb != nullptr && trap_cb->is_compiled_by_jeandle(), "safepoint handler must be called from jeandle compiled method");
+
+  ThreadSafepointState* state = current->safepoint_state();
+  state->set_at_poll_safepoint(true);
+
+  // TODO: Exception check.
+  SafepointMechanism::process_if_requested_with_exit_check(current, false /* check asyncs */);
+
+  state->set_at_poll_safepoint(false);
+JRT_END

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef SHARE_JEANDLE_RUNTIME_ROUTINE_HPP
+#define SHARE_JEANDLE_RUNTIME_ROUTINE_HPP
+
+#include <cassert>
+#include "llvm/IR/Jeandle/Metadata.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Target/TargetMachine.h"
+
+#include "utilities/debug.hpp"
+#include "memory/allStatic.hpp"
+#include "runtime/javaThread.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+//------------------------------------------------------------------------------------------------------
+//   |     c_func      |       return_type             |                    args_type
+//------------------------------------------------------------------------------------------------------
+#define ALL_JEANDLE_ROUTINES(def)                                                                                                     \
+  def(safepoint_handler, llvm::Type::getVoidTy(context), {llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace)})
+
+// JeandleRuntimeRoutine contains C/C++ functions that can be called from Jeandle compiled code.
+class JeandleRuntimeRoutine : public AllStatic {
+ public:
+  // Generate all routine stubs.
+  static bool generate(llvm::TargetMachine* target_machine, llvm::DataLayout* data_layout);
+
+// Define all routines' llvm::FunctionCallee.
+#define DEF_LLVM_CALLEE(c_func, return_type, args_type)                                             \
+  static llvm::FunctionCallee c_func##_callee(llvm::Module& target_module) {                        \
+    llvm::LLVMContext& context = target_module.getContext();                                        \
+    llvm::FunctionType* func_type = llvm::FunctionType::get(return_type, args_type, false);         \
+    llvm::FunctionCallee callee = target_module.getOrInsertFunction(#c_func, func_type);            \
+    llvm::cast<llvm::Function>(callee.getCallee())->setCallingConv(llvm::CallingConv::Hotspot_JIT); \
+    return callee;                                                                                  \
+  }
+
+  ALL_JEANDLE_ROUTINES(DEF_LLVM_CALLEE);
+
+  static address get_stub_entry(llvm::StringRef name) {
+    assert(_stub_entry.contains(name), "invalid runtime routine");
+    return _stub_entry.lookup(name);
+  }
+
+ private:
+  static llvm::StringMap<address> _stub_entry;
+
+  static void safepoint_handler(JavaThread* current);
+};
+
+#endif // SHARE_JEANDLE_RUNTIME_ROUTINE_HPP

--- a/src/hotspot/share/jeandle/jeandleType.cpp
+++ b/src/hotspot/share/jeandle/jeandleType.cpp
@@ -18,6 +18,9 @@
  *
  */
 
+#include <cassert>
+#include "llvm/IR/Jeandle/Metadata.h"
+
 #include "jeandle/jeandleType.hpp"
 
 llvm::Type* JeandleType::java2llvm(BasicType java_type, llvm::LLVMContext& context) {
@@ -42,9 +45,9 @@ llvm::Type* JeandleType::java2llvm(BasicType java_type, llvm::LLVMContext& conte
     case BasicType::T_LONG:
       return llvm::Type::getInt64Ty(context);
     case BasicType::T_OBJECT:
-      return llvm::PointerType::get(context, OBJECT_ADDR_SPACE);
+      return llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace);
     case BasicType::T_ARRAY:
-      return llvm::PointerType::get(context, OBJECT_ADDR_SPACE);
+      return llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace);
     case BasicType::T_VOID:
       return llvm::Type::getVoidTy(context);
     case BasicType::T_ADDRESS:

--- a/src/hotspot/share/jeandle/jeandleType.hpp
+++ b/src/hotspot/share/jeandle/jeandleType.hpp
@@ -29,21 +29,18 @@
 #include "utilities/debug.hpp"
 #include "ci/compilerInterface.hpp"
 
-// Used for GC relative passes to distinguish java objects.
-#define OBJECT_ADDR_SPACE 1
-
 class JeandleType : public AllStatic {
  public:
 
-  // Convert a JAVA type to its LLVM type.
+  // Convert a Java type to its LLVM type.
   static llvm::Type* java2llvm(BasicType jvm_type, llvm::LLVMContext& context);
 
   static bool is_double_word_type(llvm::Type* t) {
     return t->isIntegerTy(64) || t->isDoubleTy();
   }
 
-  // Get a LLVM constant value according to a JAVA type.
-  // For example: If you want to get a LLVM value that represent a JAVA int, use int_const().
+  // Get a LLVM constant value according to a Java type.
+  // For example: If you want to get a LLVM value that represent a Java int, use int_const().
 
   static llvm::ConstantInt* int_const(llvm::IRBuilder<>& builder, uint32_t value) {
     return builder.getInt32(value);

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <cassert>
+#include "llvm/IR/Jeandle/Attributes.h"
+#include "llvm/IR/Jeandle/GCStrategy.h"
+
+#include "jeandle/jeandleType.hpp"
+#include "jeandle/jeandleUtils.hpp"
+
+llvm::Function* JeandleFuncSig::create_llvm_func(ciMethod* method, llvm::Module& target_module) {
+  llvm::SmallVector<llvm::Type*> args;
+  llvm::LLVMContext& context = target_module.getContext();
+
+  // Reciever is the first argument.
+  if (!method->is_static()) {
+    args.push_back(JeandleType::java2llvm(BasicType::T_OBJECT, context));
+  }
+
+  ciSignature* sig = method->signature();
+  for (int i = 0; i < sig->count(); i++) {
+    args.push_back(JeandleType::java2llvm(sig->type_at(i)->basic_type(), context));
+  }
+
+  llvm::FunctionType* func_type =
+      llvm::FunctionType::get(JeandleType::java2llvm(sig->return_type()->basic_type(), context),
+                              args,
+                              false);
+  llvm::Function* func = llvm::Function::Create(func_type,
+                                                llvm::Function::ExternalLinkage,
+                                                method_name(method),
+                                                target_module);
+
+  setup_description(func);
+
+  return func;
+}
+
+std::string JeandleFuncSig::method_name(ciMethod* method) {
+  std::string class_name = std::string(method->holder()->name()->as_utf8());
+  std::replace(class_name.begin(), class_name.end(), '/', '_');
+
+  std::string method_name = std::string(method->name()->as_utf8());
+  std::replace(method_name.begin(), method_name.end(), '/', '_');
+
+  std::string sig_name = std::string(method->signature()->as_symbol()->as_utf8());
+  std::replace(sig_name.begin(), sig_name.end(), '/', '_');
+
+  return class_name
+         + "_" + method_name
+         + "_" + sig_name;
+}
+
+void JeandleFuncSig::setup_description(llvm::Function* func) {
+  func->setCallingConv(llvm::CallingConv::Hotspot_JIT);
+
+  func->setGC(llvm::jeandle::JeandleGC);
+
+  if (UseCompressedOops) {
+    func->addFnAttr(llvm::Attribute::get(func->getContext(), llvm::jeandle::Attribute::UseCompressedOops));
+  }
+}

--- a/src/hotspot/share/jeandle/jeandleUtils.hpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.hpp
@@ -18,38 +18,23 @@
  *
  */
 
-#ifndef SHARE_JEANDLE_JAVA_CALL_HPP
-#define SHARE_JEANDLE_JAVA_CALL_HPP
+#ifndef SHARE_JEANDLE_UTILS_HPP
+#define SHARE_JEANDLE_UTILS_HPP
 
 #include <cassert>
+#include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/Type.h"
 
 #include "utilities/debug.hpp"
 #include "ci/ciMethod.hpp"
-#include "memory/allStatic.hpp"
 
-class JeandleJavaCall : public AllStatic {
+
+class JeandleFuncSig : public AllStatic {
  public:
-
-  enum Type {
-    // Static calls dispatch directly to the verified entry point of a method and
-    // are used for static calls and non−inlined virtual calls that have only one receiver.
-    STATIC_CALL,
-
-    // Dynamic calls dispatch to the unverified entry point of a method and are
-    // preceded by an instruction that places an inline cache holder in a register.
-    DYNAMIC_CALL,
-
-    NOT_A_CALL,
-  };
-
-  static llvm::FunctionCallee callee(llvm::Module& target_module,
-                                     ciMethod* target,
-                                     llvm::Type* return_type,
-                                     std::vector<llvm::Type*>& args_type);
-
-  static int call_site_size(Type call_type);
+  // Create a llvm function according to the Java method.
+  static llvm::Function* create_llvm_func(ciMethod* method, llvm::Module& target_module);
+  static std::string method_name(ciMethod* method);
+  static void setup_description(llvm::Function* func);
 };
 
-#endif // SHARE_JEANDLE_JAVA_CALL_HPP
+#endif // SHARE_JEANDLE_UTILS_HPP

--- a/src/hotspot/share/jeandle/jeandle_globals.hpp
+++ b/src/hotspot/share/jeandle/jeandle_globals.hpp
@@ -46,6 +46,9 @@
   develop(bool, JeandleCrashOnError, DEBUG_ONLY(true) NOT_DEBUG(false),     \
           "Crash JVM on Jeandle errors")                                    \
                                                                             \
+  product(bool, JeandleDumpRuntimeStubs, false,                             \
+          "Dump Jeandle runtime stubs")                                     \
+                                                                            \
 
 // end of JEANDLE_FLAGS
 

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <cassert>
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/IRBuilder.h"
+
+#include "jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp"
+#include "jeandle/jeandleRuntimeRoutine.hpp"
+#include CPU_HEADER(jeandleRegister)
+
+#include "utilities/debug.hpp"
+#include "runtime/javaThread.hpp"
+#include "runtime/safepointMechanism.hpp"
+
+#define DEF_JAVA_OP(name, return_type, args_type, lower_phase)                              \
+  void define_##name(llvm::Module& template_module) {                                       \
+    if (RuntimeDefinedJavaOps::failed()) { return; }                                        \
+    llvm::LLVMContext& context = template_module.getContext();                              \
+    llvm::FunctionType* func_type = llvm::FunctionType::get(return_type, args_type, false); \
+    llvm::Function* func = llvm::Function::Create(func_type,                                \
+                                                  llvm::Function::PrivateLinkage,           \
+                                                  "jeandle."#name,                          \
+                                                  template_module);                         \
+    func->addFnAttr("lower-phase", #lower_phase);                                           \
+    func->addFnAttr(llvm::Attribute::NoInline);                                             \
+    func->setCallingConv(llvm::CallingConv::Hotspot_JIT);                                   \
+    llvm::BasicBlock* entry_block = llvm::BasicBlock::Create(context, "entry", func);       \
+    llvm::IRBuilder<> ir_builder(entry_block);                                              \
+
+#define JAVA_OP_END }
+
+namespace {
+
+DEF_JAVA_OP(current_thread, llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace), {}, 0)
+  llvm::NamedMDNode* thread_register = template_module.getNamedMetadata(llvm::jeandle::Metadata::CurrentThread);
+  assert(thread_register != nullptr, "current_thread metadata must exist");
+  llvm::Value* read_register_args[] = {llvm::MetadataAsValue::get(context, thread_register->getOperand(0))};
+  llvm::Type* intptr_type = ir_builder.getIntPtrTy(template_module.getDataLayout());
+  llvm::CallInst* current_thread_value = ir_builder.CreateIntrinsic(llvm::Intrinsic::read_register,
+                                                                    intptr_type,
+                                                                    read_register_args);
+  llvm::Value* current_thread_ptr = ir_builder.CreateIntToPtr(current_thread_value,
+                                                              llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace));
+  ir_builder.CreateRet(current_thread_ptr);
+JAVA_OP_END
+
+DEF_JAVA_OP(safepoint_poll, llvm::Type::getVoidTy(context), {}, 1)
+  llvm::BasicBlock* return_block = llvm::BasicBlock::Create(context, "return", func);
+  llvm::BasicBlock* do_safepoint_block = llvm::BasicBlock::Create(context, "do_safepoint", func);
+
+  llvm::Type* intptr_type = ir_builder.getIntPtrTy(template_module.getDataLayout());
+
+  // ******** Entry Block *********
+  // Get the poll word pointer.
+  llvm::Value* poll_word_ptr = ir_builder.CreateIntToPtr(ir_builder.getInt64((uint64_t)JavaThread::polling_word_offset()),
+                                                         llvm::PointerType::get(context, llvm::jeandle::AddrSpace::TLSAddrSpace));
+  // Do poll.
+  llvm::Value* poll_word = ir_builder.CreateLoad(intptr_type, poll_word_ptr);
+  llvm::Value* if_safepoint = ir_builder.CreateICmp(llvm::CmpInst::ICMP_EQ,
+                                                    poll_word,
+                                                    llvm::ConstantInt::get(intptr_type, ~SafepointMechanism::poll_bit()));
+  ir_builder.CreateCondBr(if_safepoint, return_block, do_safepoint_block);
+
+  // ***** Do Safepoint Block *****
+  ir_builder.SetInsertPoint(do_safepoint_block);
+  // Get the current thread pointer as the safepoint handler's argument.
+  llvm::Function* current_thread_func = template_module.getFunction("jeandle.current_thread");
+  if (!current_thread_func) {
+    RuntimeDefinedJavaOps::set_failed("jeandle.current_thread is not found in template module");
+    return;
+  }
+  llvm::CallInst* current_thread = ir_builder.CreateCall(current_thread_func);
+  current_thread->setCallingConv(llvm::CallingConv::Hotspot_JIT);
+  // Call safepoint handler.
+  llvm::CallInst* call_inst = ir_builder.CreateCall(JeandleRuntimeRoutine::safepoint_handler_callee(template_module), {current_thread});
+  call_inst->setCallingConv(llvm::CallingConv::Hotspot_JIT);
+  ir_builder.CreateBr(return_block);
+
+  // ******** Return Block ********
+  ir_builder.SetInsertPoint(return_block);
+  ir_builder.CreateRetVoid();
+JAVA_OP_END
+
+} // anonymous namespace
+
+const char* RuntimeDefinedJavaOps::_error_msg = nullptr;
+
+bool RuntimeDefinedJavaOps::define_all(llvm::Module& template_module) {
+  reset_state();
+
+  // Define all necessary metadata nodes:
+  define_metadata(template_module);
+
+  // Define all runtime defined JavaOps:
+  define_current_thread(template_module);
+  define_safepoint_poll(template_module);
+
+  return failed();
+}
+
+void RuntimeDefinedJavaOps::define_metadata(llvm::Module& template_module) {
+  llvm::LLVMContext& context = template_module.getContext();
+
+  // Current thread register:
+  {
+    llvm::MDNode* thread_register = llvm::MDNode::get(context, {llvm::MDString::get(context, JeandleRegister::get_current_thread_pointer())});
+    llvm::NamedMDNode* metadata_node = template_module.getOrInsertNamedMetadata(llvm::jeandle::Metadata::CurrentThread);
+    metadata_node->addOperand(thread_register);
+  }
+
+  // Stack pointer register:
+  {
+    llvm::MDNode* stack_pointer = llvm::MDNode::get(context, {llvm::MDString::get(context, JeandleRegister::get_stack_pointer())});
+    llvm::NamedMDNode* metadata_node = template_module.getOrInsertNamedMetadata(llvm::jeandle::Metadata::StackPointer);
+    metadata_node->addOperand(stack_pointer);
+  }
+}

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -24,7 +24,7 @@
 
 #include "jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
-#include CPU_HEADER(jeandleRegister)
+#include "jeandle/jeandleRegister.hpp
 
 #include "utilities/debug.hpp"
 #include "runtime/javaThread.hpp"

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -24,7 +24,7 @@
 
 #include "jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
-#include "jeandle/jeandleRegister.hpp
+#include "jeandle/jeandleRegister.hpp"
 
 #include "utilities/debug.hpp"
 #include "runtime/javaThread.hpp"

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp
@@ -18,38 +18,28 @@
  *
  */
 
-#ifndef SHARE_JEANDLE_JAVA_CALL_HPP
-#define SHARE_JEANDLE_JAVA_CALL_HPP
+#ifndef SHARE_JEANDLE_RUNTIME_DEFINED_JAVA_OPS_HPP
+#define SHARE_JEANDLE_RUNTIME_DEFINED_JAVA_OPS_HPP
 
 #include <cassert>
-#include "llvm/IR/Function.h"
-#include "llvm/IR/Type.h"
+#include "llvm/IR/Module.h"
 
 #include "utilities/debug.hpp"
-#include "ci/ciMethod.hpp"
 #include "memory/allStatic.hpp"
 
-class JeandleJavaCall : public AllStatic {
+class RuntimeDefinedJavaOps : public AllStatic {
  public:
+  static bool define_all(llvm::Module& template_module);
 
-  enum Type {
-    // Static calls dispatch directly to the verified entry point of a method and
-    // are used for static calls and non−inlined virtual calls that have only one receiver.
-    STATIC_CALL,
+  static void reset_state() { _error_msg = nullptr; }
+  static void set_failed(const char* error_msg) { assert(error_msg != nullptr, "why we failed?"); _error_msg = error_msg; }
+  static bool failed() { return _error_msg != nullptr; }
+  static const char* error_msg() { return _error_msg; }
 
-    // Dynamic calls dispatch to the unverified entry point of a method and are
-    // preceded by an instruction that places an inline cache holder in a register.
-    DYNAMIC_CALL,
+ private:
+  static const char* _error_msg;
 
-    NOT_A_CALL,
-  };
-
-  static llvm::FunctionCallee callee(llvm::Module& target_module,
-                                     ciMethod* target,
-                                     llvm::Type* return_type,
-                                     std::vector<llvm::Type*>& args_type);
-
-  static int call_site_size(Type call_type);
+  static void define_metadata(llvm::Module& template_module);
 };
 
-#endif // SHARE_JEANDLE_JAVA_CALL_HPP
+#endif // SHARE_JEANDLE_RUNTIME_DEFINED_JAVA_OPS_HPP

--- a/src/hotspot/share/jeandle/templatemodule/template.ll
+++ b/src/hotspot/share/jeandle/templatemodule/template.ll
@@ -2,7 +2,7 @@
 ; operation. These functions will be used by some passes to do Java-related optimizations. After corresponding
 ; optimizations, JavaOp will be inlined(lowered) by JavaOperationLower passes.
 
-define i32 @jeandle.instanceof(i32 %super_kid, ptr addrspace(1) nocapture %oop)  "lower-phase"="0" {
+define hotspotcc i32 @jeandle.instanceof(i32 %super_kid, ptr addrspace(1) nocapture %oop) noinline "lower-phase"="0" {
     ; TODO: There should be a real implementation of instanceof here.
     ret i32 1
 }

--- a/test/hotspot/jtreg/compiler/jeandle/TestSafepointPoll.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestSafepointPoll.java
@@ -1,0 +1,39 @@
+/**
+ * @test
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:CompileCommand=compileonly,TestSafepointPoll::test -Xcomp -XX:-TieredCompilation
+ *      -XX:+UseJeandleCompiler -Xlog:thread*=trace::time,tags -XX:+JeandleDumpIR -XX:+JeandleDumpObjects -XX:+JeandleDumpRuntimeStubs TestSafepointPoll
+ */
+
+import java.lang.reflect.Method;
+
+import jdk.test.whitebox.WhiteBox;
+
+public class TestSafepointPoll {
+    private final static WhiteBox wb = WhiteBox.getWhiteBox();
+    static volatile boolean stop = false;
+
+    public static void main(String[] args) throws Exception {
+        new Thread(() -> {
+            test();
+        }).start();
+
+        Method method = TestSafepointPoll.class.getDeclaredMethod("test");
+        while (!wb.isMethodCompiled(method)) {
+            Thread.yield();
+        }
+
+        Thread.sleep(100);
+
+        wb.forceSafepoint();
+
+        stop = true;
+    }
+
+    static void test() {
+        while (!stop) {}
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/TestSafepointPoll.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestSafepointPoll.java
@@ -1,6 +1,7 @@
 /**
  * @test
  * @library /test/lib
+ * @requires os.arch=="x86_64"
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/compiler/jeandle/relocation/TestRelocation.java
+++ b/test/hotspot/jtreg/compiler/jeandle/relocation/TestRelocation.java
@@ -20,6 +20,7 @@
 
 /*
  * @test
+ * @requires os.arch=="x86_64"
  * @library /test/lib
  * @build jdk.test.lib.Asserts
  * @run main/othervm -XX:-TieredCompilation -Xcomp


### PR DESCRIPTION
## Related issue(s):

issue #7

## What this PR does / why we need it:

The safepoint poll is defined as JavaOp, and is inlined in the later stage of optimization.

I use the thread local poll word to determine whether to enter a safepoint, and leverage a runtime stub to transfer execution to the C++-implemented safepoint handler.

Currently, only safepoint polls for back edges.
