### PR TITLE
fix: enable Jeandle compiler by default

### DIFF
--- a/make/GenerateLinkOptData.gmk
+++ b/make/GenerateLinkOptData.gmk
@@ -34,6 +34,18 @@ include MakeBase.gmk
 include JavaCompilation.gmk
 
 ################################################################################
+# Copy the template module file for Jeandle
+ifeq ($(INCLUDE_JEANDLE), true)
+  $(eval $(call SetupCopyFiles, COPY_JEANDLE_TEMPLATE, \
+      SRC := $(TOPDIR)/src/hotspot/share/jeandle/templatemodule/, \
+      DEST := $(INTERIM_IMAGE_DIR)/lib/server/, \
+      FILES := template.ll, \
+  ))
+
+  JDK_TARGETS += $(COPY_JEANDLE_TEMPLATE)
+endif
+
+################################################################################
 # Create a jar with our generator class. Using a jar is intentional since it
 # will load more classes
 
@@ -61,7 +73,7 @@ endif
 
 # Save the stderr output of the command and print it along with stdout in case
 # something goes wrong.
-$(CLASSLIST_FILE): $(INTERIM_IMAGE_DIR)/bin/java$(EXECUTABLE_SUFFIX) $(CLASSLIST_JAR)
+$(CLASSLIST_FILE): $(INTERIM_IMAGE_DIR)/bin/java$(EXECUTABLE_SUFFIX) $(CLASSLIST_JAR) $(COPY_JEANDLE_TEMPLATE)
 	$(call MakeDir, $(LINK_OPT_DIR))
 	$(call LogInfo, Generating $(patsubst $(OUTPUTDIR)/%, %, $@))
 	$(call LogInfo, Generating $(patsubst $(OUTPUTDIR)/%, %, $(JLI_TRACE_FILE)))

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -383,7 +383,7 @@
           "Don't compile methods larger than this if "                      \
           "+DontCompileHugeMethods")                                        \
                                                                             \
-  product(bool, UseJeandleCompiler, false,                                  \
+  product(bool, UseJeandleCompiler, true,                                  \
           "Use Jeandle compiler")                                           \
                                                                             \
 


### PR DESCRIPTION
## Related issue(s):

#349 

## What this PR does / why we need it:
enable Jeandle compiler by default and fix fastdebug build mode missing template.ll