### PR TITLE
fix: confirm the stub code section has enough space to avoid expanding and relocating when patching

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -60,7 +60,10 @@ void JeandleAssembler::patch_static_call_site(int inst_offset, CallSiteInfo* cal
 
   // The following `set_insts_end` conflicts with code buffer expansion,
   // we need to confirm that stub code section has enough space before invoking `set_insts_end`.
-  __ code()->stubs()->maybe_expand_to_ensure_remaining(__ max_trampoline_stub_size());
+  int required_space = __ max_trampoline_stub_size();
+  if (__ code()->stubs()->maybe_expand_to_ensure_remaining(required_space)) {
+    guarantee(__ code()->blob() != nullptr, "CodeCache is full");
+  }
 
   address call_address = __ addr_at(inst_offset);
 
@@ -117,7 +120,10 @@ void JeandleAssembler::patch_ic_call_site(int inst_offset, CallSiteInfo* call) {
 
   // The following `set_insts_end` conflicts with code buffer expansion,
   // we need to confirm that stub code section has enough space before invoking `set_insts_end`.
-  __ code()->stubs()->maybe_expand_to_ensure_remaining(__ max_trampoline_stub_size());
+  int required_space = __ max_trampoline_stub_size();
+  if (__ code()->stubs()->maybe_expand_to_ensure_remaining(required_space)) {
+    guarantee(__ code()->blob() != nullptr, "CodeCache is full");
+  }
 
   address call_address = __ addr_at(inst_offset);
 

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -122,7 +122,10 @@ void JeandleAssembler::patch_external_call_site(int inst_offset, CallSiteInfo* c
 
   // The following `set_insts_end` conflicts with code buffer expansion,
   // we need to confirm that stub code section has enough space before invoking `set_insts_end`.
-  __ code()->stubs()->maybe_expand_to_ensure_remaining(__ max_trampoline_stub_size());
+  int required_space = __ max_trampoline_stub_size();
+  if (__ code()->stubs()->maybe_expand_to_ensure_remaining(required_space)) {
+    guarantee(__ code()->blob() != nullptr, "CodeCache is full");
+  }
 
   address call_address = __ addr_at(inst_offset);
 #ifdef ASSERT


### PR DESCRIPTION
## What this PR does / why we need it:

When using `set_insts_end` to set the instruction end address, we need to confirm the stub code section has enough space and doesn't expand during patching. This patch invokes `CodeSection::maybe_expand_to_ensure_remaining` at the beginning of some `patch_*` method which can avoid the expansion and relocation of the code buffer.