### PR TITLE
docs: Use --parallel parameter when build jeandle-llvm

### DIFF
--- a/jeandle-docs/getting-started.md
+++ b/jeandle-docs/getting-started.md
@@ -19,7 +19,7 @@ cd jeandle-llvm
 mkdir build
 cd build
 cmake -G "Unix Makefiles" -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE="Release" -DCMAKE_INSTALL_PREFIX="/home/jeandle-llvm-install" -DLLVM_BUILD_LLVM_DYLIB=On -DLLVM_DYLIB_COMPONENTS=all ../llvm
-cmake --build . --target install
+cmake --build . --target install --parallel
 ```
 
 3. Clone jeandle-jdk:


### PR DESCRIPTION
## Related issue(s):

issue #50

## What this PR does / why we need it:

Update the getting-started.md about how the build the jeandle-llvm