### PR TITLE
fix: invalidate instruction cache after patching data value

### DIFF
--- a/src/hotspot/cpu/aarch64/relocInfo_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/relocInfo_aarch64.cpp
@@ -125,6 +125,7 @@ void Relocation::pd_set_jeandle_data_value(address x, bool verify_only) {
   } else {
     ShouldNotReachHere();
   }
+  ICache::invalidate_range(insn_addr, NativeInstruction::instruction_size);
 }
 
 void trampoline_stub_Relocation::pd_fix_owner_after_move() {


### PR DESCRIPTION
## What this PR does / why we need it:

This patch adds statement to invalidate instruction cache after patching data value in AArch64.