### PR TITLE
ci: mergify configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -40,4 +40,4 @@ queue_rules:
     update_method: rebase
     name: jeandle-jdk
 merge_queue:
-  max_parallel_checks: 5
+  max_parallel_checks: 1


### PR DESCRIPTION
Disable parallel check because of after #138, draft PR for parallel check cannot be labeled correctly.