### PR TITLE
enhance: Restrict rewriting certain calls to JeandleRuntimeRoutine to…

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -1572,6 +1572,9 @@ bool JeandleAbstractInterpreter::inline_intrinsic(const ciMethod* target) {
 // Generate IR for calling into llvm FunctionCallee, without exception handling.
 llvm::CallInst* JeandleAbstractInterpreter::create_call(llvm::FunctionCallee callee, llvm::ArrayRef<llvm::Value *> args, llvm::CallingConv::ID calling_conv, llvm::ArrayRef<llvm::OperandBundleDef> deopt_bundle) {
   llvm::CallInst *call = _ir_builder.CreateCall(callee, args, deopt_bundle);
+  if (llvm::isa<llvm::ConstantExpr>(callee.getCallee())) {
+    call->addFnAttr(llvm::Attribute::get(call->getContext(), "gc-leaf-function"));
+  }
   call->setCallingConv(calling_conv);
   return call;
 }

--- a/src/hotspot/share/jeandle/jeandleCallVM.cpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.cpp
@@ -97,6 +97,7 @@ void JeandleCallVM::generate_call_VM(const char* name, address routine_address, 
   ir_builder.SetInsertPoint(forward_exception_block);
 
   llvm::CallInst* call_inst = ir_builder.CreateCall(JeandleRuntimeRoutine::install_exceptional_return_for_call_vm_callee(target_module), {});
+  call_inst->addFnAttr(llvm::Attribute::get(call_inst->getContext(), "gc-leaf-function"));
   call_inst->setCallingConv(llvm::CallingConv::C);
 
   // Return

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -116,7 +116,9 @@ class JeandleCallReloc : public JeandleReloc {
 
   void emit_reloc(JeandleAssembler& assembler) override {
     // Each call reloc has an oopmap, except for EXTERNAL_CALL.
-    assert((_call->type() != JeandleCompiledCall::EXTERNAL_CALL && _stack_map != nullptr) ||
+    assert((_call->type() != JeandleCompiledCall::EXTERNAL_CALL && _call->type() != JeandleCompiledCall::ROUTINE_CALL && _stack_map != nullptr) ||
+           (_call->type() == JeandleCompiledCall::ROUTINE_CALL && JeandleRuntimeRoutine::is_gc_leaf(_call->target()) && _stack_map == nullptr) ||
+           (_call->type() == JeandleCompiledCall::ROUTINE_CALL && !JeandleRuntimeRoutine::is_gc_leaf(_call->target()) && _stack_map != nullptr) ||
            (_call->type() == JeandleCompiledCall::EXTERNAL_CALL && _stack_map == nullptr),
            "unmatched call type and oopmap");
     if (_stack_map != nullptr) {
@@ -384,10 +386,15 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
 
         // TODO: Set the right bci.
         // JeandleCallReloc for a routine call site will be created during stackmaps resolving because an oopmap is required.
-        _routine_call_sites[inst_end_offset] = new CallSiteInfo(JeandleCompiledCall::ROUTINE_CALL,
-                                                                target_addr,
-                                                                -1/* bci */,
-                                                                target_addr == JeandleRuntimeRoutine::get_routine_entry("uncommon_trap")/* has_deopt_operands */);
+        CallSiteInfo* call_info = new CallSiteInfo(JeandleCompiledCall::ROUTINE_CALL,
+                                                    target_addr,
+                                                    -1/* bci */,
+                                                    target_addr == JeandleRuntimeRoutine::get_routine_entry("uncommon_trap")/* has_deopt_operands */);
+        if (JeandleRuntimeRoutine::is_gc_leaf(target_addr)) {
+          relocs.push_back(new JeandleCallReloc(inst_end_offset, _env, _method, nullptr /* no oopmap */, call_info));
+        } else {
+          _routine_call_sites[inst_end_offset] = call_info;
+        }
       } else if (JeandleAssembler::is_external_call_reloc(target, edge.getKind())) {
         // External call relocations.
         address target_addr = (address)DynamicLibrary::SearchForAddressOfSymbol(target_name.str().c_str());

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.cpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.cpp
@@ -50,10 +50,16 @@
 #define GEN_ASSEMBLY_ROUTINE_BLOB(name) \
   generate_##name();
 
-#define REGISTER_DIRECT_ROUTINE(name, routine_address, reachable, return_type, ...) \
-  if (reachable) { _routine_entry.insert({llvm::StringRef(#name), (address)routine_address}); }
+#define REGISTER_DIRECT_ROUTINE(name, routine_address, reachable, is_leaf, return_type, ...) \
+  if (reachable) {                                                                           \
+    _routine_entry.insert({llvm::StringRef(#name), (address)routine_address});               \
+    if (is_leaf) {                                                                           \
+      _gc_leaf_routines.insert((address)routine_address);                                    \
+    }                                                                                        \
+  }
 
 llvm::StringMap<address> JeandleRuntimeRoutine::_routine_entry;
+llvm::DenseSet<address> JeandleRuntimeRoutine::_gc_leaf_routines;
 
 bool JeandleRuntimeRoutine::generate(llvm::TargetMachine* target_machine, llvm::DataLayout* data_layout) {
   // For each indirect routine, compile a runtime stub to wrap it.

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestCosDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestCosDouble.java
@@ -71,6 +71,9 @@ public class TestCosDouble {
         checker.checkNext("bci_0:");
         checker.checkNext("call double @StubRoutines_dcos");
         checker.checkNext("ret double");
+        // check gc-leaf-function
+        checker.checkPattern("declare double @StubRoutines_dcos.*#\\d+");
+        checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
 
         // intrinsic by SharedRuntime
         if (is_x86) {
@@ -110,8 +113,10 @@ public class TestCosDouble {
             checker.checkNext("entry:");
             checker.checkNext("br label %bci_0");
             checker.checkNext("bci_0:");
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            // check gc-leaf-function
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
             checker.checkNext("ret double");
+            checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestExpDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestExpDouble.java
@@ -71,9 +71,14 @@ public class TestExpDouble {
         if (is_x86) {
             checker.checkNext("call double @StubRoutines_dexp");
         } else {
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
         }
         checker.checkNext("ret double");
+        // check gc-leaf-function
+        if (is_x86) {
+            checker.checkPattern("declare double @StubRoutines_dlog10.*#\\d+");
+        }
+        checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
 
         // intrinsic by SharedRuntime
         if (is_x86) {
@@ -113,8 +118,11 @@ public class TestExpDouble {
             checker.checkNext("entry:");
             checker.checkNext("br label %bci_0");
             checker.checkNext("bci_0:");
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            // check gc-leaf-function
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
             checker.checkNext("ret double");
+            checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
+            
         }
     }
 

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestLog10Double.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestLog10Double.java
@@ -71,9 +71,14 @@ public class TestLog10Double {
         if (is_x86) {
             checker.checkNext("call double @StubRoutines_dlog10");
         } else {
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
         }
         checker.checkNext("ret double");
+        // check gc-leaf-function
+        if (is_x86) {
+            checker.checkPattern("declare double @StubRoutines_dlog10.*#\\d+");
+        }
+        checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
 
         // intrinsic by SharedRuntime
         if (is_x86) {
@@ -113,8 +118,10 @@ public class TestLog10Double {
             checker.checkNext("entry:");
             checker.checkNext("br label %bci_0");
             checker.checkNext("bci_0:");
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            // check gc-leaf-function
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
             checker.checkNext("ret double");
+            checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestLogDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestLogDouble.java
@@ -72,9 +72,14 @@ public class TestLogDouble {
         if (is_x86) {
             checker.checkNext("call double @StubRoutines_dlog");
         } else {
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
         }
         checker.checkNext("ret double");
+        // check gc-leaf-function
+        if (is_x86) {
+            checker.checkPattern("declare double @StubRoutines_dlog.*#\\d+");
+        }
+        checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
 
         // intrinsic by SharedRuntime
         if (is_x86) {
@@ -114,8 +119,10 @@ public class TestLogDouble {
             checker.checkNext("entry:");
             checker.checkNext("br label %bci_0");
             checker.checkNext("bci_0:");
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            // check gc-leaf-function
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
             checker.checkNext("ret double");
+            checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestPowDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestPowDouble.java
@@ -71,9 +71,14 @@ public class TestPowDouble {
         if (is_x86) {
             checker.checkNext("call double @StubRoutines_dpow");
         } else {
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
         }
         checker.checkNext("ret double");
+        // check gc-leaf-function
+        if (is_x86) {
+            checker.checkPattern("declare double @StubRoutines_dpow.*#\\d+");
+        }
+        checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
 
         // intrinsic by SharedRuntime
         if (is_x86) {
@@ -113,8 +118,10 @@ public class TestPowDouble {
             checker.checkNext("entry:");
             checker.checkNext("br label %bci_0");
             checker.checkNext("bci_0:");
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            // check gc-leaf-function
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
             checker.checkNext("ret double");
+            checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestSinDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestSinDouble.java
@@ -71,6 +71,9 @@ public class TestSinDouble {
         checker.checkNext("bci_0:");
         checker.checkNext("call double @StubRoutines_dsin");
         checker.checkNext("ret double");
+        // check gc-leaf-function
+        checker.checkPattern("declare double @StubRoutines_dsin.*#\\d+");
+        checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
 
         // intrinsic by SharedRuntime
         if (is_x86) {
@@ -110,8 +113,10 @@ public class TestSinDouble {
             checker.checkNext("entry:");
             checker.checkNext("br label %bci_0");
             checker.checkNext("bci_0:");
-            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+            // check gc-leaf-function
+            checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
             checker.checkNext("ret double");
+            checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestTanDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestTanDouble.java
@@ -69,6 +69,9 @@ public class TestTanDouble {
             checker.checkNext("bci_0:");
             checker.checkNext("call double @StubRoutines_dtan");
             checker.checkNext("ret double");
+            // check gc-leaf-function
+            checker.checkPattern("declare double @StubRoutines_dtan.*#\\d+");
+            checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
 
         // intrinsic by SharedRuntime
@@ -114,8 +117,10 @@ public class TestTanDouble {
         checker.checkNext("entry:");
         checker.checkNext("br label %bci_0");
         checker.checkNext("bci_0:");
-        checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\)");
+        // check gc-leaf-function
+        checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
         checker.checkNext("ret double");
+        checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
     }
 
     static public class TestWrapper {


### PR DESCRIPTION
… statepoints

## Related issue(s):

issue #92

## What this PR does / why we need it:

Some JeandleRuntimeRoutines do not need statepoints when we call them.


