### PR TITLE
fix: Add missed header file when cross-compiling

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -271,5 +271,5 @@ jobs:
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: 'hotspot ${{ inputs.make-arguments }}'
+          make-target: 'images ${{ inputs.make-arguments }}'
           platform: linux-${{ inputs.target-cpu }}

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -71,6 +71,10 @@
 #include "jfr/jfr.hpp"
 #endif
 
+#ifdef JEANDLE
+#include "os_posix.inline.hpp"
+#endif // JEANDLE
+
 #include <limits>
 
 static const char _default_java_launcher[] = "generic";


### PR DESCRIPTION
## What this PR does / why we need it:

When I cross-compile RISCV target JDK in X64 machine (by using the command `make images`  instead of `make hotspot`), the following error occurs:

```shell
src/hotspot/share/runtime/arguments.cpp:3550:18: error: incomplete type 'os::Posix' used in nested name specifier
 3550 |       os::Posix::realpath(dli_fname, jvm_path, sizeof(jvm_path));
      |                  ^~~~~~~~
```

Building x64 target JDK in X64 machine doesn't have such error (not cross-compiling), because `JVM_FEATURES_server` in file `make/autoconf/spec.gmk.in` includes the `zgc` feature and then `os_posix.inline.hpp` will be included indirectly in the including links `precompiled.hpp -> oops/access.inline.hpp -> gc/z/zBarrierSet.inline.hpp -> gc/z/zBarrier.inline.hpp -> gc/z/zHeap.inline.hpp -> gc/z/zForwardingTable.inline.hpp -> gc/z/zForwarding.inline.hpp -> gc/z/zLock.inline.hpp -> gc/z/zLock.hpp -> runtime/os.inline.hpp -> os_linux.inline.hpp -> os_posix.inline.hpp`. But the `JVM_FEATURES_server` of the `build-jdk` in file `buildjdk-spec.gmk.in` doesn't include the `zgc` feature and then doesn't include the header `os_posix.inline.hpp`.

This patch fixes this bug and adjusts the GitHub workflow to expose such bugs.

