### PR TITLE
refactor: Estimate CodeBuffer's size when creating it

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -31,14 +31,10 @@
 
 #define __ _masm->
 
-enum {
-  _max_stubs_size = 128,
-  // call stub size: static call stub size + trampoline size
-  _call_stub_size = 13 * NativeInstruction::instruction_size,
-  // TODO: exception handler has not been implemented in aarch64.
-  _exception_handler_size = 0,
-  _routine_stub_size = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size
-};
+const int JeandleAssembler::_call_stub_size         = 13 * NativeInstruction::instruction_size;
+const int JeandleAssembler::_routine_stub_size      = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
+// TODO: exception handler has not been implemented on aarch64.
+const int JeandleAssembler::_exception_handler_size = 0;
 
 int JeandleAssembler::get_call_stub_size() {
   return _call_stub_size;

--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -33,8 +33,8 @@
 
 const int JeandleAssembler::_call_stub_size         = 13 * NativeInstruction::instruction_size;
 const int JeandleAssembler::_routine_stub_size      = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
-// TODO: exception handler has not been implemented on aarch64.
-const int JeandleAssembler::_exception_handler_size = 0;
+// for far branches on AArch64, use ADRP + ADD + BR to reach the target.
+const int JeandleAssembler::_exception_handler_size = 3 * NativeInstruction::instruction_size;
 
 int JeandleAssembler::get_call_stub_size() {
   return _call_stub_size;

--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -31,10 +31,11 @@
 
 #define __ _masm->
 
+// Use worst-case size for estimation (matches MacroAssembler::far_codestub_branch_size())
+const int JeandleAssembler::_exception_handler_size = 3 * NativeInstruction::instruction_size;
 const int JeandleAssembler::_call_stub_size         = 13 * NativeInstruction::instruction_size;
 const int JeandleAssembler::_routine_stub_size      = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
-// for far branches on AArch64, use ADRP + ADD + BR to reach the target.
-const int JeandleAssembler::_exception_handler_size = 3 * NativeInstruction::instruction_size;
+const int JeandleAssembler::_deopt_handler_size     = 7 * NativeInstruction::instruction_size;
 
 int JeandleAssembler::get_call_stub_size() {
   return _call_stub_size;
@@ -46,6 +47,10 @@ int JeandleAssembler::get_exception_handler_size() {
 
 int JeandleAssembler::get_routine_stub_size() {
   return _routine_stub_size;
+}
+
+int JeandleAssembler::get_deopt_handler_size() {
+  return _deopt_handler_size;
 }
 
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
@@ -253,12 +258,8 @@ int JeandleAssembler::emit_exception_handler() {
   return offset;
 }
 
-int JeandleAssembler::deopt_handler_size() {
-  return 7 * NativeInstruction::instruction_size;
-}
-
 int JeandleAssembler::emit_deopt_handler() {
-  int stub_size = deopt_handler_size();
+  int stub_size = get_deopt_handler_size();
   address base = __ start_a_stub(stub_size);
   if (base == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET("deopt handler stub overflow", 0);

--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -35,9 +35,6 @@
 const int JeandleAssembler::_call_stub_size    = 13 * NativeInstruction::instruction_size;
 const int JeandleAssembler::_routine_stub_size = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
 
-// Handler sizes matching C2's HandlerImpl (see aarch64.ad):
-//   size_exception_handler() = MacroAssembler::far_codestub_branch_size()
-//   size_deopt_handler()     = NativeInstruction::instruction_size + MacroAssembler::far_codestub_branch_size()
 int JeandleAssembler::exception_handler_size() {
   return MacroAssembler::far_codestub_branch_size();
 }

--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -31,12 +31,33 @@
 
 #define __ _masm->
 
+enum {
+  _max_stubs_size = 128,
+  // call stub size: static call stub size + trampoline size
+  _call_stub_size = 13 * NativeInstruction::instruction_size,
+  // TODO: exception handler has not been implemented in aarch64.
+  _exception_handler_size = 0,
+  _routine_stub_size = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size
+};
+
+int JeandleAssembler::get_call_stub_size() {
+  return _call_stub_size;
+}
+
+int JeandleAssembler::get_exception_handler_size() {
+  return _exception_handler_size;
+}
+
+int JeandleAssembler::get_routine_stub_size() {
+  return _routine_stub_size;
+}
+
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
   assert(call->type() == JeandleCompiledCall::STATIC_CALL, "illegal call type");
   address call_address = __ addr_at(inst_offset);
 
   // same as C1 call_stub_size()
-  const int stub_size = 13 * NativeInstruction::instruction_size;
+  const int stub_size = _call_stub_size;
   address stub = __ start_a_stub(stub_size);
   if (stub == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET_VOID("static call stub overflow");

--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -35,6 +35,14 @@
 const int JeandleAssembler::_call_stub_size    = 13 * NativeInstruction::instruction_size;
 const int JeandleAssembler::_routine_stub_size = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
 
+int JeandleAssembler::static_call_stub_size() {
+  return _call_stub_size;
+}
+
+int JeandleAssembler::routine_call_stub_size() {
+  return _routine_stub_size;
+}
+
 int JeandleAssembler::exception_handler_size() {
   return MacroAssembler::far_codestub_branch_size();
 }

--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -31,11 +31,20 @@
 
 #define __ _masm->
 
-// Use worst-case size for estimation (matches MacroAssembler::far_codestub_branch_size())
-const int JeandleAssembler::_exception_handler_size = 3 * NativeInstruction::instruction_size;
-const int JeandleAssembler::_call_stub_size         = 13 * NativeInstruction::instruction_size;
-const int JeandleAssembler::_routine_stub_size      = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
-const int JeandleAssembler::_deopt_handler_size     = 7 * NativeInstruction::instruction_size;
+// Stub sizes for call sites
+const int JeandleAssembler::_call_stub_size    = 13 * NativeInstruction::instruction_size;
+const int JeandleAssembler::_routine_stub_size = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
+
+// Handler sizes matching C2's HandlerImpl (see aarch64.ad):
+//   size_exception_handler() = MacroAssembler::far_codestub_branch_size()
+//   size_deopt_handler()     = NativeInstruction::instruction_size + MacroAssembler::far_codestub_branch_size()
+int JeandleAssembler::exception_handler_size() {
+  return MacroAssembler::far_codestub_branch_size();
+}
+
+int JeandleAssembler::deopt_handler_size() {
+  return NativeInstruction::instruction_size + MacroAssembler::far_codestub_branch_size();
+}
 
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
   assert(call->type() == JeandleCompiledCall::STATIC_CALL, "illegal call type");
@@ -243,7 +252,7 @@ int JeandleAssembler::emit_exception_handler() {
 }
 
 int JeandleAssembler::emit_deopt_handler() {
-  int stub_size = JeandleAssembler::_deopt_handler_size;
+  int stub_size = deopt_handler_size();
   address base = __ start_a_stub(stub_size);
   if (base == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET("deopt handler stub overflow", 0);

--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -37,22 +37,6 @@ const int JeandleAssembler::_call_stub_size         = 13 * NativeInstruction::in
 const int JeandleAssembler::_routine_stub_size      = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
 const int JeandleAssembler::_deopt_handler_size     = 7 * NativeInstruction::instruction_size;
 
-int JeandleAssembler::get_call_stub_size() {
-  return _call_stub_size;
-}
-
-int JeandleAssembler::get_exception_handler_size() {
-  return _exception_handler_size;
-}
-
-int JeandleAssembler::get_routine_stub_size() {
-  return _routine_stub_size;
-}
-
-int JeandleAssembler::get_deopt_handler_size() {
-  return _deopt_handler_size;
-}
-
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
   assert(call->type() == JeandleCompiledCall::STATIC_CALL, "illegal call type");
   address call_address = __ addr_at(inst_offset);
@@ -259,7 +243,7 @@ int JeandleAssembler::emit_exception_handler() {
 }
 
 int JeandleAssembler::emit_deopt_handler() {
-  int stub_size = get_deopt_handler_size();
+  int stub_size = JeandleAssembler::_deopt_handler_size;
   address base = __ start_a_stub(stub_size);
   if (base == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET("deopt handler stub overflow", 0);

--- a/src/hotspot/cpu/riscv/jeandleAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jeandleAssembler_riscv.cpp
@@ -26,9 +26,17 @@
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "code/nativeInst.hpp"
 #include "runtime/sharedRuntime.hpp"
 
 #define __ _masm->
+
+// Use worst-case size for estimation (matches MacroAssembler::far_branch_size())
+const int JeandleAssembler::_call_stub_size         = 14 * NativeInstruction::instruction_size +
+                                                      (NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size);
+const int JeandleAssembler::_routine_stub_size      = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
+const int JeandleAssembler::_exception_handler_size = 2 * NativeInstruction::instruction_size;
+const int JeandleAssembler::_deopt_handler_size     = 7 * NativeInstruction::instruction_size;
 
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
   assert(call->type() == JeandleCompiledCall::STATIC_CALL, "legal call type");

--- a/src/hotspot/cpu/riscv/jeandleAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jeandleAssembler_riscv.cpp
@@ -31,12 +31,21 @@
 
 #define __ _masm->
 
-// Use worst-case size for estimation (matches MacroAssembler::far_branch_size())
-const int JeandleAssembler::_call_stub_size         = 14 * NativeInstruction::instruction_size +
-                                                      (NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size);
-const int JeandleAssembler::_routine_stub_size      = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
-const int JeandleAssembler::_exception_handler_size = 2 * NativeInstruction::instruction_size;
-const int JeandleAssembler::_deopt_handler_size     = 7 * NativeInstruction::instruction_size;
+// Stub sizes for call sites
+const int JeandleAssembler::_call_stub_size    = 14 * NativeInstruction::instruction_size +
+                                                  (NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size);
+const int JeandleAssembler::_routine_stub_size = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
+
+// Handler sizes matching C2's HandlerImpl (see riscv.ad):
+//   size_exception_handler() = MacroAssembler::far_branch_size()
+//   size_deopt_handler()     = NativeInstruction::instruction_size + MacroAssembler::far_branch_size()
+int JeandleAssembler::exception_handler_size() {
+  return MacroAssembler::far_branch_size();
+}
+
+int JeandleAssembler::deopt_handler_size() {
+  return NativeInstruction::instruction_size + MacroAssembler::far_branch_size();
+}
 
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
   assert(call->type() == JeandleCompiledCall::STATIC_CALL, "legal call type");
@@ -231,25 +240,18 @@ int JeandleAssembler::emit_exception_handler() {
   return start;
 }
 
-int JeandleAssembler::deopt_handler_size() {
-  // count auipc + far branch
-  return NativeInstruction::instruction_size + MacroAssembler::far_branch_size();
-}
-
-// Emit deopt handler code.
 int JeandleAssembler::emit_deopt_handler() {
-  address base = __ start_a_stub(deopt_handler_size());
-  if (base == NULL) {
-    JEANDLE_REPORT_ERROR_AND_RET("deopt handler stub overflow", 0);
-  }
-  int offset = __ offset();
+  int stub_size = deopt_handler_size();
+  address stub = __ start_a_stub(stub_size);
+  JEANDLE_ERROR_ASSERT_AND_RET_ON_FAIL(stub != nullptr, "deopt handler stub overflow", 0);
 
+  int start = __ offset();
   __ auipc(ra, 0);
   __ far_jump(RuntimeAddress(JeandleRuntimeRoutine::get_routine_entry(JeandleRuntimeRoutine::_deopt_blob)));
 
-  assert(__ offset() - offset <= (int) deopt_handler_size(), "deopt handler stub overflow");
+  assert(__ offset() - start <= stub_size, "deopt handler stub overflow");
   __ end_a_stub();
-  return offset;
+  return start;
 }
 
 using LinkKind_riscv = llvm::jitlink::riscv::EdgeKind_riscv;

--- a/src/hotspot/cpu/riscv/jeandleAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jeandleAssembler_riscv.cpp
@@ -36,9 +36,6 @@ const int JeandleAssembler::_call_stub_size    = 14 * NativeInstruction::instruc
                                                   (NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size);
 const int JeandleAssembler::_routine_stub_size = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
 
-// Handler sizes matching C2's HandlerImpl (see riscv.ad):
-//   size_exception_handler() = MacroAssembler::far_branch_size()
-//   size_deopt_handler()     = NativeInstruction::instruction_size + MacroAssembler::far_branch_size()
 int JeandleAssembler::exception_handler_size() {
   return MacroAssembler::far_branch_size();
 }

--- a/src/hotspot/cpu/riscv/jeandleAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jeandleAssembler_riscv.cpp
@@ -36,6 +36,14 @@ const int JeandleAssembler::_call_stub_size    = 14 * NativeInstruction::instruc
                                                   (NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size);
 const int JeandleAssembler::_routine_stub_size = NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size;
 
+int JeandleAssembler::static_call_stub_size() {
+  return _call_stub_size;
+}
+
+int JeandleAssembler::routine_call_stub_size() {
+  return _routine_stub_size;
+}
+
 int JeandleAssembler::exception_handler_size() {
   return MacroAssembler::far_branch_size();
 }
@@ -49,8 +57,7 @@ void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call
   address call_address = __ addr_at(inst_offset);
 
   // same as C1 call_stub_size()
-  int stub_size = 14 * NativeInstruction::instruction_size +
-                  (NativeInstruction::instruction_size + NativeCallTrampolineStub::instruction_size);
+  int stub_size = static_call_stub_size();
   address stub = __ start_a_stub(stub_size);
   JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(stub != nullptr, "static call stub overflow");
 

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -31,11 +31,21 @@
 
 #define __ _masm->
 
-const int JeandleAssembler::_call_stub_size         = 28;
+// Stub sizes for call sites
+const int JeandleAssembler::_call_stub_size    = 28;
 // No need to emit routine stub on x86.
-const int JeandleAssembler::_routine_stub_size      = 0;
-const int JeandleAssembler::_exception_handler_size = NativeJump::instruction_size;
-const int JeandleAssembler::_deopt_handler_size     = 17;
+const int JeandleAssembler::_routine_stub_size = 0;
+
+// Handler sizes matching C2's HandlerImpl (see x86.ad):
+//   size_exception_handler() = NativeJump::instruction_size
+//   size_deopt_handler()     = NOT_LP64(10) LP64_ONLY(17)
+int JeandleAssembler::exception_handler_size() {
+  return NativeJump::instruction_size;
+}
+
+int JeandleAssembler::deopt_handler_size() {
+  return NOT_LP64(10) LP64_ONLY(17);
+}
 
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
   assert(inst_offset >= 0, "invalid call instruction address");
@@ -206,7 +216,7 @@ int JeandleAssembler::emit_exception_handler() {
 }
 
 int JeandleAssembler::emit_deopt_handler() {
-  address base = __ start_a_stub(JeandleAssembler::_deopt_handler_size);
+  address base = __ start_a_stub(deopt_handler_size());
   if (base == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET("deopt handler stub overflow", 0);
   }
@@ -228,7 +238,7 @@ int JeandleAssembler::emit_deopt_handler() {
   __ pushptr(here.addr(), noreg);
 #endif
   __ jump(RuntimeAddress(JeandleRuntimeRoutine::get_routine_entry(JeandleRuntimeRoutine::_deopt_blob)));
-  assert(__ offset() - offset <= JeandleAssembler::_deopt_handler_size, "deopt handler stub overflow");
+  assert(__ offset() - offset <= deopt_handler_size(), "deopt handler stub overflow");
   __ end_a_stub();
   return offset;
 }

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -36,9 +36,6 @@ const int JeandleAssembler::_call_stub_size    = 28;
 // No need to emit routine stub on x86.
 const int JeandleAssembler::_routine_stub_size = 0;
 
-// Handler sizes matching C2's HandlerImpl (see x86.ad):
-//   size_exception_handler() = NativeJump::instruction_size
-//   size_deopt_handler()     = NOT_LP64(10) LP64_ONLY(17)
 int JeandleAssembler::exception_handler_size() {
   return NativeJump::instruction_size;
 }

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -36,6 +36,14 @@ const int JeandleAssembler::_call_stub_size    = 28;
 // No need to emit routine stub on x86.
 const int JeandleAssembler::_routine_stub_size = 0;
 
+int JeandleAssembler::static_call_stub_size() {
+  return _call_stub_size;
+}
+
+int JeandleAssembler::routine_call_stub_size() {
+  return _routine_stub_size;
+}
+
 int JeandleAssembler::exception_handler_size() {
   return NativeJump::instruction_size;
 }

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -31,13 +31,10 @@
 
 #define __ _masm->
 
-enum {
-  _max_stubs_size = 128,
-  // The x86 architecture does not have a trampoline.
-  _call_stub_size = 28,
-  _exception_handler_size = NativeJump::instruction_size + _max_stubs_size,
-  _routine_stub_size = NativCall::instruction_size
-};
+const int JeandleAssembler::_call_stub_size         = 28;
+// No need to emit routine stub on x86.
+const int JeandleAssembler::_routine_stub_size      = 0;
+const int JeandleAssembler::_exception_handler_size = NativeJump::instruction_size;
 
 int JeandleAssembler::get_call_stub_size() {
   return _call_stub_size;

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -37,22 +37,6 @@ const int JeandleAssembler::_routine_stub_size      = 0;
 const int JeandleAssembler::_exception_handler_size = NativeJump::instruction_size;
 const int JeandleAssembler::_deopt_handler_size     = 17;
 
-int JeandleAssembler::get_call_stub_size() {
-  return _call_stub_size;
-}
-
-int JeandleAssembler::get_exception_handler_size() {
-  return _exception_handler_size;
-}
-
-int JeandleAssembler::get_routine_stub_size() {
-  return _routine_stub_size;
-}
-
-int JeandleAssembler::get_deopt_handler_size() {
-  return _deopt_handler_size;
-}
-
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
   assert(inst_offset >= 0, "invalid call instruction address");
   assert(call->type() == JeandleCompiledCall::STATIC_CALL, "legal call type");
@@ -222,7 +206,7 @@ int JeandleAssembler::emit_exception_handler() {
 }
 
 int JeandleAssembler::emit_deopt_handler() {
-  address base = __ start_a_stub(get_deopt_handler_size());
+  address base = __ start_a_stub(JeandleAssembler::_deopt_handler_size);
   if (base == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET("deopt handler stub overflow", 0);
   }
@@ -244,7 +228,7 @@ int JeandleAssembler::emit_deopt_handler() {
   __ pushptr(here.addr(), noreg);
 #endif
   __ jump(RuntimeAddress(JeandleRuntimeRoutine::get_routine_entry(JeandleRuntimeRoutine::_deopt_blob)));
-  assert(__ offset() - offset <= get_deopt_handler_size(), "deopt handler stub overflow");
+  assert(__ offset() - offset <= JeandleAssembler::_deopt_handler_size, "deopt handler stub overflow");
   __ end_a_stub();
   return offset;
 }

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -35,6 +35,7 @@ const int JeandleAssembler::_call_stub_size         = 28;
 // No need to emit routine stub on x86.
 const int JeandleAssembler::_routine_stub_size      = 0;
 const int JeandleAssembler::_exception_handler_size = NativeJump::instruction_size;
+const int JeandleAssembler::_deopt_handler_size     = 17;
 
 int JeandleAssembler::get_call_stub_size() {
   return _call_stub_size;
@@ -46,6 +47,10 @@ int JeandleAssembler::get_exception_handler_size() {
 
 int JeandleAssembler::get_routine_stub_size() {
   return _routine_stub_size;
+}
+
+int JeandleAssembler::get_deopt_handler_size() {
+  return _deopt_handler_size;
 }
 
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
@@ -216,12 +221,8 @@ int JeandleAssembler::emit_exception_handler() {
   return offset;
 }
 
-int JeandleAssembler::deopt_handler_size() {
-  return 17;
-}
-
 int JeandleAssembler::emit_deopt_handler() {
-  address base = __ start_a_stub(deopt_handler_size());
+  address base = __ start_a_stub(get_deopt_handler_size());
   if (base == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET("deopt handler stub overflow", 0);
   }
@@ -243,7 +244,7 @@ int JeandleAssembler::emit_deopt_handler() {
   __ pushptr(here.addr(), noreg);
 #endif
   __ jump(RuntimeAddress(JeandleRuntimeRoutine::get_routine_entry(JeandleRuntimeRoutine::_deopt_blob)));
-  assert(__ offset() - offset <= deopt_handler_size(), "deopt handler stub overflow");
+  assert(__ offset() - offset <= get_deopt_handler_size(), "deopt handler stub overflow");
   __ end_a_stub();
   return offset;
 }

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -31,12 +31,32 @@
 
 #define __ _masm->
 
+enum {
+  _max_stubs_size = 128,
+  // The x86 architecture does not have a trampoline.
+  _call_stub_size = 28,
+  _exception_handler_size = NativeJump::instruction_size + _max_stubs_size,
+  _routine_stub_size = NativCall::instruction_size
+};
+
+int JeandleAssembler::get_call_stub_size() {
+  return _call_stub_size;
+}
+
+int JeandleAssembler::get_exception_handler_size() {
+  return _exception_handler_size;
+}
+
+int JeandleAssembler::get_routine_stub_size() {
+  return _routine_stub_size;
+}
+
 void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call) {
   assert(inst_offset >= 0, "invalid call instruction address");
   assert(call->type() == JeandleCompiledCall::STATIC_CALL, "legal call type");
   address call_address = __ addr_at(inst_offset);
 
-  int stub_size = 28;
+  int stub_size = _call_stub_size;
   address stub = __ start_a_stub(stub_size);
   if (stub == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET_VOID("static call stub overflow");

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -78,24 +78,16 @@ class JeandleAssembler : public StackObj {
   // Mirrors C2's InteriorEntryAlignment flag.
   int interior_entry_alignment() const;
 
-  static int get_call_stub_size();
-
-  static int get_routine_stub_size();
-
-  static int get_exception_handler_size();
-
-  static int get_deopt_handler_size();
-
- private:
-  MacroAssembler* _masm;
-
-#include CPU_HEADER(jeandleAssembler)
-
   // Static stub size constants defined in platform-specific implementation files
   static const int _call_stub_size;
   static const int _routine_stub_size;
   static const int _exception_handler_size;
   static const int _deopt_handler_size;
+
+ private:
+  MacroAssembler* _masm;
+
+#include CPU_HEADER(jeandleAssembler)
 };
 
 #endif // SHARE_JEANDLE_ASSEMBLER_HPP

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -79,6 +79,12 @@ class JeandleAssembler : public StackObj {
   // Mirrors C2's InteriorEntryAlignment flag.
   int interior_entry_alignment() const;
 
+  static int get_call_stub_size();
+
+  static int get_routine_stub_size();
+
+  static int get_exception_handler_size();
+
  private:
   MacroAssembler* _masm;
 

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -50,7 +50,6 @@ class JeandleAssembler : public StackObj {
   int emit_exception_handler();
 
   int emit_deopt_handler();
-  int deopt_handler_size();
 
   void emit_insts(address code_start, uint64_t code_size);
 
@@ -85,13 +84,18 @@ class JeandleAssembler : public StackObj {
 
   static int get_exception_handler_size();
 
+  static int get_deopt_handler_size();
+
  private:
   MacroAssembler* _masm;
 
 #include CPU_HEADER(jeandleAssembler)
- static const int _call_stub_size;
- static const int _routine_stub_size;
- static const int _exception_handler_size;
+
+  // Static stub size constants defined in platform-specific implementation files
+  static const int _call_stub_size;
+  static const int _routine_stub_size;
+  static const int _exception_handler_size;
+  static const int _deopt_handler_size;
 };
 
 #endif // SHARE_JEANDLE_ASSEMBLER_HPP

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -78,11 +78,15 @@ class JeandleAssembler : public StackObj {
   // Mirrors C2's InteriorEntryAlignment flag.
   int interior_entry_alignment() const;
 
-  // Static stub size constants defined in platform-specific implementation files
+  // Stub sizes for call sites, defined in platform-specific implementation files.
   static const int _call_stub_size;
   static const int _routine_stub_size;
-  static const int _exception_handler_size;
-  static const int _deopt_handler_size;
+
+  // Handler sizes matching C2's HandlerImpl::size_exception_handler/size_deopt_handler,
+  // defined in platform-specific implementation files. These are functions (not constants)
+  // because the size may depend on runtime flags (e.g., far_branches on aarch64).
+  static int exception_handler_size();
+  static int deopt_handler_size();
 
  private:
   MacroAssembler* _masm;

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -78,9 +78,8 @@ class JeandleAssembler : public StackObj {
   // Mirrors C2's InteriorEntryAlignment flag.
   int interior_entry_alignment() const;
 
-  // Stub sizes for call sites, defined in platform-specific implementation files.
-  static const int _call_stub_size;
-  static const int _routine_stub_size;
+  static int static_call_stub_size();
+  static int routine_call_stub_size();
 
   // Handler sizes matching C2's HandlerImpl::size_exception_handler/size_deopt_handler,
   // defined in platform-specific implementation files. These are functions (not constants)
@@ -89,6 +88,10 @@ class JeandleAssembler : public StackObj {
   static int deopt_handler_size();
 
  private:
+  // Stub sizes for call sites, defined in platform-specific implementation files.
+  static const int _call_stub_size;
+  static const int _routine_stub_size;
+
   MacroAssembler* _masm;
 
 #include CPU_HEADER(jeandleAssembler)

--- a/src/hotspot/share/jeandle/jeandleAssembler.hpp
+++ b/src/hotspot/share/jeandle/jeandleAssembler.hpp
@@ -89,6 +89,9 @@ class JeandleAssembler : public StackObj {
   MacroAssembler* _masm;
 
 #include CPU_HEADER(jeandleAssembler)
+ static const int _call_stub_size;
+ static const int _routine_stub_size;
+ static const int _exception_handler_size;
 };
 
 #endif // SHARE_JEANDLE_ASSEMBLER_HPP

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -47,14 +47,33 @@ inline void swap(JeandleReloc*& a, JeandleReloc*& b) {
 }
 
 // CodeBuffer initialization constants (following C2's PhaseOutput::init_buffer pattern).
-static constexpr int PROLOG_RESERVED_SIZE = 2048;
+static constexpr int CODE_SLOP_SIZE = 2048;
 // Reloc capacity (in bytes). CodeBuffer divides by sizeof(relocInfo)=2 for the
-// element count. For large methods the actual count is max(256/2, insts_size/16),
-// so this 256 only serves as the lower bound for small methods.
+// element count, so this is a lower bound for small methods.
 static constexpr int INITIAL_RELOC_CAPACITY = 256;
 // Slop for uncounted stubs (EXTERNAL_CALL trampolines, finalize_stubs() shared
 // trampolines, alignment padding, estimation errors).
 static constexpr int STUB_SLOP_SIZE = 256;
+
+static int estimate_reloc_capacity(uint64_t code_size) {
+  uint64_t reloc_capacity = MAX2((uint64_t)INITIAL_RELOC_CAPACITY, code_size / 16);
+  return checked_cast<int>(reloc_capacity);
+}
+
+static int estimate_call_stub_size(CallSiteInfo* call_info) {
+  if (call_info == nullptr) {
+    return 0;
+  }
+
+  switch (call_info->type()) {
+    case JeandleCompiledCall::STATIC_CALL:
+      return JeandleAssembler::static_call_stub_size() + JeandleAssembler::routine_call_stub_size();
+    case JeandleCompiledCall::DYNAMIC_CALL:
+      return JeandleAssembler::routine_call_stub_size();
+    default:
+      return 0;
+  }
+}
 
 // Decide whether to emit a stack overflow check for the compiled entry based on
 // Java call presence and frame size pressure (skip stub compilations).
@@ -124,9 +143,13 @@ void JeandleCompiledCode::install_obj(std::unique_ptr<ObjectBuffer> obj) {
   JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(_elf, "bad ELF file");
 }
 
-void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, int &stubs_size) {
-  // Estimate const section size from ELF rodata sections.
-  const_size = (int) ReadELF::calculate_const_sections_size(*_elf);
+JeandleCompiledCode::CodeBufferSizing JeandleCompiledCode::estimate_codebuffer_component_sizes(uint64_t code_size) {
+  CodeBufferSizing sizing;
+
+  sizing._code = checked_cast<int>(code_size) + CODE_SLOP_SIZE + NativeCall::instruction_size;
+  sizing._consts = checked_cast<int>(ReadELF::calculate_const_sections_size(*_elf));
+  sizing._stubs = 0;
+  sizing._relocs = estimate_reloc_capacity(code_size);
 
   // Count stub sizes from call sites in stackmaps.
   SectionInfo section_info(".llvm_stackmaps");
@@ -134,37 +157,25 @@ void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, i
     StackMapParser stackmaps(llvm::ArrayRef(((uint8_t *) object_start()) + section_info._offset, section_info._size));
     for (auto record = stackmaps.records_begin(); record != stackmaps.records_end(); ++record) {
       if (record->getID() < _non_routine_call_sites.size()) {
-        CallSiteInfo *call_info = _non_routine_call_sites[record->getID()];
-        if (call_info) {
-          switch (call_info->type()) {
-            case JeandleCompiledCall::STATIC_CALL:
-              // emit_static_call_stub + patch_static_call_site trampoline.
-              stubs_size += JeandleAssembler::_call_stub_size + JeandleAssembler::_routine_stub_size;
-              break;
-            case JeandleCompiledCall::DYNAMIC_CALL:
-              // patch_ic_call_site trampoline.
-              stubs_size += JeandleAssembler::_routine_stub_size;
-              break;
-            default:
-              break;
-          }
-        }
+        sizing._stubs += estimate_call_stub_size(_non_routine_call_sites[record->getID()]);
       } else {
         // _routine_call_sites only contains routine calls.
-        stubs_size += JeandleAssembler::_routine_stub_size;
+        sizing._stubs += JeandleAssembler::routine_call_stub_size();
       }
     }
   }
 
-  // Handlers.
-  stubs_size += JeandleAssembler::exception_handler_size();
-  stubs_size += JeandleAssembler::deopt_handler_size();
-  if (_has_method_handle_invoke) {
-    stubs_size += JeandleAssembler::deopt_handler_size();
+  if (_method != nullptr) {
+    sizing._stubs += JeandleAssembler::exception_handler_size();
+    sizing._stubs += JeandleAssembler::deopt_handler_size();
+    if (_has_method_handle_invoke) {
+      sizing._stubs += JeandleAssembler::deopt_handler_size();
+    }
   }
 
-  // Slop for uncounted stubs.
-  stubs_size += STUB_SLOP_SIZE;
+  sizing._stubs += STUB_SLOP_SIZE;
+  sizing._total = sizing._code + sizing._consts + sizing._stubs;
+  return sizing;
 }
 
 void JeandleCompiledCode::finalize() {
@@ -179,23 +190,14 @@ void JeandleCompiledCode::finalize() {
   RETURN_VOID_ON_JEANDLE_ERROR();
   assert(_frame_size > 0, "frame size must be positive");
 
-  // Estimate component sizes following C2's PhaseOutput::init_buffer().
-  int consts_size = 0;
-  int stubs_size = 0;
-  estimate_codebuffer_component_sizes(consts_size, stubs_size);
-
-  // Pad for patching nmethod entry when made not-entrant (same as C2).
-  int pad_req = NativeCall::instruction_size;
-
-  int total_req = (int)code_size + consts_size + PROLOG_RESERVED_SIZE + pad_req + stubs_size;
-  _code_buffer.initialize(total_req,
-                          INITIAL_RELOC_CAPACITY,
-                          stubs_size,
-                          _env->oop_recorder());
+  CodeBufferSizing sizing = estimate_codebuffer_component_sizes(code_size);
+  _code_buffer.initialize(sizing._total, sizing._relocs);
   if (_code_buffer.blob() == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET_VOID("CodeCache is full");
   }
-  _code_buffer.initialize_consts_size(consts_size);
+  _code_buffer.initialize_consts_size(sizing._consts);
+  _code_buffer.initialize_stubs_size(sizing._stubs);
+  _code_buffer.initialize_oop_recorder(_env->oop_recorder());
 
   // Initialize assembler.
   MacroAssembler* masm = new MacroAssembler(&_code_buffer);
@@ -276,7 +278,7 @@ void JeandleCompiledCode::finalize() {
   assert(_code_buffer.before_expand() == nullptr,
          "CodeBuffer expanded during code emission, pre-allocation was insufficient "
          "(initial_req=%d, insts=%d, stubs=%d, consts=%d)",
-         total_req,
+         sizing._total,
          (int)_code_buffer.insts_size(),
          (int)_code_buffer.stubs()->size(),
          (int)_code_buffer.consts()->size());

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -62,8 +62,13 @@ static constexpr int PROLOG_RESERVED_SIZE = 2048;
 // - Worst case: expand_locs() reallocates (doubles capacity), but the above
 //   sizing makes this rare
 static constexpr int INITIAL_RELOC_CAPACITY = 256;
-// Marginal slop for handler and per-stub allocation (matches C2's MAX_stubs_size)
-static constexpr int STUB_SLOP_SIZE = 128;
+// Slop to cover uncounted stub allocations:
+// - EXTERNAL_CALL trampoline stubs (not in stackmaps, created during reloc resolution)
+// - Shared trampoline stubs from finalize_stubs() for gc-leaf routine calls
+// - Alignment padding within the stubs section
+// - Minor estimation errors
+// Reduces the chance of CodeBuffer::expand() which reallocates and copies the entire blob.
+static constexpr int STUB_SLOP_SIZE = 256;
 
 // Decide whether to emit a stack overflow check for the compiled entry based on
 // Java call presence and frame size pressure (skip stub compilations).
@@ -144,8 +149,23 @@ void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, i
     for (auto record = stackmaps.records_begin(); record != stackmaps.records_end(); ++record) {
       if (record->getID() < _non_routine_call_sites.size()) {
         CallSiteInfo *call_info = _non_routine_call_sites[record->getID()];
-        if (call_info && call_info->type() == JeandleCompiledCall::STATIC_CALL) {
-          stubs_size += JeandleAssembler::_call_stub_size;
+        if (call_info) {
+          switch (call_info->type()) {
+            case JeandleCompiledCall::STATIC_CALL:
+              // Static call stub (method metadata + jump target) plus trampoline
+              // stub on platforms that need it (e.g., aarch64 with far_branches).
+              // _routine_stub_size is 0 on x86 (no trampoline needed).
+              stubs_size += JeandleAssembler::_call_stub_size + JeandleAssembler::_routine_stub_size;
+              break;
+            case JeandleCompiledCall::DYNAMIC_CALL:
+              // Inline cache trampoline stub on platforms that need it.
+              // _routine_stub_size is 0 on x86 (ic_call is inline).
+              stubs_size += JeandleAssembler::_routine_stub_size;
+              break;
+            default:
+              // STUB_C_CALL and other types don't allocate stub section space.
+              break;
+          }
         }
       } else {
         // _routine_call_sites only contains routine calls.
@@ -167,7 +187,8 @@ void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, i
     stubs_size += JeandleAssembler::deopt_handler_size();
   }
 
-  // Slop to cover alignment padding within the stubs section and minor
+  // Slop to cover EXTERNAL_CALL trampoline stubs (not in stackmaps), shared
+  // trampoline stubs from finalize_stubs(), alignment padding, and minor
   // estimation errors. Reduces the chance of CodeBuffer::expand() which
   // reallocates and copies the entire blob.
   stubs_size += STUB_SLOP_SIZE;

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -47,8 +47,21 @@ inline void swap(JeandleReloc*& a, JeandleReloc*& b) {
 }
 
 // Code buffer initialization constants (following C2's PhaseOutput::init_buffer pattern)
-static constexpr int PROLOG_RESERVED_SIZE  = 2048;
-static constexpr int RELOC_SIZE_MULTIPLIER = 20;
+static constexpr int PROLOG_RESERVED_SIZE = 2048;
+// Initial reloc capacity (in bytes) passed to CodeBuffer::initialize as locs_size.
+//
+// CodeBuffer internally divides by sizeof(relocInfo)=2 to get the element count,
+// then applies a floor of insts_size/16 (see CodeSection::initialize_locs).
+//
+// The combined effect ensures adequate capacity for all method sizes:
+// - Small methods (<2KB code): 256/2=128 records, far exceeding typical reloc
+//   counts (a 2KB method has ~10 call sites + ~10 const/oop refs, each expanding
+//   to 1-3 relocInfo records = ~60 records, well within 128)
+// - Medium/large methods: the insts_size/16 floor dominates, providing 256+
+//   records for 4KB code, 1024+ records for 16KB code
+// - Worst case: expand_locs() reallocates (doubles capacity), but the above
+//   sizing makes this rare
+static constexpr int INITIAL_RELOC_CAPACITY = 256;
 // Marginal slop for handler and per-stub allocation (matches C2's MAX_stubs_size)
 static constexpr int STUB_SLOP_SIZE = 128;
 
@@ -141,18 +154,22 @@ void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, i
     }
   }
 
-  // Add handler sizes following C2's init_buffer() pattern:
-  //   exception_handler_req = size_exception_handler() + STUB_SLOP_SIZE
-  //   deopt_handler_req     = size_deopt_handler()     + STUB_SLOP_SIZE
-  stubs_size += JeandleAssembler::exception_handler_size() + STUB_SLOP_SIZE;
-  stubs_size += JeandleAssembler::deopt_handler_size() + STUB_SLOP_SIZE;
+  // Handler sizes. Jeandle pre-allocates all stub space including handlers in
+  // stubs_size, so start_a_stub() rarely needs to trigger CodeBuffer::expand()
+  // (which reallocates and copies the entire blob). C2 adds handlers to total_req
+  // but not stub_req, relying on expand at runtime, hence needs per-handler slop.
+  // Jeandle's pre-allocation approach avoids that overhead.
+  stubs_size += JeandleAssembler::exception_handler_size();
+  stubs_size += JeandleAssembler::deopt_handler_size();
 
   // If method has MethodHandle invokes, add a second deopt handler.
   if (_has_method_handle_invoke) {
-    stubs_size += JeandleAssembler::deopt_handler_size() + STUB_SLOP_SIZE;
+    stubs_size += JeandleAssembler::deopt_handler_size();
   }
 
-  // Ensure per-stub margin (matches C2's stub_req += MAX_stubs_size).
+  // Slop to cover alignment padding within the stubs section and minor
+  // estimation errors. Reduces the chance of CodeBuffer::expand() which
+  // reallocates and copies the entire blob.
   stubs_size += STUB_SLOP_SIZE;
 }
 
@@ -173,14 +190,14 @@ void JeandleCompiledCode::finalize() {
   int stubs_size = 0;
   estimate_codebuffer_component_sizes(consts_size, stubs_size);
 
-  // The extra spacing after the code is necessary on some platforms.
-  // Sometimes we need to patch in a jump after the last instruction,
-  // if the nmethod has been deoptimized. (See 4932387, 4894843.)
+  // C2 reserves NativeCall::instruction_size after the instruction section for
+  // patching a jump at the nmethod entry when it is made not-entrant (deoptimized
+  // or dependency invalidated). See NativeJump::patch_verified_entry in nmethod.cpp.
   int pad_req = NativeCall::instruction_size;
 
   int total_req = (int)code_size + consts_size + PROLOG_RESERVED_SIZE + pad_req + stubs_size;
   _code_buffer.initialize(total_req,
-                          RELOC_SIZE_MULTIPLIER * (sizeof(relocInfo) + relocInfo::length_limit),
+                          INITIAL_RELOC_CAPACITY,
                           stubs_size,
                           _env->oop_recorder());
   if (_code_buffer.blob() == nullptr) {
@@ -262,6 +279,15 @@ void JeandleCompiledCode::finalize() {
       RETURN_VOID_ON_JEANDLE_ERROR();
     }
   }
+
+  // Verify CodeBuffer pre-allocation was sufficient (no expand needed).
+  assert(_code_buffer.before_expand() == nullptr,
+         "CodeBuffer expanded during code emission, pre-allocation was insufficient "
+         "(initial_req=%d, insts=%d, stubs=%d, consts=%d)",
+         total_req,
+         (int)_code_buffer.insts_size(),
+         (int)_code_buffer.stubs_size(),
+         (int)_code_buffer.consts_size());
 }
 
 void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -119,17 +119,7 @@ void JeandleCompiledCode::install_obj(std::unique_ptr<ObjectBuffer> obj) {
 }
 
 void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, int &stubs_size) {
-  for (const auto &section: _elf->sections()) {
-    llvm::Expected <llvm::StringRef> expected_sec_name = section.getName();
-    if (auto Err = expected_sec_name.takeError()) {
-      JeandleCompilation::report_jeandle_error("failed to get section name");
-      return;
-    }
-    llvm::StringRef sec_name = *expected_sec_name;
-    if (sec_name.starts_with(".rodata") || sec_name.starts_with(".data.rel.ro")) {
-      const_size += (int) section.getSize() + section.getAlignment().value();
-    }
-  }
+  const_size = (int) ReadELF::calculate_const_sections_size(*_elf);
 
   SectionInfo section_info(".llvm_stackmaps");
   if (ReadELF::findSection(*_elf, section_info)) {
@@ -139,17 +129,17 @@ void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, i
       if (record->getID() < _non_routine_call_sites.size()) {
         call_info = _non_routine_call_sites[record->getID()];
         if (call_info && call_info->type() == JeandleCompiledCall::STATIC_CALL)
-          stubs_size += JeandleAssembler::get_call_stub_size();
+          stubs_size += JeandleAssembler::_call_stub_size;
       } else {
         // _routine_call_sites only contains routine call
-        stubs_size += JeandleAssembler::get_routine_stub_size();
+        stubs_size += JeandleAssembler::_routine_stub_size;
       }
     }
   }
   // Add exception handler size
-  stubs_size += JeandleAssembler::get_exception_handler_size();
+  stubs_size += JeandleAssembler::_exception_handler_size;
   // Add deopt handler sizes (regular deopt + MethodHandle deopt if needed)
-  stubs_size += MAX_DEOPT_HANDLER_COUNT * JeandleAssembler::get_deopt_handler_size();
+  stubs_size += MAX_DEOPT_HANDLER_COUNT * JeandleAssembler::_deopt_handler_size;
 }
 
 void JeandleCompiledCode::finalize() {

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -35,6 +35,7 @@
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "asm/macroAssembler.hpp"
 #include "ci/ciEnv.hpp"
+#include "code/nativeInst.hpp"
 #include "code/vmreg.inline.hpp"
 #include "interpreter/interpreter.hpp"
 #include "logging/log.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -45,6 +45,11 @@ inline void swap(JeandleReloc*& a, JeandleReloc*& b) {
   std::swap(a, b);
 }
 
+// Code buffer initialization constants
+static constexpr int PROLOG_RESERVED_SIZE = 2048;
+static constexpr int RELOC_SIZE_MULTIPLIER = 20;
+static constexpr int MAX_DEOPT_HANDLER_COUNT = 2;  // Regular deopt + MethodHandle deopt
+
 // Decide whether to emit a stack overflow check for the compiled entry based on
 // Java call presence and frame size pressure (skip stub compilations).
 static bool need_stack_overflow_check(bool is_method_compilation,
@@ -141,8 +146,10 @@ void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, i
       }
     }
   }
-  // Add an exception handler size
+  // Add exception handler size
   stubs_size += JeandleAssembler::get_exception_handler_size();
+  // Add deopt handler sizes (regular deopt + MethodHandle deopt if needed)
+  stubs_size += MAX_DEOPT_HANDLER_COUNT * JeandleAssembler::get_deopt_handler_size();
 }
 
 void JeandleCompiledCode::finalize() {
@@ -160,8 +167,8 @@ void JeandleCompiledCode::finalize() {
   int consts_size = 0;
   int stubs_size = 0;
   estimate_codebuffer_component_sizes(consts_size, stubs_size);
-  _code_buffer.initialize(code_size + consts_size + 2048/* for prolog */,
-                          20 * (sizeof(relocInfo) + relocInfo::length_limit), /* preinitialize the relocs to some large size */
+  _code_buffer.initialize(code_size + consts_size + PROLOG_RESERVED_SIZE,
+                          RELOC_SIZE_MULTIPLIER * (sizeof(relocInfo) + relocInfo::length_limit),
                           stubs_size,
                           _env->oop_recorder());
   if (_code_buffer.blob() == nullptr) {

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -45,10 +45,11 @@ inline void swap(JeandleReloc*& a, JeandleReloc*& b) {
   std::swap(a, b);
 }
 
-// Code buffer initialization constants
-static constexpr int PROLOG_RESERVED_SIZE = 2048;
+// Code buffer initialization constants (following C2's PhaseOutput::init_buffer pattern)
+static constexpr int PROLOG_RESERVED_SIZE  = 2048;
 static constexpr int RELOC_SIZE_MULTIPLIER = 20;
-static constexpr int MAX_DEOPT_HANDLER_COUNT = 2;  // Regular deopt + MethodHandle deopt
+// Marginal slop for handler and per-stub allocation (matches C2's MAX_stubs_size)
+static constexpr int STUB_SLOP_SIZE = 128;
 
 // Decide whether to emit a stack overflow check for the compiled entry based on
 // Java call presence and frame size pressure (skip stub compilations).
@@ -119,27 +120,39 @@ void JeandleCompiledCode::install_obj(std::unique_ptr<ObjectBuffer> obj) {
 }
 
 void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, int &stubs_size) {
+  // Estimate const section size from ELF rodata sections.
   const_size = (int) ReadELF::calculate_const_sections_size(*_elf);
 
+  // Count stub sizes from call sites in stackmaps.
   SectionInfo section_info(".llvm_stackmaps");
   if (ReadELF::findSection(*_elf, section_info)) {
     StackMapParser stackmaps(llvm::ArrayRef(((uint8_t *) object_start()) + section_info._offset, section_info._size));
     for (auto record = stackmaps.records_begin(); record != stackmaps.records_end(); ++record) {
-      CallSiteInfo *call_info = nullptr;
       if (record->getID() < _non_routine_call_sites.size()) {
-        call_info = _non_routine_call_sites[record->getID()];
-        if (call_info && call_info->type() == JeandleCompiledCall::STATIC_CALL)
+        CallSiteInfo *call_info = _non_routine_call_sites[record->getID()];
+        if (call_info && call_info->type() == JeandleCompiledCall::STATIC_CALL) {
           stubs_size += JeandleAssembler::_call_stub_size;
+        }
       } else {
-        // _routine_call_sites only contains routine call
+        // _routine_call_sites only contains routine calls.
         stubs_size += JeandleAssembler::_routine_stub_size;
       }
     }
   }
-  // Add exception handler size
-  stubs_size += JeandleAssembler::_exception_handler_size;
-  // Add deopt handler sizes (regular deopt + MethodHandle deopt if needed)
-  stubs_size += MAX_DEOPT_HANDLER_COUNT * JeandleAssembler::_deopt_handler_size;
+
+  // Add handler sizes following C2's init_buffer() pattern:
+  //   exception_handler_req = size_exception_handler() + STUB_SLOP_SIZE
+  //   deopt_handler_req     = size_deopt_handler()     + STUB_SLOP_SIZE
+  stubs_size += JeandleAssembler::exception_handler_size() + STUB_SLOP_SIZE;
+  stubs_size += JeandleAssembler::deopt_handler_size() + STUB_SLOP_SIZE;
+
+  // If method has MethodHandle invokes, add a second deopt handler.
+  if (_has_method_handle_invoke) {
+    stubs_size += JeandleAssembler::deopt_handler_size() + STUB_SLOP_SIZE;
+  }
+
+  // Ensure per-stub margin (matches C2's stub_req += MAX_stubs_size).
+  stubs_size += STUB_SLOP_SIZE;
 }
 
 void JeandleCompiledCode::finalize() {
@@ -154,10 +167,18 @@ void JeandleCompiledCode::finalize() {
   RETURN_VOID_ON_JEANDLE_ERROR();
   assert(_frame_size > 0, "frame size must be positive");
 
+  // Estimate component sizes following C2's PhaseOutput::init_buffer() pattern.
   int consts_size = 0;
   int stubs_size = 0;
   estimate_codebuffer_component_sizes(consts_size, stubs_size);
-  _code_buffer.initialize(code_size + consts_size + PROLOG_RESERVED_SIZE,
+
+  // The extra spacing after the code is necessary on some platforms.
+  // Sometimes we need to patch in a jump after the last instruction,
+  // if the nmethod has been deoptimized. (See 4932387, 4894843.)
+  int pad_req = NativeCall::instruction_size;
+
+  int total_req = (int)code_size + consts_size + PROLOG_RESERVED_SIZE + pad_req + stubs_size;
+  _code_buffer.initialize(total_req,
                           RELOC_SIZE_MULTIPLIER * (sizeof(relocInfo) + relocInfo::length_limit),
                           stubs_size,
                           _env->oop_recorder());

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -121,7 +121,7 @@ void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, i
       return;
     }
     llvm::StringRef sec_name = *expected_sec_name;
-    if (sec_name.starts_with(".rodata")) {
+    if (sec_name.starts_with(".rodata") || sec_name.starts_with(".data.rel.ro")) {
       const_size += (int) section.getSize() + section.getAlignment().value();
     }
   }

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -113,6 +113,38 @@ void JeandleCompiledCode::install_obj(std::unique_ptr<ObjectBuffer> obj) {
   JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(_elf, "bad ELF file");
 }
 
+void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, int &stubs_size) {
+  for (const auto &Section: _elf->sections()) {
+    llvm::Expected <llvm::StringRef> expected_sec_name = Section.getName();
+    if (auto Err = expected_sec_name.takeError()) {
+      JeandleCompilation::report_jeandle_error("failed to get section name");
+      return;
+    }
+    llvm::StringRef sec_name = *expected_sec_name;
+    if (sec_name.starts_with(".rodata")) {
+      const_size += (int) Section.getSize() + Section.getAlignment().value();
+    }
+  }
+
+  SectionInfo section_info(".llvm_stackmaps");
+  if (ReadELF::findSection(*_elf, section_info)) {
+    StackMapParser stackmaps(llvm::ArrayRef(((uint8_t *) object_start()) + section_info._offset, section_info._size));
+    for (auto record = stackmaps.records_begin(); record != stackmaps.records_end(); ++record) {
+      CallSiteInfo *call_info = nullptr;
+      if (record->getID() < _non_routine_call_sites.size()) {
+        call_info = _non_routine_call_sites[record->getID()];
+        if (call_info && call_info->type() == JeandleCompiledCall::STATIC_CALL)
+          stubs_size += JeandleAssembler::get_call_stub_size();
+      } else {
+        // _routine_call_sites only contains routine call
+        stubs_size += JeandleAssembler::get_routine_stub_size();
+      }
+    }
+  }
+  // Add an exception handler size
+  stubs_size += JeandleAssembler::get_exception_handler_size();
+}
+
 void JeandleCompiledCode::finalize() {
   // Set up code buffer.
   uint64_t align;
@@ -125,13 +157,12 @@ void JeandleCompiledCode::finalize() {
   RETURN_VOID_ON_JEANDLE_ERROR();
   assert(_frame_size > 0, "frame size must be positive");
 
-  // An estimated initial value.
-  uint64_t consts_size = 6144 * wordSize;
-
-  // TODO: How to figure out memory usage.
+  int consts_size = 0;
+  int stubs_size = 0;
+  estimate_codebuffer_component_sizes(consts_size, stubs_size);
   _code_buffer.initialize(code_size + consts_size + 2048/* for prolog */,
                           sizeof(relocInfo) + relocInfo::length_limit,
-                          160,
+                          stubs_size,
                           _env->oop_recorder());
   if (_code_buffer.blob() == nullptr) {
     JEANDLE_REPORT_ERROR_AND_RET_VOID("CodeCache is full");

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -114,15 +114,15 @@ void JeandleCompiledCode::install_obj(std::unique_ptr<ObjectBuffer> obj) {
 }
 
 void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, int &stubs_size) {
-  for (const auto &Section: _elf->sections()) {
-    llvm::Expected <llvm::StringRef> expected_sec_name = Section.getName();
+  for (const auto &section: _elf->sections()) {
+    llvm::Expected <llvm::StringRef> expected_sec_name = section.getName();
     if (auto Err = expected_sec_name.takeError()) {
       JeandleCompilation::report_jeandle_error("failed to get section name");
       return;
     }
     llvm::StringRef sec_name = *expected_sec_name;
     if (sec_name.starts_with(".rodata")) {
-      const_size += (int) Section.getSize() + Section.getAlignment().value();
+      const_size += (int) section.getSize() + section.getAlignment().value();
     }
   }
 
@@ -160,8 +160,8 @@ void JeandleCompiledCode::finalize() {
   int consts_size = 0;
   int stubs_size = 0;
   estimate_codebuffer_component_sizes(consts_size, stubs_size);
-  _code_buffer.initialize(code_size + consts_size + 2048/* for prolog */,
-                          sizeof(relocInfo) + relocInfo::length_limit,
+  _code_buffer.initialize(code_size + 2048/* for prolog */,
+                          20 * (sizeof(relocInfo) + relocInfo::length_limit), /* preinitialize the relocs to some large size */
                           stubs_size,
                           _env->oop_recorder());
   if (_code_buffer.blob() == nullptr) {

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -286,8 +286,8 @@ void JeandleCompiledCode::finalize() {
          "(initial_req=%d, insts=%d, stubs=%d, consts=%d)",
          total_req,
          (int)_code_buffer.insts_size(),
-         (int)_code_buffer.stubs_size(),
-         (int)_code_buffer.consts_size());
+         (int)_code_buffer.stubs()->size(),
+         (int)_code_buffer.consts()->size());
 }
 
 void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -46,28 +46,14 @@ inline void swap(JeandleReloc*& a, JeandleReloc*& b) {
   std::swap(a, b);
 }
 
-// Code buffer initialization constants (following C2's PhaseOutput::init_buffer pattern)
+// CodeBuffer initialization constants (following C2's PhaseOutput::init_buffer pattern).
 static constexpr int PROLOG_RESERVED_SIZE = 2048;
-// Initial reloc capacity (in bytes) passed to CodeBuffer::initialize as locs_size.
-//
-// CodeBuffer internally divides by sizeof(relocInfo)=2 to get the element count,
-// then applies a floor of insts_size/16 (see CodeSection::initialize_locs).
-//
-// The combined effect ensures adequate capacity for all method sizes:
-// - Small methods (<2KB code): 256/2=128 records, far exceeding typical reloc
-//   counts (a 2KB method has ~10 call sites + ~10 const/oop refs, each expanding
-//   to 1-3 relocInfo records = ~60 records, well within 128)
-// - Medium/large methods: the insts_size/16 floor dominates, providing 256+
-//   records for 4KB code, 1024+ records for 16KB code
-// - Worst case: expand_locs() reallocates (doubles capacity), but the above
-//   sizing makes this rare
+// Reloc capacity (in bytes). CodeBuffer divides by sizeof(relocInfo)=2 for the
+// element count. For large methods the actual count is max(256/2, insts_size/16),
+// so this 256 only serves as the lower bound for small methods.
 static constexpr int INITIAL_RELOC_CAPACITY = 256;
-// Slop to cover uncounted stub allocations:
-// - EXTERNAL_CALL trampoline stubs (not in stackmaps, created during reloc resolution)
-// - Shared trampoline stubs from finalize_stubs() for gc-leaf routine calls
-// - Alignment padding within the stubs section
-// - Minor estimation errors
-// Reduces the chance of CodeBuffer::expand() which reallocates and copies the entire blob.
+// Slop for uncounted stubs (EXTERNAL_CALL trampolines, finalize_stubs() shared
+// trampolines, alignment padding, estimation errors).
 static constexpr int STUB_SLOP_SIZE = 256;
 
 // Decide whether to emit a stack overflow check for the compiled entry based on
@@ -152,18 +138,14 @@ void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, i
         if (call_info) {
           switch (call_info->type()) {
             case JeandleCompiledCall::STATIC_CALL:
-              // Static call stub (method metadata + jump target) plus trampoline
-              // stub on platforms that need it (e.g., aarch64 with far_branches).
-              // _routine_stub_size is 0 on x86 (no trampoline needed).
+              // emit_static_call_stub + patch_static_call_site trampoline.
               stubs_size += JeandleAssembler::_call_stub_size + JeandleAssembler::_routine_stub_size;
               break;
             case JeandleCompiledCall::DYNAMIC_CALL:
-              // Inline cache trampoline stub on platforms that need it.
-              // _routine_stub_size is 0 on x86 (ic_call is inline).
+              // patch_ic_call_site trampoline.
               stubs_size += JeandleAssembler::_routine_stub_size;
               break;
             default:
-              // STUB_C_CALL and other types don't allocate stub section space.
               break;
           }
         }
@@ -174,23 +156,14 @@ void JeandleCompiledCode::estimate_codebuffer_component_sizes(int &const_size, i
     }
   }
 
-  // Handler sizes. Jeandle pre-allocates all stub space including handlers in
-  // stubs_size, so start_a_stub() rarely needs to trigger CodeBuffer::expand()
-  // (which reallocates and copies the entire blob). C2 adds handlers to total_req
-  // but not stub_req, relying on expand at runtime, hence needs per-handler slop.
-  // Jeandle's pre-allocation approach avoids that overhead.
+  // Handlers.
   stubs_size += JeandleAssembler::exception_handler_size();
   stubs_size += JeandleAssembler::deopt_handler_size();
-
-  // If method has MethodHandle invokes, add a second deopt handler.
   if (_has_method_handle_invoke) {
     stubs_size += JeandleAssembler::deopt_handler_size();
   }
 
-  // Slop to cover EXTERNAL_CALL trampoline stubs (not in stackmaps), shared
-  // trampoline stubs from finalize_stubs(), alignment padding, and minor
-  // estimation errors. Reduces the chance of CodeBuffer::expand() which
-  // reallocates and copies the entire blob.
+  // Slop for uncounted stubs.
   stubs_size += STUB_SLOP_SIZE;
 }
 
@@ -206,14 +179,12 @@ void JeandleCompiledCode::finalize() {
   RETURN_VOID_ON_JEANDLE_ERROR();
   assert(_frame_size > 0, "frame size must be positive");
 
-  // Estimate component sizes following C2's PhaseOutput::init_buffer() pattern.
+  // Estimate component sizes following C2's PhaseOutput::init_buffer().
   int consts_size = 0;
   int stubs_size = 0;
   estimate_codebuffer_component_sizes(consts_size, stubs_size);
 
-  // C2 reserves NativeCall::instruction_size after the instruction section for
-  // patching a jump at the nmethod entry when it is made not-entrant (deoptimized
-  // or dependency invalidated). See NativeJump::patch_verified_entry in nmethod.cpp.
+  // Pad for patching nmethod entry when made not-entrant (same as C2).
   int pad_req = NativeCall::instruction_size;
 
   int total_req = (int)code_size + consts_size + PROLOG_RESERVED_SIZE + pad_req + stubs_size;

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -160,7 +160,7 @@ void JeandleCompiledCode::finalize() {
   int consts_size = 0;
   int stubs_size = 0;
   estimate_codebuffer_component_sizes(consts_size, stubs_size);
-  _code_buffer.initialize(code_size + 2048/* for prolog */,
+  _code_buffer.initialize(code_size + consts_size + 2048/* for prolog */,
                           20 * (sizeof(relocInfo) + relocInfo::length_limit), /* preinitialize the relocs to some large size */
                           stubs_size,
                           _env->oop_recorder());

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -280,6 +280,7 @@ class JeandleCompiledCode : public StackObj {
 
   void setup_frame_size();
 
+  void estimate_codebuffer_component_sizes(int &, int &);
   void resolve_reloc_info(JeandleAssembler& assembler);
   bool pd_resolve_reloc(JeandleAssembler& assembler,
                         llvm::SmallVector<JeandleReloc*>& relocs,

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -280,7 +280,15 @@ class JeandleCompiledCode : public StackObj {
 
   void setup_frame_size();
 
-  void estimate_codebuffer_component_sizes(int &, int &);
+  struct CodeBufferSizing {
+    int _code;
+    int _consts;
+    int _stubs;
+    int _relocs;
+    int _total;
+  };
+
+  CodeBufferSizing estimate_codebuffer_component_sizes(uint64_t code_size);
   void resolve_reloc_info(JeandleAssembler& assembler);
   bool pd_resolve_reloc(JeandleAssembler& assembler,
                         llvm::SmallVector<JeandleReloc*>& relocs,

--- a/src/hotspot/share/jeandle/jeandleReadELF.cpp
+++ b/src/hotspot/share/jeandle/jeandleReadELF.cpp
@@ -84,3 +84,19 @@ bool ReadELF::findSection(ELFObject& elf, SectionInfo& section_info) {
   }
   return false;
 }
+
+uint64_t ReadELF::calculate_const_sections_size(ELFObject& elf) {
+  uint64_t total_size = 0;
+  for (auto sec = elf.section_begin(); sec != elf.section_end(); ++sec) {
+    llvm::Expected<llvm::StringRef> sec_name = sec->getName();
+    if (!sec_name) {
+      continue;
+    }
+    if (sec_name->starts_with(".rodata") || sec_name->starts_with(".data.rel.ro")) {
+      uint64_t size = sec->getSize();
+      uint64_t align = sec->getAlignment().value();
+      total_size += size + (align > 0 ? align - 1 : 0);
+    }
+  }
+  return total_size;
+}

--- a/src/hotspot/share/jeandle/jeandleReadELF.hpp
+++ b/src/hotspot/share/jeandle/jeandleReadELF.hpp
@@ -50,6 +50,8 @@ class ReadELF : public AllStatic {
 
   static bool findSection(ELFObject& elf,
                           SectionInfo& section_info);
+
+  static uint64_t calculate_const_sections_size(ELFObject& elf);
 };
 
 #endif // SHARE_JEANDLE_READ_ELF_HPP


### PR DESCRIPTION
## Related issue(s):

#15

## What this PR does / why we need it:

 **Total size calculation includes:**
 - Function symbol sizes from `.text` (via `.symtab`).
 - Relocation info estimate (`20 * sizeof(RelocInfo)`).
 - ELF `rodata`  and `reloc.rodata` section sizes.
 - Accumulated LLVM stackmap stub sizes after parsing.
 - Fixed-size exception handler overhead.