### PR TITLE
fix: use uncommon trap for checkcast fail

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -1737,8 +1737,6 @@ void JeandleAbstractInterpreter::checkcast() {
     return;
   }
 
-  _jvm->apop(); // Object was already get by raw_peek().
-
   Klass* super_klass = (Klass*)(ci_super_klass->constant_encoding());
   llvm::PointerType* klass_type = llvm::PointerType::get(*_context,llvm::jeandle::AddrSpace::CHeapAddrSpace);
 
@@ -1757,25 +1755,12 @@ void JeandleAbstractInterpreter::checkcast() {
 
   _ir_builder.CreateCondBr(call, checkcast_pass, checkcast_fail);
 
-  _ir_builder.SetInsertPoint(checkcast_fail);
-  llvm::Value* exception_oop_handle = find_or_insert_oop(CURRENT_ENV->ClassCastException_instance());
-  llvm::Value* exception_oop = _ir_builder.CreateLoad(JeandleType::java2llvm(BasicType::T_OBJECT, *_context), exception_oop_handle);
-
-  // Clear the detail message of the preallocated exception object.
-  // Weblogic sometimes mutates the detail message of exceptions using reflection.
-  int detailMessage_offset = java_lang_Throwable::get_detailMessage_offset();
-  llvm::Value* detailMessage_addr = compute_instance_field_address(exception_oop, detailMessage_offset);
-  llvm::StoreInst* store_inst = _ir_builder.CreateStore(llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(JeandleType::java2llvm(BasicType::T_OBJECT, *_context))),
-                                                        detailMessage_addr);
-  store_inst->setAtomic(llvm::AtomicOrdering::Unordered);
-
-  dispatch_exception_to_handler(exception_oop);
-  RETURN_VOID_ON_JEANDLE_ERROR();
+  // TODO: When too many traps occur, throw exception directly 
+  // instead of deoptimizing, similar to GraphKit::builtin_throw.
+  uncommon_trap(Deoptimization::Reason_class_check, Deoptimization::Action_maybe_recompile, checkcast_fail);
 
   _ir_builder.SetInsertPoint(checkcast_pass);
   _block->set_tail_llvm_block(checkcast_pass);
-
-  _jvm->apush(obj);
 }
 
 void JeandleAbstractInterpreter::instanceof(int klass_index) {

--- a/test/jdk/ProblemList-jeandle.txt
+++ b/test/jdk/ProblemList-jeandle.txt
@@ -14,7 +14,6 @@ java/lang/constant/MethodTypeDescTest.java                                 linux
 java/lang/ref/Basic.java                                                   linux-aarch64,linux-x64
 java/lang/ref/FinalizeOverride.java                                        linux-aarch64,linux-x64
 java/lang/ref/FinalizerHistogramTest.java                                  linux-aarch64,linux-x64
-java/lang/reflect/IllegalArgumentsTest.java                                linux-aarch64,linux-x64
 java/math/BigInteger/largeMemory/SymmetricRangeTests.java                  linux-aarch64,linux-x64
 java/math/BigDecimal/StringConstructor.java                                linux-x64
 java/util/BitSet/stream/BitSetStreamTest.java                              linux-x64


### PR DESCRIPTION
## Related issue(s):

issue #397 

## What this PR does / why we need it:

Replaces the preallocated exception with an uncommon trap on the checkcast failure path, so the interpreter creates a new exception with a complete stack trace.