### PR TITLE
refactor: refactor header files to resolve macro conflicts between LLVM and Hotspot source code.

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -18,13 +18,13 @@
  *
  */
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/ExecutionEngine/JITLink/aarch64.h"
 
 #include "jeandle/jeandleAssembler.hpp"
 #include "jeandle/jeandleCompilation.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "code/nativeInst.hpp"
 #include "runtime/sharedRuntime.hpp"
 

--- a/src/hotspot/cpu/aarch64/jeandleCompiledCall_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleCompiledCall_aarch64.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "jeandle/jeandleCompiledCall.hpp"
+
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "nativeInst_aarch64.hpp"
 
 int JeandleCompiledCall::call_site_size(JeandleCompiledCall::Type call_type) {

--- a/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
@@ -21,7 +21,7 @@
 #ifndef CPU_AARCH64_JEANDLEREGISTER_AARCH64_HPP
 #define CPU_AARCH64_JEANDLEREGISTER_AARCH64_HPP
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "register_aarch64.hpp"
 
 class JeandleRegister : public AllStatic {

--- a/src/hotspot/cpu/aarch64/jeandleRuntimeRoutine_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleRuntimeRoutine_aarch64.cpp
@@ -20,7 +20,7 @@
 
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 
 #define __ masm->

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -18,13 +18,13 @@
  *
  */
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/ExecutionEngine/JITLink/x86_64.h"
 
 #include "jeandle/jeandleAssembler.hpp"
 #include "jeandle/jeandleCompilation.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "code/nativeInst.hpp"
 #include "runtime/sharedRuntime.hpp"
 

--- a/src/hotspot/cpu/x86/jeandleCompiledCall_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleCompiledCall_x86.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "jeandle/jeandleCompiledCall.hpp"
+
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "nativeInst_x86.hpp"
 
 int JeandleCompiledCall::call_site_size(JeandleCompiledCall::Type call_type) {

--- a/src/hotspot/cpu/x86/jeandleRegister_x86.hpp
+++ b/src/hotspot/cpu/x86/jeandleRegister_x86.hpp
@@ -21,7 +21,7 @@
 #ifndef CPU_X86_JEANDLEREGISTER_X86_HPP
 #define CPU_X86_JEANDLEREGISTER_X86_HPP
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "register_x86.hpp"
 
 #ifdef _LP64

--- a/src/hotspot/cpu/x86/jeandleRuntimeRoutine_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleRuntimeRoutine_x86.cpp
@@ -20,7 +20,7 @@
 
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
 #include "code/codeBlob.hpp"

--- a/src/hotspot/cpu/x86/jeandleUtils_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleUtils_x86.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
 

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -24,9 +24,9 @@
  */
 
 #ifdef JEANDLE
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/Support/TargetSelect.h"
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #endif // JEANDLE
 
 #include "precompiled.hpp"
@@ -87,10 +87,7 @@
 #include "opto/c2compiler.hpp"
 #endif
 #ifdef JEANDLE
-#pragma push_macro("AARCH64")
-#undef AARCH64
 #include "jeandle/jeandleCompiler.hpp"
-#pragma pop_macro("AARCH64")
 #endif // JEANDLE
 #if INCLUDE_JVMCI
 #include "jvmci/jvmciEnv.hpp"

--- a/src/hotspot/share/jeandle/__hotspotHeadersBegin__.hpp
+++ b/src/hotspot/share/jeandle/__hotspotHeadersBegin__.hpp
@@ -26,6 +26,6 @@
 
 // Resolve conflict with AARCH64 macro in LLVM headers.
 #ifdef SAVED_HOTSPOT_AARCH64
-  #define AARCH64 SAVED_HOTSPOT_AARCH64
+  #define AARCH64
   #undef SAVED_HOTSPOT_AARCH64
 #endif // SAVED_HOTSPOT_AARCH64

--- a/src/hotspot/share/jeandle/__hotspotHeadersBegin__.hpp
+++ b/src/hotspot/share/jeandle/__hotspotHeadersBegin__.hpp
@@ -18,13 +18,17 @@
  *
  */
 
-// Need to undef assert from stdlib. Then redefine our assert.
+// This file is used to resolve macro conflicts between LLVM and HotSpot.
+// For more information on macro conflicts, see __llvmHeadersBegin__.hpp
+
+// __hotspotHeadersBegin__.hpp undefines 'assert' from stdlib, and redefines
+// 'AArch64' becuase it may be undefined by __llvmHeadersBegin__.hpp.
+
 #undef assert
 #ifdef SHARE_UTILITIES_DEBUG_HPP
   #define assert(p, ...) vmassert(p, __VA_ARGS__)
 #endif // SHARE_UTILITIES_DEBUG_HPP
 
-// Resolve conflict with AARCH64 macro in LLVM headers.
 #ifdef SAVED_HOTSPOT_AARCH64
   #define AARCH64
   #undef SAVED_HOTSPOT_AARCH64

--- a/src/hotspot/share/jeandle/__hotspotHeadersBegin__.hpp
+++ b/src/hotspot/share/jeandle/__hotspotHeadersBegin__.hpp
@@ -18,22 +18,14 @@
  *
  */
 
-#include "jeandle/__llvmHeadersBegin__.hpp"
-#include "llvm/IR/Jeandle/Attributes.h"
-#include "llvm/IR/Jeandle/GCStrategy.h"
+// Need to undef assert from stdlib. Then redefine our assert.
+#undef assert
+#ifdef SHARE_UTILITIES_DEBUG_HPP
+  #define assert(p, ...) vmassert(p, __VA_ARGS__)
+#endif // SHARE_UTILITIES_DEBUG_HPP
 
-#include "jeandle/jeandleUtils.hpp"
-
-void JeandleFuncSig::setup_description(llvm::Function* func, bool is_stub) {
-  func->setCallingConv(llvm::CallingConv::Hotspot_JIT);
-
-  func->setGC(llvm::jeandle::JeandleGC);
-
-  if (!is_stub) {
-    func->addFnAttr("patchable-function-entry", "1");
-  }
-
-  if (UseCompressedOops) {
-    func->addFnAttr(llvm::Attribute::get(func->getContext(), llvm::jeandle::Attribute::UseCompressedOops));
-  }
-}
+// Resolve conflict with AARCH64 macro in LLVM headers.
+#ifdef SAVED_HOTSPOT_AARCH64
+  #define AARCH64 SAVED_HOTSPOT_AARCH64
+  #undef SAVED_HOTSPOT_AARCH64
+#endif // SAVED_HOTSPOT_AARCH64

--- a/src/hotspot/share/jeandle/__llvmHeadersBegin__.hpp
+++ b/src/hotspot/share/jeandle/__llvmHeadersBegin__.hpp
@@ -18,22 +18,8 @@
  *
  */
 
-#include "jeandle/__llvmHeadersBegin__.hpp"
-#include "llvm/IR/Jeandle/Attributes.h"
-#include "llvm/IR/Jeandle/GCStrategy.h"
-
-#include "jeandle/jeandleUtils.hpp"
-
-void JeandleFuncSig::setup_description(llvm::Function* func, bool is_stub) {
-  func->setCallingConv(llvm::CallingConv::Hotspot_JIT);
-
-  func->setGC(llvm::jeandle::JeandleGC);
-
-  if (!is_stub) {
-    func->addFnAttr("patchable-function-entry", "1");
-  }
-
-  if (UseCompressedOops) {
-    func->addFnAttr(llvm::Attribute::get(func->getContext(), llvm::jeandle::Attribute::UseCompressedOops));
-  }
-}
+#include <cassert>
+#ifdef AARCH64
+  #define SAVED_HOTSPOT_AARCH64 AARCH64
+  #undef AARCH64
+#endif // AARCH64

--- a/src/hotspot/share/jeandle/__llvmHeadersBegin__.hpp
+++ b/src/hotspot/share/jeandle/__llvmHeadersBegin__.hpp
@@ -18,6 +18,28 @@
  *
  */
 
+// Jeandle includes many LLVM header files, and produces some macro conflicts with Hotspot header files.
+// The current conflicts are:
+//   1. AARCH64
+//   2. assert
+// We use __llvmHeadersBegin__.hpp and __HotspotHeadersBegin__.hpp to solve them.
+
+// All Jeandle source files should include __llvmHeadersBegin__.hpp and __hotspotHeadersBegin__.hpp
+// like this:
+//   #include "jeandle/__llvmHeadersBegin__.hpp"
+//   #include "llvm/..."
+//   #include "llvm/..."
+//
+//   #include "jeandle/..."
+//   #include "jeandle/..."
+//
+//   #include "jeandle/__hostpotHeadersBegin__.hpp"
+//   // Here we can include header files from Hotspot.
+
+// __llvmHeadersBegin__.hpp is used to define 'assert' from stdlib for LLVM, because Hotspot uses a self defined 'assert'
+// and it's not compatible with stdlib's 'assert'. This header file also undefines 'AARCH64' which is defined by Hotspot
+// and conflicts with LLVM's 'AArch64'.
+
 #include <cassert>
 #ifdef AARCH64
   #define SAVED_HOTSPOT_AARCH64

--- a/src/hotspot/share/jeandle/__llvmHeadersBegin__.hpp
+++ b/src/hotspot/share/jeandle/__llvmHeadersBegin__.hpp
@@ -20,6 +20,6 @@
 
 #include <cassert>
 #ifdef AARCH64
-  #define SAVED_HOTSPOT_AARCH64 AARCH64
+  #define SAVED_HOTSPOT_AARCH64
   #undef AARCH64
 #endif // AARCH64

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
@@ -30,9 +31,9 @@
 #include "jeandle/jeandleType.hpp"
 #include "jeandle/jeandleUtils.hpp"
 
-#include "logging/log.hpp"
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciMethodBlocks.hpp"
+#include "logging/log.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/ostream.hpp"

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -21,7 +21,7 @@
 #ifndef SHARE_JEANDLE_ABSTRACT_INTERPRETER_HPP
 #define SHARE_JEANDLE_ABSTRACT_INTERPRETER_HPP
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/IRBuilder.h"
@@ -31,7 +31,7 @@
 
 #include "jeandle/jeandleCompilation.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/compilerInterface.hpp"
 #include "memory/allocation.hpp"
 #include "utilities/bitMap.inline.hpp"

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -21,12 +21,12 @@
 #ifndef SHARE_JEANDLE_ASSEMBLER_HPP
 #define SHARE_JEANDLE_ASSEMBLER_HPP
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 
 #include "jeandle/jeandleCompilation.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "asm/macroAssembler.hpp"
 
 using LinkKind  = llvm::jitlink::Edge::Kind;

--- a/src/hotspot/share/jeandle/jeandleCallVM.cpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Jeandle/Attributes.h"

--- a/src/hotspot/share/jeandle/jeandleCallVM.hpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.hpp
@@ -21,14 +21,14 @@
 #ifndef SHARE_JEANDLE_CALL_VM_HPP
 #define SHARE_JEANDLE_CALL_VM_HPP
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
 
 #include "jeandle/jeandleCompiledCode.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class JeandleCallVM : public AllStatic {

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Jeandle/Jeandle.h"
@@ -51,7 +51,7 @@
 #include "jeandle/jeandleType.hpp"
 #include "jeandle/jeandleUtils.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "logging/log.hpp"
 #include "runtime/sharedRuntime.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -21,9 +21,7 @@
 #ifndef SHARE_JEANDLE_COMPILATION_HPP
 #define SHARE_JEANDLE_COMPILATION_HPP
 
-#include <cassert>
-#pragma push_macro("AARCH64")
-#undef AARCH64
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
@@ -32,9 +30,8 @@
 #include <memory>
 
 #include "jeandle/jeandleCompiledCode.hpp"
-#pragma pop_macro("AARCH64")
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciEnv.hpp"
 #include "ci/ciMethod.hpp"
 #include "memory/arena.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompiledCall.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCall.hpp
@@ -21,11 +21,11 @@
 #ifndef SHARE_JEANDLE_COMPILED_CALL_HPP
 #define SHARE_JEANDLE_COMPILED_CALL_HPP
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Type.h"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciMethod.hpp"
 #include "memory/allStatic.hpp"
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/Support/DataExtractor.h"
 
 #include "jeandle/jeandleAssembler.hpp"
@@ -27,7 +27,7 @@
 #include "jeandle/jeandleRegister.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "asm/macroAssembler.hpp"
 #include "ci/ciEnv.hpp"
 #include "code/vmreg.inline.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -21,7 +21,7 @@
 #ifndef SHARE_JEANDLE_COMPILED_CODE_HPP
 #define SHARE_JEANDLE_COMPILED_CODE_HPP
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/IR/Statepoint.h"
@@ -34,7 +34,7 @@
 #include "jeandle/jeandleResourceObj.hpp"
 #include  "jeandle/jeandleUtils.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "asm/codeBuffer.hpp"
 #include "ci/ciEnv.hpp"
 #include "ci/ciMethod.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompiler.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiler.cpp
@@ -18,8 +18,7 @@
  *
  */
 
-#include <cassert>
-
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/MC/TargetRegistry.h"
@@ -32,6 +31,8 @@
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 #include "jeandle/jeandleType.hpp"
 #include "jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp"
+
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "runtime/arguments.hpp"
 
 JeandleCompiler::JeandleCompiler(llvm::TargetMachine* target_machine) :

--- a/src/hotspot/share/jeandle/jeandleCompiler.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiler.hpp
@@ -21,16 +21,13 @@
 #ifndef SHARE_JEANDLE_COMPILER_HPP
 #define SHARE_JEANDLE_COMPILER_HPP
 
-#include <cassert>
-#pragma push_macro("AARCH64")
-#undef AARCH64
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Target/TargetMachine.h"
-#pragma pop_macro("AARCH64")
 
 #include <memory>
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "compiler/abstractCompiler.hpp"
 #include "compiler/compilerDirectives.hpp"
 

--- a/src/hotspot/share/jeandle/jeandleReadELF.hpp
+++ b/src/hotspot/share/jeandle/jeandleReadELF.hpp
@@ -21,11 +21,11 @@
 #ifndef SHARE_JEANDLE_READ_ELF_HPP
 #define SHARE_JEANDLE_READ_ELF_HPP
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Support/MemoryBuffer.h"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "memory/allStatic.hpp"
 
 using ELFT = llvm::object::ELF64LE;

--- a/src/hotspot/share/jeandle/jeandleRegister.hpp
+++ b/src/hotspot/share/jeandle/jeandleRegister.hpp
@@ -21,6 +21,7 @@
 #ifndef SHARE_JEANDLE_REGISTER_HPP
 #define SHARE_JEANDLE_REGISTER_HPP
 
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "utilities/macros.hpp"
 #include CPU_HEADER(jeandleRegister)
 

--- a/src/hotspot/share/jeandle/jeandleResourceObj.hpp
+++ b/src/hotspot/share/jeandle/jeandleResourceObj.hpp
@@ -21,6 +21,7 @@
 #ifndef SHARE_JEANDLE_RESOURCE_OBJ_HPP
 #define SHARE_JEANDLE_RESOURCE_OBJ_HPP
 
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "memory/arena.hpp"
 
 // Base class for objects allocated by the compiler in the compilation arena

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.cpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.cpp
@@ -21,7 +21,7 @@
 #include "jeandle/jeandleCompilation.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "runtime/frame.hpp"

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -21,15 +21,12 @@
 #ifndef SHARE_JEANDLE_RUNTIME_ROUTINE_HPP
 #define SHARE_JEANDLE_RUNTIME_ROUTINE_HPP
 
-#include <cassert>
-#pragma push_macro("AARCH64")
-#undef AARCH64
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Jeandle/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Target/TargetMachine.h"
-#pragma pop_macro("AARCH64")
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "memory/allStatic.hpp"
 #include "runtime/javaThread.hpp"
 #include "utilities/globalDefinitions.hpp"

--- a/src/hotspot/share/jeandle/jeandleType.cpp
+++ b/src/hotspot/share/jeandle/jeandleType.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Jeandle/Metadata.h"
 
 #include "jeandle/jeandleType.hpp"

--- a/src/hotspot/share/jeandle/jeandleType.hpp
+++ b/src/hotspot/share/jeandle/jeandleType.hpp
@@ -21,12 +21,12 @@
 #ifndef SHARE_JEANDLE_TYPE_HPP
 #define SHARE_JEANDLE_TYPE_HPP
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Type.h"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/compilerInterface.hpp"
 
 class JeandleType : public AllStatic {

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
 

--- a/src/hotspot/share/jeandle/jeandleUtils.hpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.hpp
@@ -21,11 +21,11 @@
 #ifndef SHARE_JEANDLE_UTILS_HPP
 #define SHARE_JEANDLE_UTILS_HPP
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciMethod.hpp"
 
 

--- a/src/hotspot/share/jeandle/jeandle_globals.hpp
+++ b/src/hotspot/share/jeandle/jeandle_globals.hpp
@@ -21,6 +21,7 @@
 #ifndef SHARE_JEANDLE_GLOBALS_HPP
 #define SHARE_JEANDLE_GLOBALS_HPP
 
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "runtime/globals_shared.hpp"
 #include "utilities/macros.hpp"
 //

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/IRBuilder.h"
 
@@ -26,7 +26,7 @@
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 #include "jeandle/jeandleRegister.hpp"
 
-#include "utilities/debug.hpp"
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "oops/arrayOop.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/safepointMechanism.hpp"

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp
@@ -21,9 +21,10 @@
 #ifndef SHARE_JEANDLE_RUNTIME_DEFINED_JAVA_OPS_HPP
 #define SHARE_JEANDLE_RUNTIME_DEFINED_JAVA_OPS_HPP
 
-#include <cassert>
+#include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Module.h"
 
+#include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "utilities/debug.hpp"
 #include "memory/allStatic.hpp"
 

--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,14 +21,6 @@
  * questions.
  *
  */
-
-// Need to undef assert from stdlib. Then redefine our assert.
-#ifdef JEANDLE
-#ifdef SHARE_UTILITIES_DEBUG_HPP
-  #undef assert
-  #define assert(p, ...) vmassert(p, __VA_ARGS__)
-#endif // SHARE_UTILITIES_DEBUG_HPP
-#endif // JEANDLE
 
 #ifndef SHARE_UTILITIES_DEBUG_HPP
 #define SHARE_UTILITIES_DEBUG_HPP
@@ -164,14 +155,6 @@ do {                                                                           \
   }                                                                            \
 } while (0)
 #endif
-
-
-// Undef assert from stdlib.
-#ifdef JEANDLE
-#ifdef assert
-  #undef assert
-#endif
-#endif // JEANDLE
 
 // For backward compatibility.
 #define assert(p, ...) vmassert(p, __VA_ARGS__)


### PR DESCRIPTION
## Related issue(s):

issue #52

## What this PR does / why we need it:

Add two new headers `__llvmHeadersBegin__.hpp` and `__hotspotHeadersBegin__.hpp` to resolve macro conflicts.