### PR TITLE
fix: Include template.ll in java.base jmod

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -164,6 +164,20 @@ ifeq ($(call isTargetOsType, unix), true)
 endif
 
 ################################################################################
+# Copy the template module file for Jeandle
+ifeq ($(INCLUDE_JEANDLE), true)
+  LIB_OUTPUTDIR := $(call FindLibDirForModule, java.base)
+
+  $(eval $(call SetupCopyFiles, COPY_JEANDLE_TEMPLATE, \
+      SRC := $(TOPDIR)/src/hotspot/share/jeandle/templatemodule/, \
+      DEST := $(LIB_OUTPUTDIR)/server/, \
+      FILES := template.ll, \
+  ))
+
+  TARGETS += $(COPY_JEANDLE_TEMPLATE)
+endif
+
+################################################################################
 # Create the symbols file for static builds.
 
 ifeq ($(STATIC_BUILD), true)

--- a/test/langtools/ProblemList-jeandle.txt
+++ b/test/langtools/ProblemList-jeandle.txt
@@ -1243,9 +1243,6 @@ tools/javac/patterns/NullSwitch.java                                            
 tools/javac/patterns/Switches.java                                                                        linux-aarch64
 tools/javac/patterns/Unnamed.java                                                                         linux-aarch64
 tools/javac/patterns/UnnamedErrors.java                                                                   linux-aarch64
-tools/javac/plugin/AutostartPlugins.java                                                                  linux-x64
-tools/javac/plugin/InternalAPI.java                                                                       linux-x64
-tools/javac/plugin/MultiplePlugins.java                                                                   linux-x64
 tools/javac/policy/test3/Test.java                                                                        linux-x64
 tools/javac/preview/PreviewErrors.java                                                                    linux-x64
 tools/javac/processing/6365040/T6365040.java                                                              linux-x64


### PR DESCRIPTION
## Related issue(s):

issue #401 

## What this PR does / why we need it:

This fixes the crash occurring when running applications on a 
custom-built JRE without the full JDK environment.

