### PR TITLE
feat: Support inline intrinsic functions

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -901,13 +901,13 @@ void JeandleAbstractInterpreter::invoke() {
   assert(will_link == target->is_loaded(), "");
 
   if (target->is_loaded() && target->check_intrinsic_candidate()) {
-    if (log_is_enabled(Debug, jit)) {
-      ResourceMark rm;
-      stringStream ss;
-      target->print_name(&ss);
-      log_debug(jit)("Find intrinsic candidate :%s", ss.as_string());
-    }
     if (inline_intrinsic(target)) {
+      if (log_is_enabled(Debug, jeandle)) {
+        ResourceMark rm;
+        stringStream ss;
+        target->print_name(&ss);
+        log_debug(jeandle)("Method `%s` is parsed as intrinsic", ss.as_string());
+      }
       return;
     };
   }
@@ -984,8 +984,12 @@ void JeandleAbstractInterpreter::invoke() {
 bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
   switch(target->intrinsic_id()) {
     case vmIntrinsics::_dabs: {
-      // _ir_builder.CreateIntrinsic()
-      return false;
+      _jvm->dpush(_ir_builder.CreateIntrinsic(JeandleType::java2llvm(BasicType::T_DOUBLE, *_context), llvm::Intrinsic::fabs, {_jvm->dpop()}));
+      break;
+    }
+    case vmIntrinsicID::_fabs: {
+      _jvm->fpush(_ir_builder.CreateIntrinsic(JeandleType::java2llvm(BasicType::T_FLOAT, *_context), llvm::Intrinsic::fabs, {_jvm->fpop()}));
+      break;
     }
     default:
       return false;

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -244,6 +244,7 @@ class JeandleAbstractInterpreter : public StackObj {
   void goto_bci(int bci);
   void lookup_switch();
   void invoke();
+  bool inline_intrinsic(const ciMethod* target);
   void stack_op(Bytecodes::Code code);
   void shift_op(BasicType type, Bytecodes::Code code);
   void instanceof(int klass_index);

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -98,6 +98,7 @@ class outputStream;
   LOG_TAG(install) \
   LOG_TAG(interpreter) \
   LOG_TAG(itables) \
+  LOG_TAG(jeandle) \
   LOG_TAG(jfr) \
   LOG_TAG(jit) \
   LOG_TAG(jni) \

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsDouble.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.Asserts
+ * @run main/othervm compiler.jeandle.intrinsic.TestAbsDouble
+ */
+
+package compiler.jeandle.intrinsic;
+
+import java.nio.file.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestAbsDouble {
+    public static void main(String[] args) throws Exception {
+        String dump_path = System.getProperty("java.io.tmpdir");
+        ArrayList<String> command_args = new ArrayList<String>(List.of(
+            "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
+            "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
+            "-XX:JeandleDumpDirectory="+dump_path,
+            "-XX:CompileCommand=compileonly,"+TestWrapper.class.getName()+"::abs_double",
+            TestWrapper.class.getName()
+        ));
+    
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command_args);
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+
+        output.shouldHaveExitValue(0)
+              .shouldContain("Method `static jdouble java.lang.Math.abs(jdouble)` is parsed as intrinsic");
+
+        // verify IR
+        String dumpedIR = getJeandleIR(dump_path);
+        Asserts.assertTrue(dumpedIR.indexOf("call double @llvm.fabs.f64(double") != -1);
+    }
+
+    static String getJeandleIR(String dir) throws Exception {
+        Pattern pattern = Pattern.compile("^compiler_jeandle_intrinsic_TestAbsDouble\\$TestWrapper_abs_double_.*-[0-9]+\\.ll$");  // skip *_optimized.ll
+        Path directory = Paths.get(dir);
+        if (!Files.isDirectory(directory)) {
+            throw new RuntimeException("Directory " + dir + " does not exist");
+        }
+        try (Stream<Path> paths = Files.list(directory)) {
+            List<Path> matched = paths.filter(Files::isRegularFile)
+                 .filter(path -> {
+                   return pattern.matcher(path.getFileName().toString()).matches();})
+                 .toList();
+
+            if (matched.size() != 1) {
+                throw new RuntimeException("Should dump only one jeandle ir file: " + matched.size());
+            }
+
+            return Files.readString(matched.get(0));
+        }
+    }
+
+    static public class TestWrapper {
+        static double v = Math.abs(1.0d);   // Force load java.lang.Math class
+        public static void main(String[] args) {
+            Random random = new Random();
+            Asserts.assertEquals(1.5d, abs_double(1.5d));
+            Asserts.assertEquals(1.5d, abs_double(-1.5d));
+            Asserts.assertEquals(Double.NaN, abs_double(Double.NaN));
+            Asserts.assertEquals(Double.POSITIVE_INFINITY, abs_double(Double.POSITIVE_INFINITY));
+            Asserts.assertEquals(Double.POSITIVE_INFINITY, abs_double(Double.NEGATIVE_INFINITY));
+            for (int i=0; i< 1000; i++) {
+                double d = random.nextDouble();
+                double r = d > 0.0d ? d : -1*d;
+                Asserts.assertEquals(r , abs_double(d));
+            }
+        }
+
+        public static double abs_double(double a) {
+            return Math.abs(a);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsFloat.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsFloat.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.Asserts
+ * @run main/othervm compiler.jeandle.intrinsic.TestAbsFloat
+ */
+
+package compiler.jeandle.intrinsic;
+
+import java.nio.file.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestAbsFloat {
+    public static void main(String[] args) throws Exception {
+        String dump_path = System.getProperty("java.io.tmpdir");
+        ArrayList<String> command_args = new ArrayList<String>(List.of(
+            "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
+            "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
+            "-XX:JeandleDumpDirectory="+dump_path,
+            "-XX:CompileCommand=compileonly,"+TestWrapper.class.getName()+"::abs_float",
+            TestWrapper.class.getName()
+        ));
+    
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command_args);
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+
+        output.shouldHaveExitValue(0)
+              .shouldContain("Method `static jfloat java.lang.Math.abs(jfloat)` is parsed as intrinsic");
+
+        // verify IR
+        String dumpedIR = getJeandleIR(dump_path);
+        Asserts.assertTrue(dumpedIR.indexOf("call float @llvm.fabs.f32(float") != -1);
+    }
+
+    static String getJeandleIR(String dir) throws Exception {
+        Pattern pattern = Pattern.compile("^compiler_jeandle_intrinsic_TestAbsFloat\\$TestWrapper_abs_float_.*-[0-9]+\\.ll$");  // skip *_optimized.ll
+        Path directory = Paths.get(dir);
+        if (!Files.isDirectory(directory)) {
+            throw new RuntimeException("Directory " + dir + " does not exist");
+        }
+        try (Stream<Path> paths = Files.list(directory)) {
+            List<Path> matched = paths.filter(Files::isRegularFile)
+                 .filter(path -> {
+                   return pattern.matcher(path.getFileName().toString()).matches();})
+                 .toList();
+
+            if (matched.size() != 1) {
+                throw new RuntimeException("Should dump only one jeandle ir file: " + matched.size());
+            }
+
+            return Files.readString(matched.get(0));
+        }
+    }
+
+    static public class TestWrapper {
+        static float v = Math.abs(1.0f);   // Force load java.lang.Math class
+        public static void main(String[] args) {
+            Random random = new Random();
+            Asserts.assertEquals(1.5f, abs_float(1.5f));
+            Asserts.assertEquals(1.5f, abs_float(-1.5f));
+            Asserts.assertEquals(Float.NaN, abs_float(Float.NaN));
+            Asserts.assertEquals(Float.POSITIVE_INFINITY, abs_float(Float.POSITIVE_INFINITY));
+            Asserts.assertEquals(Float.POSITIVE_INFINITY, abs_float(Float.NEGATIVE_INFINITY));
+            for (int i=0; i< 1000; i++) {
+                float f = random.nextFloat();
+                float r = f > 0.0f ? f : -1*f;
+                Asserts.assertEquals(r , abs_float(f));
+            }
+        }
+
+        public static float abs_float(float a) {
+            return Math.abs(a);
+        }
+    }
+}


### PR DESCRIPTION
## Related issue(s):

issue #59

## What this PR does / why we need it:
Initial support for inline intrinsic functions.
During abstract interpreter, jeandle can recognize methods which can be converted as llvm intrinsic.
Implement intrinsic for Math.abs(double) and Math.abs(float)

Testing:
- test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsDouble.java
- test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsFloat.java