### PR TITLE
ci: Refactor CI

### DIFF
--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -39,6 +39,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: 'Clean for more disk space'
+      id: clean
+      run: rm -rf .git
+      shell: bash
     - name: 'Build'
       id: build
       run: >

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -79,9 +79,9 @@ jobs:
           - debug-level: debug
             flags: --with-debug-level=fastdebug
             suffix: -debug
-            llvm-flags: '-DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON'
+            llvm-flags: '-DCMAKE_BUILD_TYPE=MinSizeRel -DLLVM_ENABLE_ASSERTIONS=ON'
           - debug-level: release
-            llvm-flags: '-DCMAKE_BUILD_TYPE=Release'
+            llvm-flags: '-DCMAKE_BUILD_TYPE=MinSizeRel'
 
     steps:
       - name: 'Checkout the JDK source'

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -44,3 +44,5 @@ queue_rules:
     update_bot_account: jeandle-bot
 merge_queue:
   max_parallel_checks: 1
+  queued_label: ""
+  dequeued_label: ""


### PR DESCRIPTION
## What this PR does / why we need it:
- The GitHub CI runners do not have enough disk storage to compile the jdk. So use MinSizeRel to compile jeandle-llvm to get more free disk space. And before compile the jdk, delete the .git directory.
- Label/unlabel on PRs will trigger CI, don't let mergify do that.
