### PR TITLE
fix: use the explicit LLVM include directory in JVM_CFLAGS

### DIFF
--- a/make/hotspot/lib/JvmFlags.gmk
+++ b/make/hotspot/lib/JvmFlags.gmk
@@ -95,9 +95,7 @@ JVM_CFLAGS += \
     #
 
 ifeq ($(INCLUDE_JEANDLE), true)
-  JVM_CFLAGS += \
-      `$(JEANDLE_LLVM_DIR)/bin/llvm-config --cflags` \
-      #
+  JVM_CFLAGS += -I$(JEANDLE_LLVM_DIR)/include
 endif
 
 # -DDONT_USE_PRECOMPILED_HEADER will exclude all includes in precompiled.hpp.


### PR DESCRIPTION
## Related issue(s):

issue #93

## What this PR does / why we need it:

This patch fixes the wrong string `$(JEANDLE_LLVM_DIR)/bin/llvm-config --cflags` in file `compile_commands.json`. Such string can only be identified and run by shell, but can't be identified by the IDE in compilation database (json) file.

Fixed #93