### PR TITLE
feat: Implement intrinsics: dcos, dtan

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -1086,6 +1086,18 @@ bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
       _jvm->dpush(call_runtime_routine(callee, {_jvm->dpop()}, /* is_leaf */ true));
       break;
     }
+    case vmIntrinsicID::_dcos: {
+      llvm::FunctionCallee callee = StubRoutines::dcos() != nullptr ? JeandleRuntimeRoutine::hotspot_StubRoutines_dcos_callee(_module) :
+                                                                      JeandleRuntimeRoutine::hotspot_SharedRuntime_dcos_callee(_module);
+      _jvm->dpush(call_runtime_routine(callee, {_jvm->dpop()}, /* is_leaf */ true));
+      break;
+    }
+    case vmIntrinsicID::_dtan: {
+      llvm::FunctionCallee callee = StubRoutines::dtan() != nullptr ? JeandleRuntimeRoutine::hotspot_StubRoutines_dtan_callee(_module) :
+                                                                      JeandleRuntimeRoutine::hotspot_SharedRuntime_dtan_callee(_module);
+      _jvm->dpush(call_runtime_routine(callee, {_jvm->dpop()}, /* is_leaf */ true));
+      break;
+    }
     default:
       return false;
   }

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -48,6 +48,10 @@
 #define ALL_HOTSPOT_ROUTINES(def)                                                                                                    \
   def(SharedRuntime_dsin,    SharedRuntime::dsin,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
   def(StubRoutines_dsin,     StubRoutines::dsin(),    llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
+  def(SharedRuntime_dcos,    SharedRuntime::dcos,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
+  def(StubRoutines_dcos,     StubRoutines::dcos(),    llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
+  def(SharedRuntime_dtan,    SharedRuntime::dtan,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
+  def(StubRoutines_dtan,     StubRoutines::dtan(),    llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
   def(SharedRuntime_drem,    SharedRuntime::drem,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context),         \
                                                                                            llvm::Type::getDoubleTy(context))         \
   def(SharedRuntime_frem,    SharedRuntime::frem,     llvm::Type::getFloatTy(context),     llvm::Type::getFloatTy(context),          \

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestCosDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestCosDouble.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @library /test/lib /
+ * @build jdk.test.lib.Asserts
+ * @run main/othervm compiler.jeandle.intrinsic.TestCosDouble
+ */
+
+package compiler.jeandle.intrinsic;
+
+import compiler.jeandle.fileCheck.FileCheck;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.nio.file.Path;
+import java.nio.file.Files;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestCosDouble {
+    public static void main(String[] args) throws Exception {
+        boolean is_x86 = System.getProperty("os.arch").equals("amd64");
+        String dump_path = System.getProperty("java.io.tmpdir");
+
+        // intrinsic by StubRoutine
+        ArrayList<String> command_args = new ArrayList<String>(List.of(
+            "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
+            "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
+            "-XX:JeandleDumpDirectory="+dump_path,
+            "-XX:CompileCommand=compileonly,"+TestWrapper.class.getName()+"::cos_double"));
+        if (is_x86) {
+          command_args.addAll(List.of("-XX:+UnlockDiagnosticVMOptions", "-XX:+UseLibmIntrinsic"));
+        }
+        command_args.add(TestWrapper.class.getName());
+
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command_args);
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+
+        output.shouldHaveExitValue(0)
+              .shouldContain("Method `static jdouble java.lang.Math.cos(jdouble)` is parsed as intrinsic");
+
+        // Verify llvm IR
+        FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("cos_double", double.class), false);
+        // find compiled method
+        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestCosDouble$TestWrapper_cos_double_(D)D\"(double %0)");
+        // check IR
+        checker.checkNext("entry:");
+        checker.checkNext("br label %bci_0");
+        checker.checkNext("bci_0:");
+        checker.checkNext("call double @StubRoutines_dcos");
+        checker.checkNext("ret double");
+
+        // intrinsic by SharedRuntime
+        if (is_x86) {
+            dump_path = System.getProperty("java.io.tmpdir")+"/test2";
+            Path tmp2 = Path.of(dump_path);
+            if (!Files.exists(tmp2)) {
+                Files.createDirectory(tmp2);
+            }
+
+            command_args = new ArrayList<String>(List.of(
+                "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
+                "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
+                "-XX:JeandleDumpDirectory="+dump_path,
+                "-XX:CompileCommand=compileonly,"+TestWrapper.class.getName()+"::cos_double",
+                "-XX:+UnlockDiagnosticVMOptions", "-XX:-UseLibmIntrinsic",
+                TestWrapper.class.getName()));
+            pb = ProcessTools.createLimitedTestJavaProcessBuilder(command_args);
+            output = ProcessTools.executeCommand(pb);
+            output.shouldHaveExitValue(0)
+                .shouldContain("Method `static jdouble java.lang.Math.cos(jdouble)` is parsed as intrinsic");
+            // Verify llvm IR
+            checker = new FileCheck(dump_path, TestWrapper.class.getMethod("cos_double", double.class), false);
+            // find compiled method
+            checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestCosDouble$TestWrapper_cos_double_(D)D\"(double %0)");
+            // check IR
+            checker.checkNext("entry:");
+            checker.checkNext("br label %bci_0");
+            checker.checkNext("bci_0:");
+            checker.checkNext("call double @SharedRuntime_dcos");
+            checker.checkNext("ret double");
+        }
+    }
+
+    static public class TestWrapper {
+        static double v = Math.abs(1.0d);   // Force load java.lang.Math class
+        public static void main(String[] args) {
+            Random random = new Random();
+            Asserts.assertEquals(cos_double_verified(1.5d), cos_double(1.5d));
+            Asserts.assertEquals(cos_double_verified(-1.5d), cos_double(-1.5d));
+            Asserts.assertEquals(cos_double_verified(Double.NaN), cos_double(Double.NaN));
+            Asserts.assertEquals(cos_double_verified(Double.POSITIVE_INFINITY), cos_double(Double.POSITIVE_INFINITY));
+            Asserts.assertEquals(cos_double_verified(Double.NEGATIVE_INFINITY), cos_double(Double.NEGATIVE_INFINITY));
+            for (int i=0; i< 1000; i++) {
+                double d = random.nextDouble();
+                Asserts.assertEquals(cos_double_verified(d) , cos_double(d));
+            }
+        }
+
+        public static double cos_double(double a) {
+            return Math.cos(a);
+        }
+
+        public static double cos_double_verified(double a) {
+            return Math.cos(a);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestTanDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestTanDouble.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @library /test/lib /
+ * @build jdk.test.lib.Asserts
+ * @run main/othervm compiler.jeandle.intrinsic.TestTanDouble
+ */
+
+package compiler.jeandle.intrinsic;
+
+import compiler.jeandle.fileCheck.FileCheck;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.nio.file.Path;
+import java.nio.file.Files;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestTanDouble {
+    public static void main(String[] args) throws Exception {
+        boolean is_x86 = System.getProperty("os.arch").equals("amd64");
+        String dump_path = System.getProperty("java.io.tmpdir");
+
+        // intrinsic by StubRoutine
+        if (is_x86) {
+            ArrayList<String> command_args = new ArrayList<String>(List.of(
+                "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
+                "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
+                "-XX:JeandleDumpDirectory="+dump_path,
+                "-XX:CompileCommand=compileonly,"+TestWrapper.class.getName()+"::tan_double",
+                "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseLibmIntrinsic",
+                TestWrapper.class.getName()));
+
+            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command_args);
+            OutputAnalyzer output = ProcessTools.executeCommand(pb);
+
+            output.shouldHaveExitValue(0)
+                .shouldContain("Method `static jdouble java.lang.Math.tan(jdouble)` is parsed as intrinsic");
+
+            // Verify llvm IR
+            FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("tan_double", double.class), false);
+            // find compiled method
+            checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestTanDouble$TestWrapper_tan_double_(D)D\"(double %0)");
+            // check IR
+            checker.checkNext("entry:");
+            checker.checkNext("br label %bci_0");
+            checker.checkNext("bci_0:");
+            checker.checkNext("call double @StubRoutines_dtan");
+            checker.checkNext("ret double");
+        }
+
+        // intrinsic by SharedRuntime
+        dump_path = System.getProperty("java.io.tmpdir")+"/test2";
+        Path tmp2 = Path.of(dump_path);
+        if (!Files.exists(tmp2)) {
+            Files.createDirectory(tmp2);
+        }
+
+        ArrayList<String> command_args = new ArrayList<String>(List.of(
+            "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
+            "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
+            "-XX:JeandleDumpDirectory="+dump_path,
+            "-XX:CompileCommand=compileonly,"+TestWrapper.class.getName()+"::tan_double"));
+        if (is_x86) {
+            command_args.addAll(List.of("-XX:+UnlockDiagnosticVMOptions", "-XX:-UseLibmIntrinsic"));
+        }
+        command_args.add(TestWrapper.class.getName());
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command_args);
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+        output.shouldHaveExitValue(0)
+            .shouldContain("Method `static jdouble java.lang.Math.tan(jdouble)` is parsed as intrinsic");
+        // Verify llvm IR
+        FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("tan_double", double.class), false);
+        // find compiled method
+        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestTanDouble$TestWrapper_tan_double_(D)D\"(double %0)");
+        // check IR
+        checker.checkNext("entry:");
+        checker.checkNext("br label %bci_0");
+        checker.checkNext("bci_0:");
+        checker.checkNext("call double @SharedRuntime_dtan");
+        checker.checkNext("ret double");
+    }
+
+    static public class TestWrapper {
+        static double v = Math.abs(1.0d);   // Force load java.lang.Math class
+        public static void main(String[] args) {
+            Random random = new Random();
+            Asserts.assertEquals(tan_double_verified(1.5d), tan_double(1.5d));
+            Asserts.assertEquals(tan_double_verified(-1.5d), tan_double(-1.5d));
+            Asserts.assertEquals(tan_double_verified(Double.NaN), tan_double(Double.NaN));
+            Asserts.assertEquals(tan_double_verified(Double.POSITIVE_INFINITY), tan_double(Double.POSITIVE_INFINITY));
+            Asserts.assertEquals(tan_double_verified(Double.NEGATIVE_INFINITY), tan_double(Double.NEGATIVE_INFINITY));
+            for (int i=0; i< 1000; i++) {
+                double d = random.nextDouble();
+                Asserts.assertEquals(tan_double_verified(d) , tan_double(d));
+            }
+        }
+
+        public static double tan_double(double a) {
+            return Math.tan(a);
+        }
+
+        public static double tan_double_verified(double a) {
+            return Math.tan(a);
+        }
+    }
+}


### PR DESCRIPTION
## Related issue(s):

https://github.com/jeandle/jeandle-jdk/issues/107

## What this PR does / why we need it:

This intrinsifies `dcos` and `dtan` for performance reasons.
Testing: tier1_compiler_jeandle linux-x86 & linux-aarch64.
