### PR TITLE
fix: erase invalid phi node

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -126,6 +126,8 @@ bool JeandleVMState::update_phi_nodes(JeandleVMState* income_jvm, llvm::BasicBlo
     llvm::PHINode* phi_node = llvm::cast<llvm::PHINode>(_locals[i].value());
 
     if (income_locals[i].is_null() || phi_node->getType() != income_locals[i].value()->getType()) {
+      assert(phi_node->use_empty(), "cannot use invalid local variable");
+      phi_node->eraseFromParent();
       invalidate_local(i);
       continue;
     }
@@ -291,17 +293,15 @@ bool JeandleBasicBlock::merge_VM_state_from(JeandleVMState* vm_state, llvm::Basi
       initialize_VM_state_from(vm_state, incoming, method->liveness_at_bci(_start_bci));
     }
 
-    if (is_set(is_loop_header)) {
-      // Copy loop header's initial JeandleVMState.
-      _initial_jvm = _jvm->copy();
-    }
-
     return true;
 
   } else if (!is_set(is_compiled) && !is_set(is_loop_header)) {
     assert(_predecessors.size() > 1 || is_exception_handler(), "more than one predecessors are needed for phi nodes");
     return _jvm->update_phi_nodes(vm_state, incoming);
   } else if (is_set(is_loop_header)) {
+    if (!is_set(is_compiled)) {
+      return _jvm->update_phi_nodes(vm_state, incoming);
+    }
     assert(_initial_jvm != nullptr, "loop header initial JeandleVMState is needed");
     return _initial_jvm->update_phi_nodes(vm_state, incoming);
   }
@@ -704,6 +704,11 @@ void JeandleAbstractInterpreter::interpret_block(JeandleBasicBlock* block) {
   // Skip blocks that are unreachable.
   if (_jvm == nullptr) {
     return;
+  }
+
+  if (block->is_set(JeandleBasicBlock::is_loop_header)) {
+    // Copy loop header's initial JeandleVMState.
+    block->set_initial_jvm(_jvm->copy());
   }
 
   _bytecodes.reset_to_bci(block->start_bci());

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -187,6 +187,8 @@ class JeandleBasicBlock : public JeandleCompilationResourceObj {
   int exeption_range_start_bci() { return _ci_block->ex_start_bci(); }
   int exeption_range_limit_bci() { return _ci_block->ex_limit_bci(); }
 
+  void set_initial_jvm(JeandleVMState* initial_jvm) { _initial_jvm = initial_jvm; }
+
  private:
   int _block_id;
   int _flags;

--- a/test/hotspot/jtreg/ProblemList-jeandle.txt
+++ b/test/hotspot/jtreg/ProblemList-jeandle.txt
@@ -386,7 +386,6 @@ runtime/modules/AccessCheck/ExpQualToM1PrivateMethodIAE.java                    
 runtime/modules/ModulesSymLink.java                                                            linux-aarch64,linux-x64
 runtime/stringtable/StringTableCleaningTest.java                                               linux-aarch64
 serviceability/dcmd/gc/FinalizerInfoTest.java                                                  linux-aarch64,linux-x64
-serviceability/jvmti/GetLocalVariable/GetLocalVars.java                                        linux-aarch64,linux-x64
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java                            linux-aarch64,linux-x64
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorEventOnOffTest.java                      linux-aarch64,linux-x64
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorGCParallelTest.java                      linux-aarch64,linux-x64
@@ -394,7 +393,6 @@ serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorGCSerialTest.java         
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorGCTest.java                              linux-aarch64,linux-x64
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatIntervalTest.java                    linux-aarch64,linux-x64
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorTest.java                                linux-aarch64,linux-x64
-serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java#default  linux-aarch64,linux-x64
 serviceability/sa/ClhsdbAttachDifferentJVMs.java                                               linux-aarch64
 serviceability/sa/ClhsdbThread.java                                                            linux-aarch64
 serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java                                      linux-aarch64


### PR DESCRIPTION
## Related issue(s):

issue #342 

## What this PR does / why we need it:

Fix a bug where PHI nodes in LLVM IR could have fewer incoming edges
than the number of predecessor blocks, causing module verification to
fail.