### PR TITLE
fix: refactor InternalErrorTest.java to pass when UseCompressedClassPointers is false

### DIFF
--- a/test/hotspot/jtreg/ProblemList-jeandle.txt
+++ b/test/hotspot/jtreg/ProblemList-jeandle.txt
@@ -374,7 +374,6 @@ runtime/Metaspace/PrintMetaspaceDcmd.java#test-64bit-ccs-guarded                
 runtime/StackGap/TestStackGap.java                                                             linux-aarch64
 runtime/Thread/AsyncExceptionTest.java                                                         linux-aarch64,linux-x64
 runtime/Thread/StopAtExit.java                                                                 linux-aarch64,linux-x64
-runtime/Unsafe/InternalErrorTest.java                                                          linux-x64
 runtime/cds/serviceability/ReplaceCriticalClasses.java                                         linux-aarch64
 runtime/jni/FindClassUtf8/FindClassUtf8.java                                                   linux-aarch64
 runtime/jni/getCreatedJavaVMs/TestGetCreatedJavaVMs.java                                       linux-aarch64

--- a/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
+++ b/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
@@ -143,8 +143,9 @@ public class InternalErrorTest {
                 buffer.get(new byte[8]);
                 break;
             case 1:
+                boolean compressed = WhiteBox.getWhiteBox().getVMFlag("UseCompressedClassPointers").toString().equals("true");
                 // testing Unsafe.copySwapMemory, trying to access next  page after truncation.
-                unsafe.copySwapMemory(null, mapAddr + pageSize, new byte[4000], 16, 2000, 2);
+                unsafe.copySwapMemory(null, mapAddr + pageSize, new byte[4000], compressed ? 16 : 20, 2000, 2);
                 break;
             case 2:
                 // testing Unsafe.copySwapMemory, trying to access next  page after truncation.


### PR DESCRIPTION
## Related issue(s):

issue #403 

