### PR TITLE
enhance: mangle the dumped file's name

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -298,6 +298,7 @@ static std::string construct_dump_path(const std::string& method_name,
                                        const std::string& suffix) {
   assert(suffix == ".ll" || suffix == "_optimized.ll" || suffix == ".o", "invalid suffix for dump file of Jeandle compiler");
   std::string dump_dir = JeandleDumpDirectory ? std::string(JeandleDumpDirectory) : std::string("./");
+
   // Full name.
   std::string file_name = dump_dir + '/' + method_name + '_' + timestamp + suffix;
   // Normalize the path and remove redundant separators.
@@ -306,30 +307,8 @@ static std::string construct_dump_path(const std::string& method_name,
   return clean_path.lexically_normal().string();
 }
 
-static std::string mangle_filename(const std::string &in) {
-  std::string out;
-  out.reserve(in.size());
-
-  for (unsigned char c : in) {
-    switch (c) {
-    case '[': case ']':
-    case '(': case ';':
-      break;
-    case ')': case '-':
-    case '.': case '/':
-      if (!out.empty() && out.back() != '_')
-        out.push_back('_');
-      break;
-    default:
-      out.push_back(c);
-      break;
-    }
-  }
-  return out;
-}
-
 void JeandleCompilation::dump_obj() {
-  std::string dump_path = construct_dump_path(mangle_filename(_llvm_module->getModuleIdentifier()), _comp_start_time, ".o");
+  std::string dump_path = construct_dump_path(_llvm_module->getModuleIdentifier(), _comp_start_time, ".o");
   std::error_code err_code;
   llvm::raw_fd_ostream dump_stream(dump_path, err_code);
   if (err_code) {
@@ -342,7 +321,7 @@ void JeandleCompilation::dump_obj() {
 }
 
 void JeandleCompilation::dump_ir(bool optimized) {
-  std::string dump_path = construct_dump_path(mangle_filename(_llvm_module->getModuleIdentifier()), _comp_start_time, optimized ? "_optimized.ll" : ".ll");
+  std::string dump_path = construct_dump_path(_llvm_module->getModuleIdentifier(), _comp_start_time, optimized ? "_optimized.ll" : ".ll");
   std::error_code err_code;
   llvm::raw_fd_ostream dump_stream(dump_path, err_code, llvm::sys::fs::OF_TextWithCRLF);
 

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -60,10 +60,5 @@ std::string JeandleFuncSig::method_name(ciMethod* method) {
   std::string method_name = std::string(method->name()->as_utf8());
   std::replace(method_name.begin(), method_name.end(), '/', '_');
 
-  std::string sig_name = std::string(method->signature()->as_symbol()->as_utf8());
-  std::replace(sig_name.begin(), sig_name.end(), '/', '_');
-
-  return class_name
-         + "_" + method_name
-         + "_" + sig_name;
+  return class_name + "_" + method_name;
 }

--- a/test/hotspot/jtreg/compiler/jeandle/TestVolatile.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestVolatile.java
@@ -57,7 +57,7 @@ public class TestVolatile {
             FileCheck fileCheck = new FileCheck(currentDir,
                                                 TestVolatile.class.getDeclaredMethod("test"),
                                                 false);
-            fileCheck.check("define hotspotcc void @\"TestVolatile_test");
+            fileCheck.check("define hotspotcc void @TestVolatile_test");
             fileCheck.checkPattern("load atomic i8, ptr addrspace\\(1\\) %[0-9]+ seq_cst, align 1");
             fileCheck.checkPattern("store atomic i32 %[0-9]+, ptr addrspace\\(1\\) %[0-9]+ unordered, align 4");
             fileCheck.checkPattern("store atomic i8 0, ptr addrspace\\(1\\) %[0-9]+ seq_cst, align 1");

--- a/test/hotspot/jtreg/compiler/jeandle/fileCheck/FileCheck.java
+++ b/test/hotspot/jtreg/compiler/jeandle/fileCheck/FileCheck.java
@@ -41,26 +41,6 @@ import java.lang.reflect.Method;
 public class FileCheck {
     private int lineIndex;
     private List<String> lines;
-    private static String mangleFilename(String in) {
-        StringBuilder out = new StringBuilder(in.length());
-        for (char c : in.toCharArray()) {
-            switch (c) {
-                case '[': case ']':
-                case '(': case ';':
-                    break;
-                case ')': case '-':
-                case '.': case '/':
-                    if (out.length() > 0 && out.charAt(out.length() - 1) != '_') {
-                        out.append('_');
-                    }
-                    break;
-                default:
-                    out.append(c);
-                    break;
-            }
-        }
-        return out.toString();
-    }
 
     public FileCheck(String path, Method method, boolean optimized) throws Exception {
         this(path, method, optimized, 0);
@@ -70,7 +50,7 @@ public class FileCheck {
         this.lineIndex = 0;
 
         Class declaringClass = method.getDeclaringClass();
-        String filePrefix = mangleFilename(declaringClass.getName() + "_" + method.getName() + "_" + getMethodSignature(method));
+        String filePrefix = declaringClass.getName().replace('.', '_') + "_" + method.getName();
         String fileSuffix = ".ll";
         String optimizedFileSuffix = "_optimized.ll";
 

--- a/test/hotspot/jtreg/compiler/jeandle/fileCheck/TestFileCheck.java
+++ b/test/hotspot/jtreg/compiler/jeandle/fileCheck/TestFileCheck.java
@@ -39,7 +39,7 @@ public class TestFileCheck {
             FileCheck fileCheck = new FileCheck(currentDir,
                                                 TestFileCheck.class.getDeclaredMethod("add", int.class, int.class),
                                                 false);
-            fileCheck.check("define hotspotcc i32 @\"compiler_jeandle_fileCheck_TestFileCheck_add_(II)I\"(i32 %0, i32 %1)");
+            fileCheck.check("define hotspotcc i32 @compiler_jeandle_fileCheck_TestFileCheck_add");
             fileCheck.checkNext("entry:");
             fileCheck.checkNext("br label %bci_0");
         }
@@ -47,7 +47,7 @@ public class TestFileCheck {
             FileCheck fileCheck = new FileCheck(currentDir,
                                                 TestFileCheck.class.getDeclaredMethod("add", int.class, int.class),
                                                 true);
-            fileCheck.check("define hotspotcc i32 @\"compiler_jeandle_fileCheck_TestFileCheck_add_(II)I\"(i32 %0, i32 %1)");
+            fileCheck.check("define hotspotcc i32 @compiler_jeandle_fileCheck_TestFileCheck_add");
             fileCheck.checkNext("entry:");
             fileCheck.checkNext("%2 = add i32 %1, %0");
             fileCheck.checkNot("define private hotspotcc void @jeandle.safepoint_poll() #2 {");
@@ -56,7 +56,7 @@ public class TestFileCheck {
             FileCheck fileCheck = new FileCheck(currentDir,
                                                 TestFileCheck.class.getDeclaredMethod("add", int.class, int.class),
                                                 false);
-            fileCheck.checkPattern("define hotspotcc i32 @\"compiler_jeandle_fileCheck_TestFileCheck_add_\\(II\\)I\"\\(i32 %[0-9]+, i32 %[0-9]+\\)");
+            fileCheck.checkPattern("define hotspotcc i32 @compiler_jeandle_fileCheck_TestFileCheck_add");
             fileCheck.checkNextPattern("entry:");
             fileCheck.checkNextPattern("br label %bci_[0-9]+");
         }
@@ -64,7 +64,7 @@ public class TestFileCheck {
             FileCheck fileCheck = new FileCheck(currentDir,
                                                 TestFileCheck.class.getDeclaredMethod("add", int.class, int.class),
                                                 true);
-            fileCheck.checkPattern("define hotspotcc i32 @\"compiler_jeandle_fileCheck_TestFileCheck_add_\\(II\\)I\"\\(i32 %[0-9]+, i32 %[0-9]+\\)");
+            fileCheck.checkPattern("define hotspotcc i32 @compiler_jeandle_fileCheck_TestFileCheck_add");
             fileCheck.checkNextPattern("entry:");
             fileCheck.checkNextPattern("%[0-9]+ = add i32 %[0-9]+, %[0-9]+");
             fileCheck.checkNotPattern("define private hotspotcc void @jeandle\\.safepoint_poll\\(\\) #\\d+ \\{");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsDouble.java
@@ -56,7 +56,7 @@ public class TestAbsDouble {
         // Verify llvm IR
         FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("abs_double", double.class), false);
         // find compiled method
-        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestAbsDouble$TestWrapper_abs_double_(D)D\"(double %0)");
+        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestAbsDouble$TestWrapper_abs_double");
         // check IR
         checker.checkNext("entry:");
         checker.checkNext("br label %bci_0");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsFloat.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsFloat.java
@@ -56,7 +56,7 @@ public class TestAbsFloat {
         // Verify llvm IR
         FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("abs_float", float.class), false);
         // find compiled method
-        checker.check("define hotspotcc float @\"compiler_jeandle_intrinsic_TestAbsFloat$TestWrapper_abs_float_(F)F\"(float %0)");
+        checker.check("define hotspotcc float @\"compiler_jeandle_intrinsic_TestAbsFloat$TestWrapper_abs_float");
         // check IR
         checker.checkNext("entry:");
         checker.checkNext("br label %bci_0");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsInt.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsInt.java
@@ -56,7 +56,7 @@ public class TestAbsInt {
         FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("abs_int", int.class), false);
         // find compiled method
         checker.check(
-                "define hotspotcc i32 @\"compiler_jeandle_intrinsic_TestAbsInt$TestWrapper_abs_int_(I)I\"(i32 %0)");
+                "define hotspotcc i32 @\"compiler_jeandle_intrinsic_TestAbsInt$TestWrapper_abs_int");
         // check IR
         checker.checkNext("entry:");
         checker.checkNext("br label %bci_0");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsLong.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsLong.java
@@ -56,7 +56,7 @@ public class TestAbsLong {
         FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("abs_long", long.class), false);
         // find compiled method
         checker.check(
-                "define hotspotcc i64 @\"compiler_jeandle_intrinsic_TestAbsLong$TestWrapper_abs_long_(J)J\"(i64 %0)");
+                "define hotspotcc i64 @\"compiler_jeandle_intrinsic_TestAbsLong$TestWrapper_abs_long");
         // check IR
         checker.checkNext("entry:");
         checker.checkNext("br label %bci_0");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestCosDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestCosDouble.java
@@ -63,7 +63,7 @@ public class TestCosDouble {
         // Verify llvm IR
         FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("cos_double", double.class), false);
         // find compiled method
-        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestCosDouble$TestWrapper_cos_double_(D)D\"(double %0)");
+        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestCosDouble$TestWrapper_cos_double");
         // check IR
         checker.checkNext("entry:");
         checker.checkNext("br label %bci_0");
@@ -93,7 +93,7 @@ public class TestCosDouble {
             // Verify llvm IR
             checker = new FileCheck(dump_path, TestWrapper.class.getMethod("cos_double", double.class), false);
             // find compiled method
-            checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestCosDouble$TestWrapper_cos_double_(D)D\"(double %0)");
+            checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestCosDouble$TestWrapper_cos_double");
             // check IR
             checker.checkNext("entry:");
             checker.checkNext("br label %bci_0");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestSinDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestSinDouble.java
@@ -63,7 +63,7 @@ public class TestSinDouble {
         // Verify llvm IR
         FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("sin_double", double.class), false);
         // find compiled method
-        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestSinDouble$TestWrapper_sin_double_(D)D\"(double %0)");
+        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestSinDouble$TestWrapper_sin_double");
         // check IR
         checker.checkNext("entry:");
         checker.checkNext("br label %bci_0");
@@ -93,7 +93,7 @@ public class TestSinDouble {
             // Verify llvm IR
             checker = new FileCheck(dump_path, TestWrapper.class.getMethod("sin_double", double.class), false);
             // find compiled method
-            checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestSinDouble$TestWrapper_sin_double_(D)D\"(double %0)");
+            checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestSinDouble$TestWrapper_sin_double");
             // check IR
             checker.checkNext("entry:");
             checker.checkNext("br label %bci_0");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestTanDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestTanDouble.java
@@ -62,7 +62,7 @@ public class TestTanDouble {
             // Verify llvm IR
             FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("tan_double", double.class), false);
             // find compiled method
-            checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestTanDouble$TestWrapper_tan_double_(D)D\"(double %0)");
+            checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestTanDouble$TestWrapper_tan_double");
             // check IR
             checker.checkNext("entry:");
             checker.checkNext("br label %bci_0");
@@ -94,7 +94,7 @@ public class TestTanDouble {
         // Verify llvm IR
         FileCheck checker = new FileCheck(dump_path, TestWrapper.class.getMethod("tan_double", double.class), false);
         // find compiled method
-        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestTanDouble$TestWrapper_tan_double_(D)D\"(double %0)");
+        checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestTanDouble$TestWrapper_tan_double");
         // check IR
         checker.checkNext("entry:");
         checker.checkNext("br label %bci_0");


### PR DESCRIPTION
## Related issue(s):

issue #
#149 
## What this PR does / why we need it:

### dump_ir:
- Current:
   compiler_jeandle_intrinsic_TestAbsDouble$TestWrapper_abs_double_(D)D_1763961011517.ll
- After mangling:
   compiler_jeandle_intrinsic_TestAbsDouble$TestWrapper_abs_double_1763967796878.ll