### PR TITLE
feat：Refactor include headers

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -18,13 +18,14 @@
  *
  */
 
-#include <cassert>
+#include "../../share/compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/ExecutionEngine/JITLink/aarch64.h"
 
 #include "jeandle/jeandleAssembler.hpp"
 #include "jeandle/jeandleCompilation.hpp"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "code/nativeInst.hpp"
 #include "runtime/sharedRuntime.hpp"
 

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -18,13 +18,14 @@
  *
  */
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/ExecutionEngine/JITLink/x86_64.h"
 
 #include "jeandle/jeandleAssembler.hpp"
 #include "jeandle/jeandleCompilation.hpp"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "code/nativeInst.hpp"
 #include "runtime/sharedRuntime.hpp"
 

--- a/src/hotspot/cpu/x86/jeandleCompiledCode_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleCompiledCode_x86.cpp
@@ -18,8 +18,8 @@
  *
  */
 
-#include "jeandle/jeandleCompiledCode.hpp"
 #include "jeandle/jeandleCompilation.hpp"
+#include "jeandle/jeandleCompiledCode.hpp"
 
 // Get the frame size from .stack_sizes section.
 void JeandleCompiledCode::setup_frame_size() {

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -23,12 +23,6 @@
  *
  */
 
-#ifdef JEANDLE
-#include <cassert>
-#include "llvm/Support/TargetSelect.h"
-#include "utilities/debug.hpp"
-#endif // JEANDLE
-
 #include "precompiled.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/symbolTable.hpp"
@@ -86,11 +80,12 @@
 #ifdef COMPILER2
 #include "opto/c2compiler.hpp"
 #endif
+#include "compiler/llvm_hotspot_macros.hpp"
 #ifdef JEANDLE
-#pragma push_macro("AARCH64")
-#undef AARCH64
+LLVM_HEADER_BEGIN
+#include "llvm/Support/TargetSelect.h"
 #include "jeandle/jeandleCompiler.hpp"
-#pragma pop_macro("AARCH64")
+LLVM_HEADER_END
 #endif // JEANDLE
 #if INCLUDE_JVMCI
 #include "jvmci/jvmciEnv.hpp"

--- a/src/hotspot/share/compiler/llvm_hotspot_macros.hpp
+++ b/src/hotspot/share/compiler/llvm_hotspot_macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -16,26 +16,25 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
  */
 
-#ifndef SHARE_JEANDLE_UTILS_HPP
-#define SHARE_JEANDLE_UTILS_HPP
+#ifndef JEANDLE_JDK_LLVM_HOTSPOT_MACROS_H
+#define JEANDLE_JDK_LLVM_HOTSPOT_MACROS_H
 
-#include "compiler/llvm_hotspot_macros.hpp"
-LLVM_HEADER_BEGIN
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Function.h"
-LLVM_HEADER_END
+#define STRINGIFY(x) #x
+#define INCLUDE_HEADER(x) _Pragma(STRINGIFY(include x))
 
-#include "ci/ciMethod.hpp"
+#define LLVM_HEADER_BEGIN \
+    _Pragma("push_macro(\"AARCH64\")") \
+    _Pragma("undef AARCH64") \
+    INCLUDE_HEADER(<cassert>)
 
+#define LLVM_HEADER_END \
+    _Pragma("pop_macro(\"AARCH64\")") \
+    INCLUDE_HEADER("utilities/debug.hpp")
 
-class JeandleFuncSig : public AllStatic {
- public:
-  // Create a llvm function according to the Java method.
-  static llvm::Function* create_llvm_func(ciMethod* method, llvm::Module& target_module);
-  static std::string method_name(ciMethod* method);
-  static void setup_description(llvm::Function* func, bool is_stub = false);
-};
-
-#endif // SHARE_JEANDLE_UTILS_HPP
+#endif

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -18,11 +18,13 @@
  *
  */
 
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
 #include "llvm/IR/Jeandle/Metadata.h"
-
+LLVM_HEADER_END
 
 #include "jeandle/jeandleAbstractInterpreter.hpp"
 #include "jeandle/jeandleCompiledCall.hpp"

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -21,7 +21,8 @@
 #ifndef SHARE_JEANDLE_ABSTRACT_INTERPRETER_HPP
 #define SHARE_JEANDLE_ABSTRACT_INTERPRETER_HPP
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/IRBuilder.h"
@@ -30,8 +31,8 @@
 #include <vector>
 
 #include "jeandle/jeandleCompilation.hpp"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "ci/compilerInterface.hpp"
 #include "memory/allocation.hpp"
 #include "utilities/bitMap.inline.hpp"

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -21,12 +21,13 @@
 #ifndef SHARE_JEANDLE_ASSEMBLER_HPP
 #define SHARE_JEANDLE_ASSEMBLER_HPP
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 
 #include "jeandle/jeandleCompilation.hpp"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "asm/macroAssembler.hpp"
 
 using LinkKind  = llvm::jitlink::Edge::Kind;

--- a/src/hotspot/share/jeandle/jeandleCallVM.cpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.cpp
@@ -18,17 +18,20 @@
  *
  */
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/Metadata.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
+LLVM_HEADER_END
 
 #include "jeandle/jeandleCompiledCall.hpp"
 #include "jeandle/jeandleUtils.hpp"
 #include "jeandle/jeandleCallVM.hpp"
 #include "jeandle/jeandleRegister.hpp"
+
 
 void JeandleCallVM::generate_call_VM(const char* name, address c_func, llvm::FunctionType* func_type, llvm::Module& target_module, JeandleCompiledCode& code) {
   llvm::Function* llvm_func = llvm::Function::Create(func_type,

--- a/src/hotspot/share/jeandle/jeandleCallVM.hpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.hpp
@@ -21,14 +21,15 @@
 #ifndef SHARE_JEANDLE_CALL_VM_HPP
 #define SHARE_JEANDLE_CALL_VM_HPP
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
 
 #include "jeandle/jeandleCompiledCode.hpp"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class JeandleCallVM : public AllStatic {

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -18,7 +18,8 @@
  *
  */
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Jeandle/Jeandle.h"
@@ -50,8 +51,8 @@
 #include "jeandle/jeandleCompiler.hpp"
 #include "jeandle/jeandleType.hpp"
 #include "jeandle/jeandleUtils.hpp"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "logging/log.hpp"
 #include "runtime/sharedRuntime.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -21,9 +21,8 @@
 #ifndef SHARE_JEANDLE_COMPILATION_HPP
 #define SHARE_JEANDLE_COMPILATION_HPP
 
-#include <cassert>
-#pragma push_macro("AARCH64")
-#undef AARCH64
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
@@ -32,9 +31,8 @@
 #include <memory>
 
 #include "jeandle/jeandleCompiledCode.hpp"
-#pragma pop_macro("AARCH64")
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "ci/ciEnv.hpp"
 #include "ci/ciMethod.hpp"
 #include "memory/arena.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompiledCall.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCall.hpp
@@ -21,11 +21,12 @@
 #ifndef SHARE_JEANDLE_COMPILED_CALL_HPP
 #define SHARE_JEANDLE_COMPILED_CALL_HPP
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Type.h"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "ci/ciMethod.hpp"
 #include "memory/allStatic.hpp"
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -18,7 +18,8 @@
  *
  */
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/Support/DataExtractor.h"
 
 #include "jeandle/jeandleAssembler.hpp"
@@ -26,8 +27,8 @@
 #include "jeandle/jeandleCompiledCode.hpp"
 #include "jeandle/jeandleRegister.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "asm/macroAssembler.hpp"
 #include "ci/ciEnv.hpp"
 #include "code/vmreg.inline.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -21,7 +21,8 @@
 #ifndef SHARE_JEANDLE_COMPILED_CODE_HPP
 #define SHARE_JEANDLE_COMPILED_CODE_HPP
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/IR/Statepoint.h"
@@ -33,8 +34,8 @@
 #include "jeandle/jeandleReadELF.hpp"
 #include "jeandle/jeandleResourceObj.hpp"
 #include  "jeandle/jeandleUtils.hpp"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "asm/codeBuffer.hpp"
 #include "ci/ciEnv.hpp"
 #include "ci/ciMethod.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompiler.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiler.cpp
@@ -18,8 +18,8 @@
  *
  */
 
-#include <cassert>
-
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/MC/TargetRegistry.h"
@@ -33,6 +33,7 @@
 #include "jeandle/jeandleType.hpp"
 #include "jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp"
 #include "runtime/arguments.hpp"
+LLVM_HEADER_END
 
 JeandleCompiler::JeandleCompiler(llvm::TargetMachine* target_machine) :
                                  AbstractCompiler(compiler_jeandle),

--- a/src/hotspot/share/jeandle/jeandleCompiler.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiler.hpp
@@ -21,16 +21,15 @@
 #ifndef SHARE_JEANDLE_COMPILER_HPP
 #define SHARE_JEANDLE_COMPILER_HPP
 
-#include <cassert>
-#pragma push_macro("AARCH64")
-#undef AARCH64
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Target/TargetMachine.h"
-#pragma pop_macro("AARCH64")
+
 
 #include <memory>
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "compiler/abstractCompiler.hpp"
 #include "compiler/compilerDirectives.hpp"
 

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -21,15 +21,13 @@
 #ifndef SHARE_JEANDLE_RUNTIME_ROUTINE_HPP
 #define SHARE_JEANDLE_RUNTIME_ROUTINE_HPP
 
-#include <cassert>
-#pragma push_macro("AARCH64")
-#undef AARCH64
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/Jeandle/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Target/TargetMachine.h"
-#pragma pop_macro("AARCH64")
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "memory/allStatic.hpp"
 #include "runtime/javaThread.hpp"
 #include "utilities/globalDefinitions.hpp"

--- a/src/hotspot/share/jeandle/jeandleType.cpp
+++ b/src/hotspot/share/jeandle/jeandleType.cpp
@@ -18,10 +18,12 @@
  *
  */
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/Jeandle/Metadata.h"
 
 #include "jeandle/jeandleType.hpp"
+LLVM_HEADER_END
 
 llvm::Type* JeandleType::java2llvm(BasicType java_type, llvm::LLVMContext& context) {
   switch (java_type) {

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -18,12 +18,14 @@
  *
  */
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
 
 #include "jeandle/jeandleType.hpp"
 #include "jeandle/jeandleUtils.hpp"
+LLVM_HEADER_END
 
 llvm::Function* JeandleFuncSig::create_llvm_func(ciMethod* method, llvm::Module& target_module) {
   llvm::SmallVector<llvm::Type*> args;

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -18,15 +18,16 @@
  *
  */
 
-#include <cassert>
+#include "compiler/llvm_hotspot_macros.hpp"
+LLVM_HEADER_BEGIN
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/IRBuilder.h"
 
 #include "jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 #include "jeandle/jeandleRegister.hpp"
+LLVM_HEADER_END
 
-#include "utilities/debug.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/safepointMechanism.hpp"
 //                  name, lower_phase, return_type, arg_types


### PR DESCRIPTION
## Related issue(s): #52 

issue #

## What this PR does / why we need it:
Refactor the current jeandle include headers to resolve macro conflicts.
A new file named `llvm_hotspot_macros.hpp` was created, which defines `LLVM_HEADER_BEGIN` and `LLVM_HEADER_END` to separate the include header files of LLVM and HotSpot.