### PR TITLE
enhance: Add unified macros for Jeandle error handling and early return

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -38,7 +38,7 @@ void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call
   // same as C1 call_stub_size()
   const int stub_size = 13 * NativeInstruction::instruction_size;
   address stub = __ start_a_stub(stub_size);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(stub != nullptr, "static call stub overflow");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(stub != nullptr, "static call stub overflow");
 
   int start = __ offset();
 
@@ -60,7 +60,7 @@ void JeandleAssembler::patch_static_call_site(int inst_offset, CallSiteInfo* cal
   int required_space = __ max_trampoline_stub_size();
   if (MacroAssembler::far_branches() &&
       __ code()->stubs()->maybe_expand_to_ensure_remaining(required_space)) {
-    CHECK_AND_REPORT_JEANDLE_ERROR_VOID(__ code()->blob() != nullptr, "trampoline stub overflow");
+    JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(__ code()->blob() != nullptr, "trampoline stub overflow");
   }
 
   address call_address = __ addr_at(inst_offset);
@@ -78,7 +78,7 @@ void JeandleAssembler::patch_static_call_site(int inst_offset, CallSiteInfo* cal
   Address call_addr = Address(call->target(), rtype);
   // emit trampoline call for patch
   address tpc = __ trampoline_call(call_addr);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(tpc != nullptr, "trampoline stub overflow");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(tpc != nullptr, "trampoline stub overflow");
   __ code()->set_insts_end(__ code()->insts_begin() + insts_end_offset);
 }
 
@@ -108,7 +108,7 @@ void JeandleAssembler::patch_routine_call_site(int inst_offset, address target) 
   __ code()->set_insts_end(call_pc);
 
   address tpc = __ trampoline_call(Address(target, relocInfo::runtime_call_type));
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(tpc != nullptr, "trampoline stub overflow");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(tpc != nullptr, "trampoline stub overflow");
 
   // Recover insts_end
   __ code()->set_insts_end(__ code()->insts_begin() + insts_end_offset);
@@ -123,7 +123,7 @@ void JeandleAssembler::patch_ic_call_site(int inst_offset, CallSiteInfo* call) {
   int required_space = __ max_trampoline_stub_size();
   if (MacroAssembler::far_branches() &&
       __ code()->stubs()->maybe_expand_to_ensure_remaining(required_space)) {
-    CHECK_AND_REPORT_JEANDLE_ERROR_VOID(__ code()->blob() != nullptr, "trampoline stub overflow");
+    JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(__ code()->blob() != nullptr, "trampoline stub overflow");
   }
 
   address call_address = __ addr_at(inst_offset);
@@ -134,7 +134,7 @@ void JeandleAssembler::patch_ic_call_site(int inst_offset, CallSiteInfo* call) {
 
   // Patch
   address tpc = __ ic_call(call->target());
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(tpc != nullptr, "trampoline stub overflow");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(tpc != nullptr, "trampoline stub overflow");
 
   // Restore insts_end
   __ code()->set_insts_end(__ code()->insts_begin() + insts_end_offset);
@@ -148,7 +148,7 @@ void JeandleAssembler::patch_external_call_site(int inst_offset, CallSiteInfo* c
   // we need to confirm that stub code section has enough space before invoking `set_insts_end`.
   int required_space = __ max_trampoline_stub_size();
   if (__ code()->stubs()->maybe_expand_to_ensure_remaining(required_space)) {
-    CHECK_AND_REPORT_JEANDLE_ERROR_VOID(__ code()->blob() != nullptr, "trampoline stub overflow");
+    JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(__ code()->blob() != nullptr, "trampoline stub overflow");
   }
 
   address call_address = __ addr_at(inst_offset);
@@ -163,7 +163,7 @@ void JeandleAssembler::patch_external_call_site(int inst_offset, CallSiteInfo* c
 
   // Patch.
   address tpc = __ trampoline_call(Address(call->target(), relocInfo::runtime_call_type));
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(tpc != nullptr, "trampoline stub overflow");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(tpc != nullptr, "trampoline stub overflow");
 
   // Recover insts_end.
   __ code()->set_insts_end(__ code()->insts_begin() + insts_end_offset);
@@ -198,7 +198,7 @@ int JeandleAssembler::interior_entry_alignment() const {
 int JeandleAssembler::emit_exception_handler() {
   int stub_size = __ far_codestub_branch_size();
   address base = __ start_a_stub(stub_size);
-  CHECK_AND_REPORT_JEANDLE_ERROR_RETURNVAL(base != nullptr, "exception handler stub overflow", 0);
+  JEANDLE_ERROR_ASSERT_AND_RET_ON_FAIL(base != nullptr, "exception handler stub overflow", 0);
   int offset = __ offset();
   __ far_jump(RuntimeAddress(JeandleRuntimeRoutine::get_routine_entry(JeandleRuntimeRoutine::_exception_handler)));
   assert(__ offset() - offset <= stub_size, "overflow");

--- a/src/hotspot/cpu/aarch64/jeandleCompiledCode_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleCompiledCode_aarch64.cpp
@@ -25,7 +25,7 @@
 void JeandleCompiledCode::setup_frame_size() {
   SectionInfo section_info(".stack_sizes");
   bool found = ReadELF::findSection(*_elf, section_info);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(found, ".stack_sizes section not found");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(found, ".stack_sizes section not found");
 
   llvm::DataExtractor data_extractor(llvm::StringRef(((char*)_obj->getBufferStart()) + section_info._offset, section_info._size),
                                      true/* IsLittleEndian */, BytesPerWord/* AddressSize */);

--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -38,7 +38,7 @@ void JeandleAssembler::emit_static_call_stub(int inst_offset, CallSiteInfo* call
 
   int stub_size = 28;
   address stub = __ start_a_stub(stub_size);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(stub != nullptr, "static call stub overflow");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(stub != nullptr, "static call stub overflow");
 
   int start = __ offset();
 
@@ -121,7 +121,7 @@ void JeandleAssembler::patch_external_call_site(int inst_offset, CallSiteInfo* c
   // we need to confirm that stub code section has enough space before invoking `set_insts_end`.
   int required_space = __ max_trampoline_stub_size();
   if (__ code()->stubs()->maybe_expand_to_ensure_remaining(required_space)) {
-    CHECK_AND_REPORT_JEANDLE_ERROR_VOID(__ code()->blob() != nullptr, "trampoline stub overflow");
+    JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(__ code()->blob() != nullptr, "trampoline stub overflow");
   }
 
   address call_address = __ addr_at(inst_offset);
@@ -136,7 +136,7 @@ void JeandleAssembler::patch_external_call_site(int inst_offset, CallSiteInfo* c
 
   // Patch.
   address tpc = __ trampoline_call(AddressLiteral(call->target(), relocInfo::none));
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(tpc != nullptr, "trampoline stub overflow");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(tpc != nullptr, "trampoline stub overflow");
 
   // Recover insts_end.
   __ code()->set_insts_end(__ code()->insts_begin() + insts_end_offset);
@@ -171,7 +171,7 @@ int JeandleAssembler::interior_entry_alignment() const {
 
 int JeandleAssembler::emit_exception_handler() {
   address base = __ start_a_stub(NativeJump::instruction_size);
-  CHECK_AND_REPORT_JEANDLE_ERROR_RETURNVAL(base != nullptr, "exception handler stub overflow", 0);
+  JEANDLE_ERROR_ASSERT_AND_RET_ON_FAIL(base != nullptr, "exception handler stub overflow", 0);
   int offset = __ offset();
   __ jump(RuntimeAddress(JeandleRuntimeRoutine::get_routine_entry(JeandleRuntimeRoutine::_exception_handler)));
   assert(__ offset() - offset <= (int)NativeJump::instruction_size, "overflow");

--- a/src/hotspot/cpu/x86/jeandleCompiledCode_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleCompiledCode_x86.cpp
@@ -25,7 +25,7 @@
 void JeandleCompiledCode::setup_frame_size() {
   SectionInfo section_info(".stack_sizes");
   bool found = ReadELF::findSection(*_elf, section_info);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(found, ".stack_sizes section not found");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(found, ".stack_sizes section not found");
 
   llvm::DataExtractor data_extractor(llvm::StringRef(((char*)_obj->getBufferStart()) + section_info._offset, section_info._size),
                                      true/* IsLittleEndian */, BytesPerWord/* AddressSize */);

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -620,7 +620,7 @@ void JeandleAbstractInterpreter::interpret() {
   bool merged = current->merge_VM_state_from(_block_builder->entry_block()->VM_state(),
                                              _block_builder->entry_block()->tail_llvm_block(),
                                              _method);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(merged, "failed to create initial VM state");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(merged, "failed to create initial VM state");
 
   // Iterate all blocks
   while (_work_list.size() > 0) {
@@ -629,7 +629,7 @@ void JeandleAbstractInterpreter::interpret() {
     current->clear(JeandleBasicBlock::is_on_work_list);
 
     interpret_block(current);
-    CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+    RETURN_VOID_ON_JEANDLE_ERROR();
   }
 
   _block_builder->remove_dead_blocks();
@@ -945,7 +945,7 @@ void JeandleAbstractInterpreter::interpret_block(JeandleBasicBlock* block) {
     }
   }
 
-  CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+  RETURN_VOID_ON_JEANDLE_ERROR();
 
   // All blocks should has their terminator.
   if (block->tail_llvm_block()->getTerminator() == nullptr) {
@@ -958,7 +958,7 @@ void JeandleAbstractInterpreter::interpret_block(JeandleBasicBlock* block) {
   for (JeandleBasicBlock* suc : block->successors()) {
     // Don't update handlers' VM state here. They are updated by exception throwers.
     if (!suc->is_exception_handler() && !suc->merge_VM_state_from(block->VM_state(), block->tail_llvm_block(), _method)) {
-      CHECK_AND_REPORT_JEANDLE_ERROR_VOID(false, "failed to merge VM state into successor block");
+      JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(false, "failed to merge VM state into successor block");
     }
 
     if (!suc->is_set(JeandleBasicBlock::is_compiled)) {
@@ -1255,7 +1255,7 @@ void JeandleAbstractInterpreter::invoke() {
 
   // Every invoke instruction may throw exceptions, handle them here.
   DispatchedDest dispatched = dispatch_exception_for_invoke();
-  CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+  RETURN_VOID_ON_JEANDLE_ERROR();
 
   // Create the invoke instruction with deopt operands.
   llvm::OperandBundleDef deopt_bundle("deopt", _jvm->deopt_args(_ir_builder));
@@ -1394,7 +1394,7 @@ llvm::InvokeInst* JeandleAbstractInterpreter::create_call_ex(llvm::FunctionCalle
 
   // Handle exceptions for the routine.
   DispatchedDest dispatched = dispatch_exception_for_invoke();
-  CHECK_JEANDLE_ERROR_AND_RETURN_VAL(nullptr);
+  RETURN_ON_JEANDLE_ERROR(nullptr);
 
   // Create the invoke instruction.
   llvm::InvokeInst* invoke = _ir_builder.CreateInvoke(callee, dispatched._normal_dest, dispatched._unwind_dest, args);
@@ -1557,7 +1557,7 @@ void JeandleAbstractInterpreter::checkcast() {
   store_inst->setAtomic(llvm::AtomicOrdering::Unordered);
 
   dispatch_exception_to_handler(exception_oop);
-  CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+  RETURN_VOID_ON_JEANDLE_ERROR();
 
   _ir_builder.SetInsertPoint(checkcast_pass);
   _block->set_tail_llvm_block(checkcast_pass);
@@ -2030,7 +2030,7 @@ JeandleAbstractInterpreter::DispatchedDest JeandleAbstractInterpreter::dispatch_
                           true /* is_volatile */);
 
   dispatch_exception_to_handler(exception_oop);
-  CHECK_JEANDLE_ERROR_AND_RETURN_VAL(dispatched);
+  RETURN_ON_JEANDLE_ERROR(dispatched);
 
   // Recover insert point.
   _ir_builder.SetInsertPoint(saved_insert_block, saved_insert_point);
@@ -2061,7 +2061,7 @@ void JeandleAbstractInterpreter::dispatch_exception_to_handler(llvm::Value* exce
       bool merged = handler_block->merge_VM_state_from(_jvm->copy_for_exception_handler(exception_oop),
                                                        _ir_builder.GetInsertBlock(),
                                                        _method);
-      CHECK_AND_REPORT_JEANDLE_ERROR_VOID(merged, "failed to update handler's VM state");
+      JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(merged, "failed to update handler's VM state");
       _ir_builder.CreateBr(handler_block->header_llvm_block());
       return;
     }
@@ -2086,7 +2086,7 @@ void JeandleAbstractInterpreter::dispatch_exception_to_handler(llvm::Value* exce
       bool merged = handler_block->merge_VM_state_from(_jvm->copy_for_exception_handler(exception_oop),
                                                        _ir_builder.GetInsertBlock(),
                                                        _method);
-      CHECK_AND_REPORT_JEANDLE_ERROR_VOID(merged, "failed to update handler's VM state");
+      JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(merged, "failed to update handler's VM state");
       llvm::Value* cond = _ir_builder.CreateICmpEQ(match, _ir_builder.getInt32(1));
       _ir_builder.CreateCondBr(cond, match_dest, next_dest);
       _ir_builder.SetInsertPoint(next_dest);
@@ -2201,7 +2201,7 @@ void JeandleAbstractInterpreter::multianewarray() {
     llvm::Value* dimensions_array_length = _ir_builder.getInt32(ndimensions);
 
     llvm::InvokeInst* dimensions_array_oop = call_java_op_ex("jeandle.newarray",{int_array_klass_ptr, dimensions_array_length});
-    CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+    RETURN_VOID_ON_JEANDLE_ERROR();
 
     llvm::Value* array_base_offset = _ir_builder.CreateLoad(llvm::Type::getInt32Ty(*_context),
                                                             _module.getGlobalVariable("arrayOopDesc.base_offset_in_bytes.int", true));

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -101,6 +101,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                        _data_layout(data_layout),
                                        _env(env),
                                        _method(method),
+                                       _name(method->get_Method()->name_and_sig_as_C_string()),
                                        _entry_bci(entry_bci),
                                        _context(std::make_unique<llvm::LLVMContext>()),
                                        _code(env, method),
@@ -147,6 +148,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                        _data_layout(data_layout),
                                        _env(env),
                                        _method(nullptr),
+                                       _name(name),
                                        _entry_bci(-1),
                                        _context(std::move(context)),
                                        _llvm_module(std::make_unique<llvm::Module>(name, *_context)),
@@ -246,7 +248,7 @@ void JeandleCompilation::setup_llvm_module(llvm::MemoryBuffer* template_buffer) 
   // Get template module from the global memory buffer.
   llvm::Expected<std::unique_ptr<llvm::Module>> module_or_error =
       parseBitcodeFile(template_buffer->getMemBufferRef(), *_context);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(module_or_error, "Failed to parse template bitcode");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(module_or_error, "Failed to parse template bitcode");
   _llvm_module = std::move(module_or_error.get());
   assert(_llvm_module != nullptr, "invalid llvm module");
 
@@ -268,7 +270,7 @@ void JeandleCompilation::compile_java_method() {
     dump_ir(false);
   }
 
-  CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+  RETURN_VOID_ON_JEANDLE_ERROR();
 
 #ifdef ASSERT
   // Verify.
@@ -298,7 +300,7 @@ void JeandleCompilation::compile_java_method() {
     dump_obj();
   }
 
-  CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+  RETURN_VOID_ON_JEANDLE_ERROR();
 
   // Unpack LLVM code information. Generate relocations, stubs and debug information.
   {
@@ -320,7 +322,7 @@ void JeandleCompilation::compile_module() {
     llvm::MCContext *ctx;
 
     bool unsupported = _target_machine->addPassesToEmitMC(pm, ctx, obj_stream);
-    CHECK_AND_REPORT_JEANDLE_ERROR_VOID(!unsupported, "target does not support MC emission");
+    JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(!unsupported, "target does not support MC emission");
 
     pm.run(*_llvm_module);
   }

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -60,14 +60,6 @@ class JeandleCompilation : public StackObj {
 
   static JeandleCompilation* current() { return (JeandleCompilation*) ciEnv::current()->compiler_data(); }
 
-  const char* name() {
-    if (_method != nullptr) {
-      return _method->name()->as_utf8();
-    } else {
-      return _llvm_module->getName().data();
-    }
-  }
-
   // Error related:
   void report_error(const char* msg) {
     if (msg != nullptr) {
@@ -83,12 +75,15 @@ class JeandleCompilation : public StackObj {
 
   Arena* arena() { return _arena; }
 
+  const std::string name() { return _name; }
+
  private:
   Arena* _arena; // Hold compilation life-time objects (JeandleCompilationResourceObj).
   llvm::TargetMachine* _target_machine;
   llvm::DataLayout* _data_layout;
   ciEnv* _env;
   ciMethod* _method;
+  const std::string _name;
   int _entry_bci;
   std::unique_ptr<llvm::LLVMContext> _context;
   std::unique_ptr<llvm::Module> _llvm_module;
@@ -113,14 +108,14 @@ class JeandleCompilation : public StackObj {
 #define JEANDLE_CRASH_ON_ERROR(_error_msg)                            \
 do {                                                                  \
   if (JeandleCrashOnError) {                                          \
-    fatal("Compilation failed in '%s': %s", JeandleCompilation::current()->name(), _error_msg); \
+    fatal("Compilation failed in '%s': %s", JeandleCompilation::current()->name().c_str(), _error_msg); \
   }                                                                   \
 } while (0)
 #else
 #define JEANDLE_CRASH_ON_ERROR(_error_msg) (void)(0)
 #endif
 
-#define CHECK_AND_REPORT_JEANDLE_ERROR_VOID(p, msg)                   \
+#define JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(p, msg)             \
 do {                                                                  \
   if (!(p)) {                                                         \
     JeandleCompilation::report_jeandle_error(msg);                    \
@@ -129,7 +124,7 @@ do {                                                                  \
   }                                                                   \
 } while (0)
 
-#define CHECK_AND_REPORT_JEANDLE_ERROR_RETURNVAL(p, msg, return_val)  \
+#define JEANDLE_ERROR_ASSERT_AND_RET_ON_FAIL(p, msg, return_val)      \
 do {                                                                  \
   if (!(p)) {                                                         \
     JeandleCompilation::report_jeandle_error(msg);                    \
@@ -138,14 +133,14 @@ do {                                                                  \
   }                                                                   \
 } while (0)
 
-#define CHECK_JEANDLE_ERROR_AND_RETURN_VOID()                         \
+#define RETURN_VOID_ON_JEANDLE_ERROR()                                \
 do {                                                                  \
   if (JeandleCompilation::jeandle_error_occurred()) {                 \
     return;                                                           \
   }                                                                   \
 } while (0)
 
-#define CHECK_JEANDLE_ERROR_AND_RETURN_VAL(return_val)                \
+#define RETURN_ON_JEANDLE_ERROR(return_val)                           \
 do {                                                                  \
   if (JeandleCompilation::jeandle_error_occurred()) {                 \
     return return_val;                                                \

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -113,7 +113,7 @@ class JeandleCallReloc : public JeandleReloc {
     switch (_call->type()) {
       case JeandleCompiledCall::STATIC_CALL:
         assembler.emit_static_call_stub(offset(), _call);
-        CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+        RETURN_VOID_ON_JEANDLE_ERROR();
         assembler.patch_static_call_site(offset(), _call);
         break;
 
@@ -123,18 +123,18 @@ class JeandleCallReloc : public JeandleReloc {
 
       case JeandleCompiledCall::DYNAMIC_CALL:
         assembler.patch_ic_call_site(offset(), _call);
-        CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+        RETURN_VOID_ON_JEANDLE_ERROR();
         break;
 
       case JeandleCompiledCall::ROUTINE_CALL:
         assembler.patch_routine_call_site(offset(), _call->target());
-        CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+        RETURN_VOID_ON_JEANDLE_ERROR();
         break;
 
       case JeandleCompiledCall::EXTERNAL_CALL:
         assert(_oop_map == nullptr, "no oopmap in external call");
         assembler.patch_external_call_site(offset(), _call);
-        CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+        RETURN_VOID_ON_JEANDLE_ERROR();
         break;
       default:
         ShouldNotReachHere();
@@ -215,10 +215,10 @@ void JeandleCompiledCode::install_obj(std::unique_ptr<ObjectBuffer> obj) {
   _obj = std::move(obj);
   llvm::MemoryBufferRef memory_buffer = _obj->getMemBufferRef();
   auto elf_or_error = llvm::object::ObjectFile::createELFObjectFile(memory_buffer);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(elf_or_error, "bad ELF file");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(elf_or_error, "bad ELF file");
 
   _elf = llvm::dyn_cast<ELFObject>(*elf_or_error);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(_elf, "bad ELF file");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(_elf, "bad ELF file");
 }
 
 void JeandleCompiledCode::finalize() {
@@ -227,10 +227,10 @@ void JeandleCompiledCode::finalize() {
   uint64_t offset;
   uint64_t code_size;
   bool found = ReadELF::findFunc(*_elf, _func_name, align, offset, code_size);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(found, "compiled function is not found in the ELF file");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(found, "compiled function is not found in the ELF file");
 
   setup_frame_size();
-  CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+  RETURN_VOID_ON_JEANDLE_ERROR();
   assert(_frame_size > 0, "frame size must be positive");
 
   // An estimated initial value.
@@ -276,20 +276,20 @@ void JeandleCompiledCode::finalize() {
   assembler.emit_insts(((address) _obj->getBufferStart()) + offset, code_size);
 
   resolve_reloc_info(assembler);
-  CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+  RETURN_VOID_ON_JEANDLE_ERROR();
 
   if (_method) {
     // For Java method compilation.
     build_exception_handler_table();
     _offsets.set_value(CodeOffsets::Exceptions, assembler.emit_exception_handler());
-    CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+    RETURN_VOID_ON_JEANDLE_ERROR();
   }
 
   build_implicit_exception_table();
 
   // generate shared trampoline stubs
   bool success = _code_buffer.finalize_stubs();
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(success, "shared stub overflow");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(success, "shared stub overflow");
 
   // No deopt support now.
   _offsets.set_value(CodeOffsets::Deopt, 0);
@@ -302,7 +302,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
   auto ssp = std::make_shared<llvm::orc::SymbolStringPool>();
 
   auto graph_or_err = llvm::jitlink::createLinkGraphFromObject(_elf->getMemoryBufferRef(), ssp);
-  CHECK_AND_REPORT_JEANDLE_ERROR_VOID(graph_or_err, "failed to create LinkGraph");
+  JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(graph_or_err, "failed to create LinkGraph");
 
   auto link_graph = std::move(*graph_or_err);
 
@@ -329,7 +329,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
       } else if (JeandleAssembler::is_external_call_reloc(target, edge.getKind())) {
         // External call relocations.
         address target_addr = (address)DynamicLibrary::SearchForAddressOfSymbol(target_name.str().c_str());
-        CHECK_AND_REPORT_JEANDLE_ERROR_VOID(target_addr, "failed to find external symbol");
+        JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(target_addr, "failed to find external symbol");
 
         int inst_end_offset = JeandleAssembler::fixup_call_inst_offset(static_cast<int>(block->getAddress().getValue() + edge.getOffset()));
 
@@ -389,7 +389,7 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
   for (JeandleReloc* reloc : relocs) {
     reloc->fixup_offset(_prolog_length);
     reloc->emit_reloc(assembler);
-    CHECK_JEANDLE_ERROR_AND_RETURN_VOID();
+    RETURN_VOID_ON_JEANDLE_ERROR();
   }
 }
 
@@ -399,7 +399,7 @@ address JeandleCompiledCode::lookup_const_section(llvm::StringRef name, JeandleA
     // Copy to CodeBuffer if const section is not found.
     SectionInfo section_info(name);
     bool found = ReadELF::findSection(*_elf, section_info);
-    CHECK_AND_REPORT_JEANDLE_ERROR_RETURNVAL(found, "const section not found, bad ELF file", nullptr);
+    JEANDLE_ERROR_ASSERT_AND_RET_ON_FAIL(found, "const section not found, bad ELF file", nullptr);
 
     address target_base = _code_buffer.consts()->end();
     _const_sections.insert({name, target_base});


### PR DESCRIPTION
## Related issue(s):

issue #249 

## What this PR does / why we need it:

Introduce a set of macros to standardize error checking and early returns in Jeandle compilation:

- `JEANDLE_CRASH_ON_ERROR`: crash in debug builds if `JeandleCrashOnError` enabled.
- `JEANDLE_ERROR_ASSERT_AND_RET_[VOID_]ON_FAIL`: check condition + report + [crash +] return.
- `RETURN_[VOID_]ON_JEANDLE_ERROR`: check jeandle error + return.