### PR TITLE
fix: refactor JeandleRuntimeRoutine to generate stubs for needed routines.

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -1046,7 +1046,7 @@ void JeandleAbstractInterpreter::uncommon_trap(Deoptimization::DeoptReason reaso
   }
 
   llvm::Value* request = _ir_builder.getInt32(Deoptimization::make_trap_request(reason, action));
-  llvm::FunctionCallee callee = JeandleRuntimeRoutine::hotspot_uncommon_trap_callee(_module);
+  llvm::FunctionCallee callee = JeandleRuntimeRoutine::uncommon_trap_callee(_module);
   llvm::OperandBundleDef deopt_bundle("deopt", _jvm->deopt_args(_ir_builder, _bytecodes.cur_bci()));
   llvm::CallInst* call = create_call(callee, {request}, llvm::CallingConv::Hotspot_JIT, {deopt_bundle});
   call->setDoesNotReturn();
@@ -1485,8 +1485,8 @@ bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
     }
     case vmIntrinsicID::_dsin: {
       if (JeandleUseHotspotIntrinsics) {
-        llvm::FunctionCallee callee = StubRoutines::dsin() != nullptr ? JeandleRuntimeRoutine::hotspot_StubRoutines_dsin_callee(_module) :
-                                                                        JeandleRuntimeRoutine::hotspot_SharedRuntime_dsin_callee(_module);
+        llvm::FunctionCallee callee = StubRoutines::dsin() != nullptr ? JeandleRuntimeRoutine::StubRoutines_dsin_callee(_module) :
+                                                                        JeandleRuntimeRoutine::SharedRuntime_dsin_callee(_module);
         _jvm->dpush(create_call(callee, {_jvm->dpop()}, llvm::CallingConv::C));
       } else {
         _jvm->dpush(_ir_builder.CreateIntrinsic(JeandleType::java2llvm(BasicType::T_DOUBLE, *_context), llvm::Intrinsic::sin, {_jvm->dpop()}));
@@ -1495,8 +1495,8 @@ bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
     }
     case vmIntrinsicID::_dcos: {
       if (JeandleUseHotspotIntrinsics) {
-        llvm::FunctionCallee callee = StubRoutines::dcos() != nullptr ? JeandleRuntimeRoutine::hotspot_StubRoutines_dcos_callee(_module) :
-                                                                        JeandleRuntimeRoutine::hotspot_SharedRuntime_dcos_callee(_module);
+        llvm::FunctionCallee callee = StubRoutines::dcos() != nullptr ? JeandleRuntimeRoutine::StubRoutines_dcos_callee(_module) :
+                                                                        JeandleRuntimeRoutine::SharedRuntime_dcos_callee(_module);
         _jvm->dpush(create_call(callee, {_jvm->dpop()}, llvm::CallingConv::C));
       } else {
         _jvm->dpush(_ir_builder.CreateIntrinsic(JeandleType::java2llvm(BasicType::T_DOUBLE, *_context), llvm::Intrinsic::cos, {_jvm->dpop()}));
@@ -1506,8 +1506,8 @@ bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
     }
     case vmIntrinsicID::_dtan: {
       if (JeandleUseHotspotIntrinsics) {
-        llvm::FunctionCallee callee = StubRoutines::dtan() != nullptr ? JeandleRuntimeRoutine::hotspot_StubRoutines_dtan_callee(_module) :
-                                                                        JeandleRuntimeRoutine::hotspot_SharedRuntime_dtan_callee(_module);
+        llvm::FunctionCallee callee = StubRoutines::dtan() != nullptr ? JeandleRuntimeRoutine::StubRoutines_dtan_callee(_module) :
+                                                                        JeandleRuntimeRoutine::SharedRuntime_dtan_callee(_module);
         _jvm->dpush(create_call(callee, {_jvm->dpop()}, llvm::CallingConv::C));
       } else {
         _jvm->dpush(_ir_builder.CreateIntrinsic(JeandleType::java2llvm(BasicType::T_DOUBLE, *_context), llvm::Intrinsic::tan, {_jvm->dpop()}));
@@ -1516,8 +1516,8 @@ bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
     }
     case vmIntrinsicID::_dlog: {
       if (JeandleUseHotspotIntrinsics) {
-        llvm::FunctionCallee callee = StubRoutines::dlog() != nullptr ? JeandleRuntimeRoutine::hotspot_StubRoutines_dlog_callee(_module) :
-                                                                        JeandleRuntimeRoutine::hotspot_SharedRuntime_dlog_callee(_module);
+        llvm::FunctionCallee callee = StubRoutines::dlog() != nullptr ? JeandleRuntimeRoutine::StubRoutines_dlog_callee(_module) :
+                                                                        JeandleRuntimeRoutine::SharedRuntime_dlog_callee(_module);
         _jvm->dpush(create_call(callee, {_jvm->dpop()}, llvm::CallingConv::C));
       } else {
         _jvm->dpush(_ir_builder.CreateIntrinsic(JeandleType::java2llvm(BasicType::T_DOUBLE, *_context), llvm::Intrinsic::log, {_jvm->dpop()}));
@@ -1526,8 +1526,8 @@ bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
     }
     case vmIntrinsicID::_dlog10: {
       if (JeandleUseHotspotIntrinsics) {
-        llvm::FunctionCallee callee = StubRoutines::dlog10() != nullptr ? JeandleRuntimeRoutine::hotspot_StubRoutines_dlog10_callee(_module) :
-                                                                        JeandleRuntimeRoutine::hotspot_SharedRuntime_dlog10_callee(_module);
+        llvm::FunctionCallee callee = StubRoutines::dlog10() != nullptr ? JeandleRuntimeRoutine::StubRoutines_dlog10_callee(_module) :
+                                                                        JeandleRuntimeRoutine::SharedRuntime_dlog10_callee(_module);
         _jvm->dpush(create_call(callee, {_jvm->dpop()}, llvm::CallingConv::C));
       } else {
         _jvm->dpush(_ir_builder.CreateIntrinsic(JeandleType::java2llvm(BasicType::T_DOUBLE, *_context), llvm::Intrinsic::log10, {_jvm->dpop()}));
@@ -1536,8 +1536,8 @@ bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
     }
     case vmIntrinsicID::_dexp: {
       if (JeandleUseHotspotIntrinsics) {
-        llvm::FunctionCallee callee = StubRoutines::dexp() != nullptr ? JeandleRuntimeRoutine::hotspot_StubRoutines_dexp_callee(_module) :
-                                                                      JeandleRuntimeRoutine::hotspot_SharedRuntime_dexp_callee(_module);
+        llvm::FunctionCallee callee = StubRoutines::dexp() != nullptr ? JeandleRuntimeRoutine::StubRoutines_dexp_callee(_module) :
+                                                                      JeandleRuntimeRoutine::SharedRuntime_dexp_callee(_module);
         _jvm->dpush(create_call(callee, {_jvm->dpop()}, llvm::CallingConv::C));
       } else {
         _jvm->dpush(_ir_builder.CreateIntrinsic(JeandleType::java2llvm(BasicType::T_DOUBLE, *_context), llvm::Intrinsic::exp, {_jvm->dpop()}));
@@ -1550,7 +1550,7 @@ bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
       llvm::Value *component = _jvm->dpop();
       llvm::Value *base = _jvm->dpop();
       if (JeandleUseHotspotIntrinsics) {
-        llvm::FunctionCallee callee = StubRoutines::dpow() != nullptr ? JeandleRuntimeRoutine::hotspot_StubRoutines_dpow_callee(_module) : JeandleRuntimeRoutine::hotspot_SharedRuntime_dpow_callee(_module);
+        llvm::FunctionCallee callee = StubRoutines::dpow() != nullptr ? JeandleRuntimeRoutine::StubRoutines_dpow_callee(_module) : JeandleRuntimeRoutine::SharedRuntime_dpow_callee(_module);
         _jvm->dpush(create_call(callee, {base, component}, llvm::CallingConv::C));
       }
       else {
@@ -1834,11 +1834,11 @@ void JeandleAbstractInterpreter::arith_op(BasicType type, Bytecodes::Code code) 
     case Bytecodes::_fdiv: // fall through
     case Bytecodes::_ddiv: _jvm->push(type, _ir_builder.CreateFDiv(l, r)); break;
     case Bytecodes::_frem: {
-      _jvm->fpush(create_call(JeandleRuntimeRoutine::hotspot_SharedRuntime_frem_callee(_module), {l, r}, llvm::CallingConv::C));
+      _jvm->fpush(create_call(JeandleRuntimeRoutine::SharedRuntime_frem_callee(_module), {l, r}, llvm::CallingConv::C));
       break;
     }
     case Bytecodes::_drem: {
-      _jvm->dpush(create_call(JeandleRuntimeRoutine::hotspot_SharedRuntime_drem_callee(_module), {l, r}, llvm::CallingConv::C));
+      _jvm->dpush(create_call(JeandleRuntimeRoutine::SharedRuntime_drem_callee(_module), {l, r}, llvm::CallingConv::C));
       break;
     }
     case Bytecodes::_fneg: // fall through
@@ -2529,18 +2529,18 @@ void JeandleAbstractInterpreter::shared_lock(LockValue lock) {
 
   _jvm->push_lock(lock);
 
-  llvm::FunctionCallee monitorenter_callee = JeandleRuntimeRoutine::hotspot_SharedRuntime_complete_monitor_locking_C_callee(_module);
+  llvm::FunctionCallee monitorenter_callee = JeandleRuntimeRoutine::SharedRuntime_complete_monitor_locking_C_callee(_module);
   llvm::CallInst* current_thread = call_java_op("jeandle.current_thread", {});
   llvm::CallInst* call_monitorenter = _ir_builder.CreateCall(monitorenter_callee, {lock.object().value(), lock.lock(), current_thread});
-  call_monitorenter->setCallingConv(llvm::CallingConv::C);
+  call_monitorenter->setCallingConv(llvm::CallingConv::Hotspot_JIT);
 }
 
 void JeandleAbstractInterpreter::shared_unlock(LockValue lock) {
   assert(!lock.is_null(), "sanity");
-  llvm::FunctionCallee monitorexit_callee = JeandleRuntimeRoutine::hotspot_SharedRuntime_complete_monitor_unlocking_C_callee(_module);
+  llvm::FunctionCallee monitorexit_callee = JeandleRuntimeRoutine::SharedRuntime_complete_monitor_unlocking_C_callee(_module);
   llvm::CallInst* current_thread = call_java_op("jeandle.current_thread", {});
   llvm::CallInst* call_monitorexit = _ir_builder.CreateCall(monitorexit_callee, {lock.object().value(), lock.lock(), current_thread});
-  call_monitorexit->setCallingConv(llvm::CallingConv::C);
+  call_monitorexit->setCallingConv(llvm::CallingConv::Hotspot_JIT);
 }
 
 void JeandleAbstractInterpreter::monitorenter() {

--- a/src/hotspot/share/jeandle/jeandleCallVM.cpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.cpp
@@ -96,7 +96,7 @@ void JeandleCallVM::generate_call_VM(const char* name, address c_func, llvm::Fun
   ir_builder.CreateCondBr(if_not_null, forward_exception_block, no_exception_block);
   ir_builder.SetInsertPoint(forward_exception_block);
 
-  llvm::CallInst* call_inst = ir_builder.CreateCall(JeandleRuntimeRoutine::hotspot_install_exceptional_return_for_call_vm_callee(target_module), {});
+  llvm::CallInst* call_inst = ir_builder.CreateCall(JeandleRuntimeRoutine::install_exceptional_return_for_call_vm_callee(target_module), {});
   call_inst->setCallingConv(llvm::CallingConv::C);
 
   // Return

--- a/src/hotspot/share/jeandle/jeandleCallVM.cpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.cpp
@@ -32,7 +32,7 @@
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 #include "jeandle/jeandleType.hpp"
 
-void JeandleCallVM::generate_call_VM(const char* name, address c_func, llvm::FunctionType* func_type, llvm::Module& target_module, JeandleCompiledCode& code) {
+void JeandleCallVM::generate_call_VM(const char* name, address routine_address, llvm::FunctionType* func_type, llvm::Module& target_module, JeandleCompiledCode& code) {
   llvm::Function* llvm_func = llvm::Function::Create(func_type,
                                                      llvm::Function::ExternalLinkage,
                                                      name,
@@ -66,22 +66,22 @@ void JeandleCallVM::generate_call_VM(const char* name, address c_func, llvm::Fun
   }
 
   // Call to the C function.
-  llvm::PointerType* c_func_ptr_type = llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
-  llvm::Value* c_func_addr = ir_builder.getInt64((intptr_t)c_func);
-  llvm::Value* c_func_ptr = ir_builder.CreateIntToPtr(c_func_addr, c_func_ptr_type);
-  llvm::CallInst* call_c_func = ir_builder.CreateCall(func_type, c_func_ptr, args);
-  call_c_func->setCallingConv(llvm::CallingConv::C);
+  llvm::PointerType* routine_address_ptr_type = llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::Value* routine_address_addr = ir_builder.getInt64((intptr_t)routine_address);
+  llvm::Value* routine_address_ptr = ir_builder.CreateIntToPtr(routine_address_addr, routine_address_ptr_type);
+  llvm::CallInst* call_routine_address = ir_builder.CreateCall(func_type, routine_address_ptr, args);
+  call_routine_address->setCallingConv(llvm::CallingConv::C);
   JeandleCompiledCall::Type call_type = JeandleCompiledCall::STUB_C_CALL;
   uint64_t statepoint_id = code.next_statepoint_id();
-  code.push_non_routine_call_site(new CallSiteInfo(call_type, c_func, -1 /* bci */, false /* _has_deopt_operands */, statepoint_id));
+  code.push_non_routine_call_site(new CallSiteInfo(call_type, routine_address, -1 /* bci */, false /* _has_deopt_operands */, statepoint_id));
   llvm::Attribute id_attr = llvm::Attribute::get(context,
                                                  llvm::jeandle::Attribute::StatepointID,
                                                  std::to_string(statepoint_id));
   llvm::Attribute patch_bytes_attr = llvm::Attribute::get(context,
                                                           llvm::jeandle::Attribute::StatepointNumPatchBytes,
                                                           std::to_string(JeandleCompiledCall::call_site_patch_size(call_type)));
-  call_c_func->addFnAttr(id_attr);
-  call_c_func->addFnAttr(patch_bytes_attr);
+  call_routine_address->addFnAttr(id_attr);
+  call_routine_address->addFnAttr(patch_bytes_attr);
 
   // Check exceptions.
   llvm::Value* pending_exception_addr = ir_builder.CreateIntToPtr(ir_builder.getInt64((uint64_t)Thread::pending_exception_offset()),
@@ -129,7 +129,7 @@ void JeandleCallVM::generate_call_VM(const char* name, address c_func, llvm::Fun
     return;
   }
 
-  llvm::Value* ret_val = call_c_func;
+  llvm::Value* ret_val = call_routine_address;
 
   // If the return type is a Java object, we need to load it from vm_result of JavaThread.
   llvm::PointerType* pointer_type = llvm::dyn_cast<llvm::PointerType>(func_type->getReturnType());

--- a/src/hotspot/share/jeandle/jeandleCallVM.hpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.hpp
@@ -33,9 +33,9 @@
 
 class JeandleCallVM : public AllStatic {
  public:
-  // Generate stubs that call Jeandle C/C++ routines.
+  // Generate stubs that call indirect Jeandle routines.
   // For more information, see JeandleRuntimeRoutine.
-  static void generate_call_VM(const char* name, address c_func, llvm::FunctionType* func_type, llvm::Module& target_module, JeandleCompiledCode& code);
+  static void generate_call_VM(const char* name, address routine_address, llvm::FunctionType* func_type, llvm::Module& target_module, JeandleCompiledCode& code);
 };
 
 #endif // SHARE_JEANDLE_CALL_VM_HPP

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -147,7 +147,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                        ciEnv* env,
                                        std::unique_ptr<llvm::LLVMContext> context,
                                        const char* name,
-                                       address c_func,
+                                       address routine_address,
                                        llvm::FunctionType* func_type) :
                                        _target_machine(target_machine),
                                        _data_layout(data_layout),
@@ -162,7 +162,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
   initialize();
 
   _llvm_module->setDataLayout(*_data_layout);
-  JeandleCallVM::generate_call_VM(name, c_func, func_type, *_llvm_module, _code);
+  JeandleCallVM::generate_call_VM(name, routine_address, func_type, *_llvm_module, _code);
 
   // Verify module, if failes, crashes in debug builds and only reports compilation error in release builds.
   bool is_failed = llvm::verifyModule(*_llvm_module, &llvm::errs());

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -53,7 +53,7 @@ class JeandleCompilation : public StackObj {
                      ciEnv* env,
                      std::unique_ptr<llvm::LLVMContext> context,
                      const char* name,
-                     address c_func,
+                     address routine_address,
                      llvm::FunctionType* func_type);
 
   ~JeandleCompilation() = default;

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -31,139 +31,233 @@
 #include "memory/allStatic.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "runtime/stubRoutines.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-//------------------------------------------------------------------------------------------------------------
-//   |        c_func            |       return_type             |                    arg_types
-//------------------------------------------------------------------------------------------------------------
-#define ALL_JEANDLE_C_ROUTINES(def)                                                                                                             \
-  def(safepoint_handler,          llvm::Type::getVoidTy(context), llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                \
-  def(install_exceptional_return, llvm::Type::getVoidTy(context), llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                \
-  def(new_instance,               llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),                                 \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                \
-  def(new_array,                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),                                 \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                \
-  def(multianewarray2,            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),                                 \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                \
-  def(multianewarray3,            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),                                 \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                \
-  def(multianewarray4,            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),                                 \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                \
-  def(multianewarray5,            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),                                 \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::Type::getInt32Ty(context),                                              \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                \
-  def(multianewarrayN,            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),                                 \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
-                                                                  llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+// Define an indirect Jeandle runtime routine.
+// def( name            ,
+//      routine_address ,
+//      return_type     ,
+//      arg0_type       ,
+//      arg1_type       ,
+//         ...          ,
+//      argn_type       )
+#define ALL_JEANDLE_INDIRECT_ROUTINES(def)                                          \
+  def(safepoint_handler,                                                            \
+      JeandleRuntimeRoutine::safepoint_handler,                                     \
+      llvm::Type::getVoidTy(context),                                               \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(install_exceptional_return,                                                   \
+      JeandleRuntimeRoutine::install_exceptional_return,                            \
+      llvm::Type::getVoidTy(context),                                               \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(new_instance,                                                                 \
+      JeandleRuntimeRoutine::new_instance,                                          \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(new_array,                                                                    \
+      JeandleRuntimeRoutine::new_array,                                             \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(multianewarray2,                                                              \
+      JeandleRuntimeRoutine::multianewarray2,                                       \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(multianewarray3,                                                              \
+      JeandleRuntimeRoutine::multianewarray3,                                       \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(multianewarray4,                                                              \
+      JeandleRuntimeRoutine::multianewarray4,                                       \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(multianewarray5,                                                              \
+      JeandleRuntimeRoutine::multianewarray5,                                       \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(multianewarrayN,                                                              \
+      JeandleRuntimeRoutine::multianewarrayN,                                       \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(SharedRuntime_complete_monitor_locking_C,                                     \
+      SharedRuntime::complete_monitor_locking_C,                                    \
+      llvm::Type::getVoidTy(context),                                               \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+                                                                                    \
+  def(SharedRuntime_complete_monitor_unlocking_C,                                   \
+      SharedRuntime::complete_monitor_unlocking_C,                                  \
+      llvm::Type::getVoidTy(context),                                               \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+
+// Define a direct Jeandle runtime routine.
+// def( name            ,
+//      routine_address ,
+//      reachable       ,
+//      return_type     ,
+//      arg0_type       ,
+//      arg1_type       ,
+//         ...          ,
+//      argn_type       )
+#define ALL_JEANDLE_DIRECT_ROUTINES(def)                             \
+  def(StubRoutines_dsin,                                             \
+      StubRoutines::dsin(),                                          \
+      true,                                                          \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(StubRoutines_dcos,                                             \
+      StubRoutines::dcos(),                                          \
+      true,                                                          \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(StubRoutines_dtan,                                             \
+      StubRoutines::dtan(),                                          \
+      true,                                                          \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(StubRoutines_dlog,                                             \
+      StubRoutines::dlog(),                                          \
+      true,                                                          \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(StubRoutines_dlog10,                                           \
+      StubRoutines::dlog10(),                                        \
+      true,                                                          \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(StubRoutines_dexp,                                             \
+      StubRoutines::dexp(),                                          \
+      true,                                                          \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(StubRoutines_dpow,                                             \
+      StubRoutines::dpow(),                                          \
+      true,                                                          \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(uncommon_trap,                                                 \
+      SharedRuntime::uncommon_trap_blob()->entry_point(),            \
+      true,                                                          \
+      llvm::Type::getVoidTy(context),                                \
+      llvm::Type::getInt32Ty(context))                               \
+                                                                     \
+  def(SharedRuntime_dsin,                                            \
+      SharedRuntime::dsin,                                           \
+      false,                                                         \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(SharedRuntime_dcos,                                            \
+      SharedRuntime::dcos,                                           \
+      false,                                                         \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(SharedRuntime_dtan,                                            \
+      SharedRuntime::dtan,                                           \
+      false,                                                         \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(SharedRuntime_drem,                                            \
+      SharedRuntime::drem,                                           \
+      false,                                                         \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(SharedRuntime_frem,                                            \
+      SharedRuntime::frem,                                           \
+      false,                                                         \
+      llvm::Type::getFloatTy(context),                               \
+      llvm::Type::getFloatTy(context),                               \
+      llvm::Type::getFloatTy(context))                               \
+                                                                     \
+  def(SharedRuntime_dlog,                                            \
+      SharedRuntime::dlog,                                           \
+      false,                                                         \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(SharedRuntime_dlog10,                                          \
+      SharedRuntime::dlog10,                                         \
+      false,                                                         \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(SharedRuntime_dexp,                                            \
+      SharedRuntime::dexp,                                           \
+      false,                                                         \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(SharedRuntime_dpow,                                            \
+      SharedRuntime::dpow,                                           \
+      false,                                                         \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context),                              \
+      llvm::Type::getDoubleTy(context))                              \
+                                                                     \
+  def(install_exceptional_return_for_call_vm,                        \
+      JeandleRuntimeRoutine::install_exceptional_return_for_call_vm, \
+      false,                                                         \
+      llvm::Type::getVoidTy(context))                                \
+
 
 #define ALL_JEANDLE_ASSEMBLY_ROUTINES(def) \
   def(exceptional_return)                  \
   def(exception_handler)
 
-//-----------------------------------------------------------------------------------------------------------------------------------
-//    name                                       | func_entry             | return_type                        | arg_types
-//-----------------------------------------------------------------------------------------------------------------------------------
-#define ALL_HOTSPOT_ROUTINES(def)                                                                                                                         \
-  def(StubRoutines_dsin,                          StubRoutines::dsin(),    llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(StubRoutines_dcos,                          StubRoutines::dcos(),    llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(StubRoutines_dtan,                          StubRoutines::dtan(),    llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(StubRoutines_dlog,                          StubRoutines::dlog(),    llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(StubRoutines_dlog10,                        StubRoutines::dlog10(),    llvm::Type::getDoubleTy(context),  llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(StubRoutines_dexp,                          StubRoutines::dexp(),    llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(StubRoutines_dpow,                          StubRoutines::dpow(),    llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context),         \
-                                                                                                                llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(uncommon_trap, SharedRuntime::uncommon_trap_blob()->entry_point(),   llvm::Type::getVoidTy(context),      llvm::Type::getInt32Ty(context))          \
-                                                                                                                                                          \
-  def(SharedRuntime_complete_monitor_locking_C,   SharedRuntime::complete_monitor_locking_C, llvm::Type::getVoidTy(context),                                             \
-                                                                                           llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
-                                                                                           llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
-                                                                                           llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                                         \
-  def(SharedRuntime_complete_monitor_unlocking_C, SharedRuntime::complete_monitor_unlocking_C, llvm::Type::getVoidTy(context),                                           \
-                                                                                           llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
-                                                                                           llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
-                                                                                           llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-                                                                                                                                                                         \
- def(SharedRuntime_throw_NullPointerException,    SharedRuntime::throw_NullPointerException, llvm::Type::getVoidTy(context),                                             \
-                                                                                           llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
-
-
-//-----------------------------------------------------------------------------------------------------------------------------------
-//    name                                       | func_entry             | return_type                        | arg_types
-//-----------------------------------------------------------------------------------------------------------------------------------
-#define ALL_HOTSPOT_C_FUNCTIONS(def)                                                                                                                      \
-  def(SharedRuntime_dsin,                         SharedRuntime::dsin,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(SharedRuntime_dcos,                         SharedRuntime::dcos,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(SharedRuntime_dtan,                         SharedRuntime::dtan,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(SharedRuntime_drem,                         SharedRuntime::drem,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context),         \
-                                                                                                                llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(SharedRuntime_frem,                         SharedRuntime::frem,     llvm::Type::getFloatTy(context),     llvm::Type::getFloatTy(context),          \
-                                                                                                                llvm::Type::getFloatTy(context))          \
-                                                                                                                                                          \
-  def(SharedRuntime_dlog,                         SharedRuntime::dlog,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(SharedRuntime_dlog10,                       SharedRuntime::dlog10,     llvm::Type::getDoubleTy(context),  llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(SharedRuntime_dexp,                         SharedRuntime::dexp,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(SharedRuntime_dpow,                         SharedRuntime::dpow,     llvm::Type::getDoubleTy(context),    llvm::Type::getDoubleTy(context),         \
-                                                                                                                llvm::Type::getDoubleTy(context))         \
-                                                                                                                                                          \
-  def(install_exceptional_return_for_call_vm,     JeandleRuntimeRoutine::install_exceptional_return_for_call_vm, llvm::Type::getVoidTy(context))          \
-
 
 // JeandleRuntimeRoutine contains C/C++/Assembly routines and Hotspot routines that can be called from Jeandle compiled code.
-// (Hotspot routines are some runtime functions provided by Hotspot. We can call them in Jeandle compiled code.)
-//
-// There are two ways to call a JeandleRuntimeRoutine: directly calling an assembly/Hotspot routine or calling a C/C++ routine
-// through a runtime stub.
-//
-// For assembly/Hotspot routines, we can directly use their addresses to generate function calls in LLVM IR.
-//
-// For C/C++ routines, before jumping into the C/C++ function, we use a runtime stub to help adjust the VM state similar to
-// what C2's GraphKit::gen_stub does, then the runtime stub uses the C/C++ function address to generate a function calling
-// into it. The runtime stubs are compiled by LLVM for every C/C++ routine by JeandleCallVM.
+// There are two ways to call a JeandleRuntimeRoutine:
+//   1. For ALL_JEANDLE_INDIRECT_ROUTINES, call a routine through a runtime stub. The runtime stub will help adjust the VM
+//      state similar to what C2's GraphKit::gen_stub does.
+//   2. For ALL_JEANDLE_ASSEMBLY_ROUTINES and ALL_JEANDLE_DIRECT_ROUTINES, directly call a routine according to its runtime address.
 class JeandleRuntimeRoutine : public AllStatic {
  public:
   // Generate all routines.
@@ -182,56 +276,49 @@ class JeandleRuntimeRoutine : public AllStatic {
   static llvm::StringMap<address> routine_entry() { return _routine_entry; }
 #endif
 
-// Define all routines' llvm::FunctionCallee.
-#define DEF_LLVM_CALLEE(c_func, return_type, ...)                                                   \
-  static llvm::FunctionCallee c_func##_callee(llvm::Module& target_module) {                        \
+#define DEF_INDIRECT_ROUTINE_CALLEE(name, routine_address, return_type, ...)                        \
+  static llvm::FunctionCallee name##_callee(llvm::Module& target_module) {                          \
     llvm::LLVMContext& context = target_module.getContext();                                        \
     llvm::FunctionType* func_type = llvm::FunctionType::get(return_type, {__VA_ARGS__}, false);     \
-    llvm::FunctionCallee callee = target_module.getOrInsertFunction(#c_func, func_type);            \
+    llvm::FunctionCallee callee = target_module.getOrInsertFunction(#name, func_type);              \
     llvm::cast<llvm::Function>(callee.getCallee())->setCallingConv(llvm::CallingConv::Hotspot_JIT); \
     return callee;                                                                                  \
   }
 
-  ALL_JEANDLE_C_ROUTINES(DEF_LLVM_CALLEE);
+  ALL_JEANDLE_INDIRECT_ROUTINES(DEF_INDIRECT_ROUTINE_CALLEE);
+
+#define DEF_DIRECT_ROUTINE_CALLEE(name, routine_address, reachable, return_type, ...)                                  \
+  static llvm::FunctionCallee name##_callee(llvm::Module& target_module) {                                             \
+    llvm::LLVMContext& context = target_module.getContext();                                                           \
+    llvm::FunctionType* func_type = llvm::FunctionType::get(return_type, {__VA_ARGS__}, false);                        \
+    if (reachable) {                                                                                                   \
+      llvm::FunctionCallee callee = target_module.getOrInsertFunction(#name, func_type);                               \
+      llvm::cast<llvm::Function>(callee.getCallee())->setCallingConv(llvm::CallingConv::C);                            \
+      return callee;                                                                                                   \
+    }                                                                                                                  \
+    llvm::GlobalValue* address_value = target_module.getNamedValue(#name);          \
+    llvm::Constant* callee_address = nullptr;                                                                          \
+    if (address_value == nullptr) {                                                                                    \
+      llvm::PointerType* func_ptr_type = llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace);    \
+      llvm::Constant* addr_value = llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), (uint64_t)routine_address); \
+      callee_address = llvm::ConstantExpr::getIntToPtr(addr_value, func_ptr_type);                                     \
+      llvm::GlobalAlias::create(func_ptr_type, llvm::jeandle::AddrSpace::CHeapAddrSpace,                               \
+                                llvm::GlobalValue::ExternalLinkage, #name,                                             \
+                                callee_address, &target_module);                                                       \
+    } else if (llvm::GlobalAlias* address_alias = llvm::dyn_cast<llvm::GlobalAlias>(address_value)) {                  \
+      callee_address = address_alias->getAliasee();                                                                    \
+    }                                                                                                                  \
+    assert(callee_address != nullptr, "callee should not be null");                                                    \
+    return {func_type, callee_address};                                                                                \
+  }
+
+  ALL_JEANDLE_DIRECT_ROUTINES(DEF_DIRECT_ROUTINE_CALLEE);
 
 // Define all assembly routine names.
 #define DEF_ASSEMBLY_ROUTINE_NAME(name) \
   static constexpr const char* _##name = #name;
 
   ALL_JEANDLE_ASSEMBLY_ROUTINES(DEF_ASSEMBLY_ROUTINE_NAME);
-
-#define DEF_HOTSPOT_ROUTINE_CALLEE(name, func_entry, return_type, ...)                          \
-  static llvm::FunctionCallee hotspot_##name##_callee(llvm::Module& target_module) {            \
-    llvm::LLVMContext& context = target_module.getContext();                                    \
-    llvm::FunctionType* func_type = llvm::FunctionType::get(return_type, {__VA_ARGS__}, false); \
-    llvm::FunctionCallee callee = target_module.getOrInsertFunction(#name, func_type);          \
-    llvm::cast<llvm::Function>(callee.getCallee())->setCallingConv(llvm::CallingConv::C);       \
-    return callee;                                                                              \
-  }
-
-  ALL_HOTSPOT_ROUTINES(DEF_HOTSPOT_ROUTINE_CALLEE);
-
-#define DEF_HOTSPOT_C_FUNCTION_CALLEE(name, func_entry, return_type, ...)                                             \
-  static llvm::FunctionCallee hotspot_##name##_callee(llvm::Module& target_module) {                                  \
-    llvm::LLVMContext& context = target_module.getContext();                                                          \
-    llvm::FunctionType* func_type = llvm::FunctionType::get(return_type, {__VA_ARGS__}, false);                       \
-    llvm::GlobalValue* global_value = target_module.getNamedValue(#name);                                             \
-    llvm::Constant* callee = nullptr;                                                                                 \
-    if (global_value == nullptr) {                                                                                    \
-      llvm::PointerType* c_func_ptr_type = llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace); \
-      llvm::Constant* c_func_addr = llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), (uint64_t)func_entry);    \
-      callee = llvm::ConstantExpr::getIntToPtr(c_func_addr, c_func_ptr_type);                                         \
-      llvm::GlobalAlias::create(c_func_ptr_type, llvm::jeandle::AddrSpace::CHeapAddrSpace,                            \
-                                llvm::GlobalValue::ExternalLinkage, #name,                                            \
-                                callee, &target_module);                                                              \
-    } else if (llvm::GlobalAlias* global_alias = llvm::dyn_cast<llvm::GlobalAlias>(global_value)) {                   \
-      callee = global_alias->getAliasee();                                                                            \
-    }                                                                                                                 \
-    assert(callee != nullptr, "callee should not be null");                                                           \
-    return {func_type, callee};                                                                                       \
-  }
-
-  ALL_HOTSPOT_C_FUNCTIONS(DEF_HOTSPOT_C_FUNCTION_CALLEE);
 
  private:
   static llvm::StringMap<address> _routine_entry; // All the routines.

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -296,7 +296,7 @@ class JeandleRuntimeRoutine : public AllStatic {
       llvm::cast<llvm::Function>(callee.getCallee())->setCallingConv(llvm::CallingConv::C);                            \
       return callee;                                                                                                   \
     }                                                                                                                  \
-    llvm::GlobalValue* address_value = target_module.getNamedValue(#name);          \
+    llvm::GlobalValue* address_value = target_module.getNamedValue(#name);                                             \
     llvm::Constant* callee_address = nullptr;                                                                          \
     if (address_value == nullptr) {                                                                                    \
       llvm::PointerType* func_ptr_type = llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace);    \


### PR DESCRIPTION
## Related issue(s):

issue #330

## What this PR does / why we need it:

Some hotspot routines need stubs like other Jeandle runtime routines.