### PR TITLE
feat: Support regular expression for the IR-checking tool

### DIFF
--- a/test/hotspot/jtreg/compiler/jeandle/fileCheck/FileCheck.java
+++ b/test/hotspot/jtreg/compiler/jeandle/fileCheck/FileCheck.java
@@ -27,6 +27,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 import java.io.File;
@@ -130,6 +132,48 @@ public class FileCheck {
         content = content.replaceAll("\\s+", " ").trim();
         for (String str : this.lines) {
             if (str.contains(content)) {
+                found = true;
+                break;
+            }
+        }
+        Asserts.assertFalse(found, "File check not: " + content);
+    }
+
+    // Check whether the pattern is in the file.
+    public void checkPattern(String content) {
+        boolean found = false;
+        content = content.trim();
+        Pattern pattern = Pattern.compile(content);
+        while (this.lineIndex < lines.size()) {
+            if (pattern.matcher(lines.get(this.lineIndex)).find()) {
+                found = true;
+                this.lineIndex++;
+                break;
+            }
+            this.lineIndex++;
+        }
+        Asserts.assertTrue(found, "File check: " + content);
+    }
+
+    // Check whether the pattern is in the next line.
+    public void checkNextPattern(String content) {
+        boolean found = false;
+        content = content.trim();
+        Pattern pattern = Pattern.compile(content);
+        if (this.lineIndex < lines.size()) {
+            found = pattern.matcher(lines.get(this.lineIndex)).find();
+            this.lineIndex++;
+        }
+        Asserts.assertTrue(found, "File check next: " + content);
+    }
+
+    // Check whether the pattern isn't in the file.
+    public void checkNotPattern(String content) {
+        boolean found = false;
+        content = content.trim();
+        Pattern pattern = Pattern.compile(content);
+        for (String str : this.lines) {
+            if (pattern.matcher(str).find()) {
                 found = true;
                 break;
             }

--- a/test/hotspot/jtreg/compiler/jeandle/fileCheck/TestFileCheck.java
+++ b/test/hotspot/jtreg/compiler/jeandle/fileCheck/TestFileCheck.java
@@ -52,6 +52,23 @@ public class TestFileCheck {
             fileCheck.checkNext("%2 = add i32 %1, %0");
             fileCheck.checkNot("define private hotspotcc void @jeandle.safepoint_poll() #2 {");
         }
+        {
+            FileCheck fileCheck = new FileCheck(currentDir,
+                                                TestFileCheck.class.getDeclaredMethod("add", int.class, int.class),
+                                                false);
+            fileCheck.checkPattern("define hotspotcc i32 @\"compiler_jeandle_fileCheck_TestFileCheck_add_\\(II\\)I\"\\(i32 %[0-9]+, i32 %[0-9]+\\)");
+            fileCheck.checkNextPattern("entry:");
+            fileCheck.checkNextPattern("br label %bci_[0-9]+");
+        }
+        {
+            FileCheck fileCheck = new FileCheck(currentDir,
+                                                TestFileCheck.class.getDeclaredMethod("add", int.class, int.class),
+                                                true);
+            fileCheck.checkPattern("define hotspotcc i32 @\"compiler_jeandle_fileCheck_TestFileCheck_add_\\(II\\)I\"\\(i32 %[0-9]+, i32 %[0-9]+\\)");
+            fileCheck.checkNextPattern("entry:");
+            fileCheck.checkNextPattern("%[0-9]+ = add i32 %[0-9]+, %[0-9]+");
+            fileCheck.checkNotPattern("define private hotspotcc void @jeandle\\.safepoint_poll\\(\\) #\\d+ \\{");
+        }
 
     }
 


### PR DESCRIPTION
## Related issue(s):

issue #99

## What this PR does / why we need it:
Support regular expression for the IR-checking tool.
There is an example in test/hotspot/jtreg/compiler/jeandle/fileCheck/TestFileCheck.java
