### PR TITLE
fix: disable VMContinuations for jeandle compiler

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -663,6 +663,15 @@ void CompilerConfig::ergo_initialize() {
 #endif // PRODUCT
 
     UseCompressedClassPointers = false;
+
+    if (FLAG_IS_DEFAULT(VMContinuations)) {
+      FLAG_SET_DEFAULT(VMContinuations, false);
+    }
+
+    if (FLAG_IS_CMDLINE(VMContinuations) && VMContinuations) {
+      warning("VMContinuations is disabled until jeandle supports virtual threads.");
+      VMContinuations = false;
+    }
   }
 #endif // JEANDLE
 }

--- a/src/hotspot/share/runtime/vm_version.cpp
+++ b/src/hotspot/share/runtime/vm_version.cpp
@@ -28,20 +28,8 @@
 #include "memory/resourceArea.hpp"
 #include "runtime/vm_version.hpp"
 
-#ifdef JEANDLE
-#include "compiler/compiler_globals.hpp"
-#include "runtime/globals_extension.hpp"
-#endif // JEANDLE
-
 void VM_Version_init() {
   VM_Version::initialize();
-
-#ifdef JEANDLE
-  if (UseJeandleCompiler && VMContinuations) {
-    warning("VMContinuations is not supported with Jeandle Compiler.");
-    VMContinuations = false;
-  }
-#endif // JEANDLE
 
   if (log_is_enabled(Info, os, cpu)) {
     char buf[1024];


### PR DESCRIPTION
## Related issue(s):

issue #323

## What this PR does / why we need it:

Jeandle does not currently support Virtual Threads, but `Continuations::enabled()` returns true.
`nmethod::make_deoptimized` may check `PostCallNop` and patch it when `VMContinuations` is `true`. But for Jeandle, we did not emit `PostCallNop` at all.
So we should check `VMContinuations` and set it to false when `UseJeandleCompiler` is enabled.
