### PR TITLE
feat: Change relocation model to PIC

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompiler.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiler.cpp
@@ -58,7 +58,7 @@ JeandleCompiler* JeandleCompiler::create() {
   options.EmitStackSizeSection = true;
 
   llvm::TargetMachine* target_machine = target->createTargetMachine(target_triple.getTriple(), ""/* CPU */, features.getString(), options,
-                                                                    llvm::Reloc::Model::Static, llvm::CodeModel::Model::Small,
+                                                                    llvm::Reloc::Model::PIC_, llvm::CodeModel::Model::Small,
                                                                     llvm::CodeGenOptLevel::Aggressive, true/* JIT */);
 
   return new JeandleCompiler(target_machine);


### PR DESCRIPTION
## What this PR does / why we need it:

Prior to this, Jeandle had been using the small code model and the static relocation model. However, this approach did not fully align with the requirements of the code cache in the JVM. For instance, on RISC-V, it led LLVM to assume that all symbols were located within the lower or upper 2GB address space. Similarly, on x86, LLVM would assume that all symbols resided in the address range from 0x00000000 to 0x7effffff, which could cause potential issues. Therefore, this PR changes the relocation model to PIC (Position-Independent Code), thereby eliminating LLVM's assumptions about the symbol address space.
