### PR TITLE
build: fix cross-compilation error with header file not found

### DIFF
--- a/make/autoconf/buildjdk-spec.gmk.in
+++ b/make/autoconf/buildjdk-spec.gmk.in
@@ -97,7 +97,7 @@ ENABLE_DEBUG_SYMBOLS := false
 
 JVM_VARIANTS := server
 JVM_VARIANT_MAIN := server
-JVM_FEATURES_server := cds compiler1 compiler2 g1gc serialgc
+JVM_FEATURES_server := cds compiler1 compiler2 jeandle g1gc serialgc
 
 # Some users still set EXTRA_*FLAGS on the make command line. Must
 # make sure to override that when building buildjdk.


### PR DESCRIPTION
## Related issue(s):

issue #165

## What this PR does / why we need it:

This patch fixes cross-compilation error. Some new patches exclude the header files according to the macro `JEANDLE` but it doesn't exclude the related implementation code. For example, in `nmethod.cpp`, the usage of `JeandleExceptionHandlerTable` has not excluded by `JEANDLE`.

```
#ifdef JEANDLE
#include "jeandle/jeandleExceptionHandlerTable.hpp" // <---- Here, it is right.
#endif

void nmethod::print_handler_table() {
  if (is_compiled_by_jeandle()) {
    JeandleExceptionHandlerTable(this).print(code_begin()); // <------ Here, it should be guarded by the macro `JEANDLE`.
  } else {
    ExceptionHandlerTable(this).print(code_begin());
  }
}
```

Although Jeandle is added to feature list by default, but when cross-compiling, feature list of build-jdk is built from `JVM_FEATURES_server` and does not include Jeandle.

Testing:
- [x] Building: host: x86_64, target: AArch64
- [x] Building: host: x86_64, target: riscv64 (you are currently unable to reproduce this test, because the RISC-V support is under development.)