### PR TITLE
feat: Check if the method is parsable for jeandle

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -93,6 +93,8 @@ class JeandleCompilation : public StackObj {
 
   const char* _error_msg;
 
+  const char* check_can_parse(ciMethod* method);
+
   void initialize();
   void setup_llvm_module(llvm::MemoryBuffer* template_buffer);
   void compile_java_method();


### PR DESCRIPTION
## Related issue(s):

issue #201

## What this PR does / why we need it:

Check if the method can be compiled by jeandle compiler. Terminate compilation early if the method cannot be parsed.