### PR TITLE
fix: add safepoint poll at back edge

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -862,12 +862,18 @@ void JeandleAbstractInterpreter::increment() {
 }
 
 void JeandleAbstractInterpreter::if_zero(llvm::CmpInst::Predicate p) {
+  if (_codes.get_dest() < _codes.cur_bci()) {
+    add_safepoint_poll();
+  }
   llvm::Value* v = _jvm->ipop();
   llvm::Value* cond = _ir_builder.CreateICmp(p, v, JeandleType::int_const(_ir_builder, 0));
   _ir_builder.CreateCondBr(cond, bci2block()[_codes.get_dest()]->llvm_block(), bci2block()[_codes.next_bci()]->llvm_block());
 }
 
 void JeandleAbstractInterpreter::if_icmp(llvm::CmpInst::Predicate p) {
+  if (_codes.get_dest() < _codes.cur_bci()) {
+    add_safepoint_poll();
+  }
   llvm::Value* r = _jvm->ipop();
   llvm::Value* l = _jvm->ipop();
   llvm::Value* cond = _ir_builder.CreateICmp(p, l, r);
@@ -885,6 +891,9 @@ void JeandleAbstractInterpreter::lcmp() {
 }
 
 void JeandleAbstractInterpreter::if_acmp(llvm::CmpInst::Predicate p) {
+  if (_codes.get_dest() < _codes.cur_bci()) {
+    add_safepoint_poll();
+  }
   llvm::Value* r = _jvm->apop();
   llvm::Value* l = _jvm->apop();
   llvm::Value* cond = _ir_builder.CreateICmp(p, l, r);
@@ -892,6 +901,9 @@ void JeandleAbstractInterpreter::if_acmp(llvm::CmpInst::Predicate p) {
 }
 
 void JeandleAbstractInterpreter::if_null(llvm::CmpInst::Predicate p) {
+  if (_codes.get_dest() < _codes.cur_bci()) {
+    add_safepoint_poll();
+  }
   llvm::Value* v = _jvm->apop();
   llvm::Value* cond = _ir_builder.CreateICmp(p, v, llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(v->getType())));
   _ir_builder.CreateCondBr(cond, bci2block()[_codes.get_dest()]->llvm_block(), bci2block()[_codes.next_bci()]->llvm_block());

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestBackedgeSafepointPoll.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestBackedgeSafepointPoll.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @summary the back edge of the `if*` bytecode should have safepoint poll
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:-TieredCompilation -Xcomp -XX:+UseJeandleCompiler
+ *      -XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.safepoint.TestBackedgeSafepointPoll::loopTest
+ *      -XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.safepoint.TestBackedgeSafepointPoll::add
+ *      compiler.jeandle.bytecodeTranslate.safepoint.TestBackedgeSafepointPoll
+ */
+
+package compiler.jeandle.bytecodeTranslate.safepoint;
+
+import java.lang.reflect.Method;
+
+import jdk.test.whitebox.WhiteBox;
+
+public class TestBackedgeSafepointPoll {
+    private final static WhiteBox wb = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) throws Exception {
+        for (int i =0; i < 10; i++) {
+            runThread();
+        }
+
+        Method method = TestBackedgeSafepointPoll.class.getDeclaredMethod("loopTest");
+        while (!wb.isMethodCompiled(method)) {
+            Thread.yield();
+        }
+
+        Thread.sleep(100);
+        System.out.println("Main thread ends");
+    }
+
+    public static void runThread() {
+        Thread loopThread = new Thread(() -> {
+            loopTest();
+        });
+        // The thread is marked as `daemon`, so when the main thread ends,
+        // the daemon thread should be finished by the JVM too.
+        // Such communication between main thread and the daemon thread
+        // is implemented by the safepoint poll of the daemon thread.
+        loopThread.setDaemon(true);
+        loopThread.start();
+    }
+
+    public static void loopTest() {
+        // The back edge of `if*` bytecode, which is generated from
+        // the `while` statement here, should generate safepoint poll by compiler,
+        // so that the daemon thread can communicate with the main thread periodically
+        // and then ends according to the main thread instead of running forever.
+        while (true) {
+            add(2, 2);
+            if (add(1, 2) != 3) {
+            }
+        }
+    }
+
+    public static int add(int a, int b) {
+        return a + b;
+    }
+}


### PR DESCRIPTION
## Related issue(s):

issue #81

## What this PR does / why we need it:

The safepoint poll was only added at `goto` bytecode, this patch adds safepoint poll at all the `if_*` bytecodes.
One related test `TestBackedgeSafepointPoll.java` is added in this patch. Please notice I create a new test directory `safepoint`.

Test:
The command `make test TEST=test/hotspot/jtreg/compiler/jeandle/` passed locally (x86_64&linux).

