### PR TITLE
test: drop unused sink from TestStackOverflowCheck

### DIFF
--- a/test/hotspot/jtreg/compiler/jeandle/TestStackOverflowCheck.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestStackOverflowCheck.java
@@ -27,11 +27,7 @@
 package compiler.jeandle;
 
 public class TestStackOverflowCheck {
-  // Volatile sink to keep the recursion side-effectful and prevent dead-code elimination.
-  private static volatile int sink;
-
   private static void recurse(int depth) {
-    sink = depth;
     recurse(depth + 1);
   }
 


### PR DESCRIPTION
## Related issue(s):

issue #76

## What this PR does / why we need it:

Drop unused sink from `TestStackOverflowCheck`.
