### PR TITLE
fix: Set global variables to PrivateLinkage

### DIFF
--- a/test/hotspot/jtreg/compiler/jeandle/TestVolatile.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestVolatile.java
@@ -57,7 +57,6 @@ public class TestVolatile {
             FileCheck fileCheck = new FileCheck(currentDir,
                                                 TestVolatile.class.getDeclaredMethod("test"),
                                                 false);
-            fileCheck.check("@ArrayKlass.base_offset_in_bytes = private constant i32");
             fileCheck.check("define hotspotcc void @\"TestVolatile_test");
             fileCheck.check("%3 = load atomic i8, ptr getelementptr inbounds (i8, ptr @oop_handle_0, i64 196) seq_cst, align 1");
             fileCheck.check("store atomic i32 %7, ptr getelementptr inbounds (i8, ptr @oop_handle_0, i64 192) unordered, align 4");

--- a/test/hotspot/jtreg/compiler/jeandle/fileCheck/FileCheck.java
+++ b/test/hotspot/jtreg/compiler/jeandle/fileCheck/FileCheck.java
@@ -43,7 +43,7 @@ public class FileCheck {
         this.lineIndex = 0;
 
         Class declaringClass = method.getDeclaringClass();
-        String filePrefix = declaringClass.getName().replace('.', '_') + "_" + method.getName() + "_" + getMethodSignature(method);
+        String filePrefix = declaringClass.getName().replace('.', '_') + "_" + method.getName() + "_" + getMethodSignature(method).replace('/', '_');
         String fileSuffix = ".ll";
         String optimizedFileSuffix = "-optimized.ll";
 


### PR DESCRIPTION
## Related issue(s):

issue #132 

## What this PR does / why we need it:

Set global variables to PrivateLinkage  so that the optimizer can safely remove dead ones.
