### PR TITLE
fix: call_register_finalizer in Object::<init>

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -2723,7 +2723,44 @@ void JeandleAbstractInterpreter::boundary_check(llvm::Value* array_oop, llvm::Va
   _block->set_tail_llvm_block(boundary_check_pass);
 }
 
+void JeandleAbstractInterpreter::call_register_finalizer() {
+  llvm::Value* receiver = _jvm->locals_at(0);
+  assert(receiver != nullptr, "must have a receiver");
+
+  // TODO: know statically that registration isn't required
+
+  // dynamic test for whether the instance needs finalization  
+  llvm::Value* klass_offset = llvm::ConstantInt::get(_ir_builder.getInt32Ty(), (uint64_t)oopDesc::klass_offset_in_bytes());
+  llvm::Value* klass_addr = _ir_builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(*_context), receiver, klass_offset);
+  llvm::Value* klass = _ir_builder.CreateLoad(_ir_builder.getPtrTy(), klass_addr);
+  
+  llvm::Value* access_flags_offset = llvm::ConstantInt::get(_ir_builder.getInt32Ty(), (uint64_t)in_bytes(Klass::access_flags_offset()));
+  llvm::Value* access_flags_addr = _ir_builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(*_context), klass, access_flags_offset);
+  llvm::Value* access_flags = _ir_builder.CreateLoad(_ir_builder.getInt32Ty(), access_flags_addr);
+  
+  llvm::Value* mask = _ir_builder.CreateAnd(access_flags, llvm::ConstantInt::get(_ir_builder.getInt32Ty(), JVM_ACC_HAS_FINALIZER));
+  llvm::Value* check = _ir_builder.CreateICmpNE(mask, llvm::ConstantInt::get(_ir_builder.getInt32Ty(), 0));
+  
+  llvm::BasicBlock* register_block = llvm::BasicBlock::Create(*_context, "register_finalizer", _llvm_func);
+  llvm::BasicBlock* skip_block = llvm::BasicBlock::Create(*_context, "skip_register_finalizer", _llvm_func);  
+  _ir_builder.CreateCondBr(check, register_block, skip_block);
+  
+  _ir_builder.SetInsertPoint(register_block);
+  llvm::CallInst* current_thread = call_java_op("jeandle.current_thread", {});
+  create_call(JeandleRuntimeRoutine::SharedRuntime_register_finalizer_callee(_module), {current_thread, receiver}, llvm::CallingConv::Hotspot_JIT);
+  _ir_builder.CreateBr(skip_block);
+  
+  _ir_builder.SetInsertPoint(skip_block);
+  _block->set_tail_llvm_block(skip_block);
+}
+
 void JeandleAbstractInterpreter::return_current(llvm::Value* value) {
+  if (RegisterFinalizersAtInit &&
+      _method &&
+      _method->intrinsic_id() == vmIntrinsics::_Object_init) {
+    call_register_finalizer();
+  }
+
   if (_method && _method->is_synchronized()) {
     LockValue lock = _jvm->pop_lock();
     assert(lock.equals(_sync_lock), "sanity");

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -402,6 +402,9 @@ class JeandleAbstractInterpreter : public StackObj {
 
   void return_current(llvm::Value* value);
 
+  // Register finalizers on return from Object::<init>
+  void call_register_finalizer();
+
   void clinit_barrier(ciInstanceKlass* ik, ciMethod* context);
   void guard_klass_being_initialized(llvm::Value* klass);
   void guard_init_thread(llvm::Value* klass);

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -118,6 +118,11 @@
       llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
       llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
       llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
+  def(SharedRuntime_register_finalizer,                                             \
+      SharedRuntime::register_finalizer,                                            \
+      llvm::Type::getVoidTy(context),                                               \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace)) \
 
 // Define a direct Jeandle runtime routine.
 // def( name            ,

--- a/test/jdk/ProblemList-jeandle.txt
+++ b/test/jdk/ProblemList-jeandle.txt
@@ -5,15 +5,11 @@ java/foreign/TestHandshake.java                                            linux
 java/foreign/TestMemorySession.java                                        linux-aarch64,linux-x64
 java/lang/Character/UnicodeCasingTest.java                                 linux-aarch64
 java/lang/Math/Log1pTests.java                                             linux-aarch64
-java/lang/Object/FinalizationOption.java                                   linux-aarch64,linux-x64
 java/lang/ProcessHandle/PermissionTest.java                                linux-aarch64,linux-x64
 java/lang/String/ToLowerCase.java                                          linux-aarch64
 java/lang/String/UnicodeCasingTest.java                                    linux-aarch64
 java/lang/Thread/ThreadSleepEvent.java                                     linux-aarch64,linux-x64
 java/lang/constant/MethodTypeDescTest.java                                 linux-aarch64
-java/lang/ref/Basic.java                                                   linux-aarch64,linux-x64
-java/lang/ref/FinalizeOverride.java                                        linux-aarch64,linux-x64
-java/lang/ref/FinalizerHistogramTest.java                                  linux-aarch64,linux-x64
 java/math/BigInteger/largeMemory/SymmetricRangeTests.java                  linux-aarch64,linux-x64
 java/math/BigDecimal/StringConstructor.java                                linux-x64
 java/util/BitSet/stream/BitSetStreamTest.java                              linux-x64
@@ -24,8 +20,6 @@ java/util/Map/BasicSerialization.java                                      linux
 java/util/Objects/CheckLongIndex.java                                      linux-aarch64
 java/util/Optional/Basic.java                                              linux-x64
 java/util/PriorityQueue/ForgetMeNot.java                                   linux-aarch64
-java/util/WeakHashMap/GCDuringIteration.java                               linux-aarch64,linux-x64
-java/util/concurrent/ArrayBlockingQueue/WhiteBox.java                      linux-aarch64,linux-x64
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java                      linux-aarch64,linux-x64
 java/util/logging/LoggingDeadlock3.java                                    linux-x64
 java/util/logging/LoggingMXBeanTest2.java                                  linux-x64


### PR DESCRIPTION
## Related issue(s):

issue #395 

## What this PR does / why we need it:

C1/C2 compiler will register finalizer in `Object::<init>`, while Jeandle will not. It causes the finalize() function can't be normally executed. This PR is to add related logic in return_current like C2.