### PR TITLE
fix: add safepoint poll at method returns and tableswitch/lookupswitch

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -324,7 +324,7 @@ bool JeandleBasicBlock::merge_VM_state_from(JeandleVMState* vm_state, llvm::Basi
     assert(_predecessors.size() > 1 || is_exception_handler(), "more than one predecessors are needed for phi nodes");
     return _jvm->update_phi_nodes(vm_state, incoming);
   } else if (is_set(is_loop_header)) {
-    if (!is_set(is_compiled)) {
+    if (_initial_jvm == nullptr) {
       return _jvm->update_phi_nodes(vm_state, incoming);
     }
     assert(_initial_jvm != nullptr, "loop header initial JeandleVMState is needed");
@@ -1024,12 +1024,12 @@ void JeandleAbstractInterpreter::interpret_block(JeandleBasicBlock* block) {
       case Bytecodes::_tableswitch: table_switch(); break;
       case Bytecodes::_lookupswitch: lookup_switch(); break;
 
-      case Bytecodes::_ireturn: return_current(_jvm->ipop()); break;
-      case Bytecodes::_lreturn: return_current(_jvm->lpop()); break;
-      case Bytecodes::_freturn: return_current(_jvm->fpop()); break;
-      case Bytecodes::_dreturn: return_current(_jvm->dpop()); break;
-      case Bytecodes::_areturn: return_current(_jvm->apop()); break;
-      case Bytecodes::_return:  return_current(nullptr); break;
+      case Bytecodes::_ireturn: add_safepoint_poll(); return_current(_jvm->ipop()); break;
+      case Bytecodes::_lreturn: add_safepoint_poll(); return_current(_jvm->lpop()); break;
+      case Bytecodes::_freturn: add_safepoint_poll(); return_current(_jvm->fpop()); break;
+      case Bytecodes::_dreturn: add_safepoint_poll(); return_current(_jvm->dpop()); break;
+      case Bytecodes::_areturn: add_safepoint_poll(); return_current(_jvm->apop()); break;
+      case Bytecodes::_return:  add_safepoint_poll(); return_current(nullptr); break;
 
       // References:
 
@@ -1215,7 +1215,7 @@ void JeandleAbstractInterpreter::increment() {
 }
 
 void JeandleAbstractInterpreter::if_zero(llvm::CmpInst::Predicate p) {
-  if (_bytecodes.get_dest() < _bytecodes.cur_bci()) {
+  if (_bytecodes.get_dest() <= _bytecodes.cur_bci()) {
     add_safepoint_poll();
   }
   llvm::Value* v = _jvm->ipop();
@@ -1226,7 +1226,7 @@ void JeandleAbstractInterpreter::if_zero(llvm::CmpInst::Predicate p) {
 }
 
 void JeandleAbstractInterpreter::if_icmp(llvm::CmpInst::Predicate p) {
-  if (_bytecodes.get_dest() < _bytecodes.cur_bci()) {
+  if (_bytecodes.get_dest() <= _bytecodes.cur_bci()) {
     add_safepoint_poll();
   }
   llvm::Value* r = _jvm->ipop();
@@ -1248,7 +1248,7 @@ void JeandleAbstractInterpreter::lcmp() {
 }
 
 void JeandleAbstractInterpreter::if_acmp(llvm::CmpInst::Predicate p) {
-  if (_bytecodes.get_dest() < _bytecodes.cur_bci()) {
+  if (_bytecodes.get_dest() <= _bytecodes.cur_bci()) {
     add_safepoint_poll();
   }
   llvm::Value* r = _jvm->apop();
@@ -1260,7 +1260,7 @@ void JeandleAbstractInterpreter::if_acmp(llvm::CmpInst::Predicate p) {
 }
 
 void JeandleAbstractInterpreter::if_null(llvm::CmpInst::Predicate p) {
-  if (_bytecodes.get_dest() < _bytecodes.cur_bci()) {
+  if (_bytecodes.get_dest() <= _bytecodes.cur_bci()) {
     add_safepoint_poll();
   }
   llvm::Value* v = _jvm->apop();
@@ -1296,7 +1296,7 @@ void JeandleAbstractInterpreter::fcmp(BasicType type, bool true_if_unordered) {
 }
 
 void JeandleAbstractInterpreter::goto_bci(int bci) {
-  if (bci < _bytecodes.cur_bci()) {
+  if (bci <= _bytecodes.cur_bci()) {
     add_safepoint_poll();
   }
   _ir_builder.CreateBr(bci2block()[bci]->header_llvm_block());
@@ -1307,6 +1307,18 @@ void JeandleAbstractInterpreter::lookup_switch() {
 
   int length = sw.number_of_pairs();
   int cur_bci = _bytecodes.cur_bci();
+
+  bool makes_backward_branch = (cur_bci + sw.default_offset()) <= cur_bci;
+  for (int i = 0; i < length && !makes_backward_branch; i++) {
+    LookupswitchPair pair = sw.pair_at(i);
+    if ((cur_bci + pair.offset()) <= cur_bci) {
+      makes_backward_branch = true;
+    }
+  }
+
+  if (makes_backward_branch) {
+    add_safepoint_poll();
+  }
 
   llvm::Value* key = _jvm->ipop();
   llvm::BasicBlock* default_block = bci2block()[cur_bci + sw.default_offset()]->header_llvm_block();
@@ -1324,6 +1336,17 @@ void JeandleAbstractInterpreter::table_switch() {
   int length = sw.length();
   int cur_bci = _bytecodes.cur_bci();
   int low = sw.low_key();
+
+  bool makes_backward_branch = (cur_bci + sw.default_offset()) <= cur_bci;
+  for (int i = 0; i < length && !makes_backward_branch; i++) {
+    if ((cur_bci + sw.dest_offset_at(i)) <= cur_bci) {
+      makes_backward_branch = true;
+    }
+  }
+
+  if (makes_backward_branch) {
+    add_safepoint_poll();
+  }
 
   llvm::Value* idx = _jvm->ipop();
   llvm::BasicBlock* default_block = bci2block()[cur_bci + sw.default_offset()]->header_llvm_block();
@@ -2430,6 +2453,9 @@ void JeandleAbstractInterpreter::dispatch_exception_to_handler(llvm::Value* exce
 
     // catch_all
     if (handler->is_catch_all()) {
+      if (handler_bci <= cur_bci) {
+        add_safepoint_poll();
+      }
       bool merged = handler_block->merge_VM_state_from(_jvm->copy_for_exception_handler(exception_oop),
                                                        _ir_builder.GetInsertBlock(),
                                                        _method);
@@ -2441,6 +2467,7 @@ void JeandleAbstractInterpreter::dispatch_exception_to_handler(llvm::Value* exce
     // dispatch
     ciKlass* klass = handler->catch_klass();
     llvm::Value* match = nullptr;
+    bool needs_explicit_poll = false;
     if (klass != nullptr && klass->is_loaded()) {
       Klass* super_klass = (Klass*)(klass->constant_encoding());
       llvm::PointerType* klass_type = llvm::PointerType::get(*_context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
@@ -2449,6 +2476,7 @@ void JeandleAbstractInterpreter::dispatch_exception_to_handler(llvm::Value* exce
 
       // instanceof distinguish
       match = call_java_op("jeandle.instanceof", {super_klass_ptr, exception_oop});
+      needs_explicit_poll = (handler_bci <= cur_bci);
     } else {
       if (exception_klass == nullptr) {
         exception_klass = call_java_op("jeandle.load_klass", {exception_oop});
@@ -2471,12 +2499,25 @@ void JeandleAbstractInterpreter::dispatch_exception_to_handler(llvm::Value* exce
                                                            "bci_" + std::to_string(cur_bci) + "_exception_dispatch_to_bci_" + std::to_string(handler_block->start_bci()),
                                                            _llvm_func);
 
-    bool merged = handler_block->merge_VM_state_from(_jvm->copy_for_exception_handler(exception_oop),
+    llvm::Value* cond = _ir_builder.CreateICmpEQ(match, _ir_builder.getInt32(1));
+    if (needs_explicit_poll) {
+      llvm::BasicBlock* match_poll = llvm::BasicBlock::Create(*_context, "bci_" + std::to_string(cur_bci) + "_exception_handler_safepoint", _llvm_func);
+      _ir_builder.CreateCondBr(cond, match_poll, next_dest);
+      _ir_builder.SetInsertPoint(match_poll);
+      add_safepoint_poll();
+
+      bool merged = handler_block->merge_VM_state_from(_jvm->copy_for_exception_handler(exception_oop),
                                                      _ir_builder.GetInsertBlock(),
                                                      _method);
-    JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(merged, "failed to update handler's VM state");
-    llvm::Value* cond = _ir_builder.CreateICmpEQ(match, _ir_builder.getInt32(1));
-    _ir_builder.CreateCondBr(cond, match_dest, next_dest);
+      JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(merged, "failed to update handler's VM state");
+      _ir_builder.CreateBr(match_dest);
+    } else {
+      bool merged = handler_block->merge_VM_state_from(_jvm->copy_for_exception_handler(exception_oop),
+                                                     _ir_builder.GetInsertBlock(),
+                                                     _method);
+      JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(merged, "failed to update handler's VM state");
+      _ir_builder.CreateCondBr(cond, match_dest, next_dest);
+    }
     _ir_builder.SetInsertPoint(next_dest);
   }
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -484,6 +484,16 @@ void JeandleCompiledCode::fill_one_monitor_value(const StackMapParser& stackmaps
   array->append(new MonitorValue(locked_object, basic_lock, false /* eliminated */));
 }
 
+static bool bytecode_should_reexecute(Bytecodes::Code code) {
+  if (code == Bytecodes::_ireturn || code == Bytecodes::_lreturn ||
+      code == Bytecodes::_freturn || code == Bytecodes::_dreturn ||
+      code == Bytecodes::_areturn || code == Bytecodes::_return) {
+    return true;
+  } else {
+    return AbstractInterpreter::bytecode_should_reexecute(code);
+  }
+}
+
 JeandleStackMap* JeandleCompiledCode::parse_stackmap(StackMapParser& stackmaps, StackMapParser::record_iterator& record, CallSiteInfo* call_info) {
   assert(_frame_size > 0, "frame size must be greater than zero");
 
@@ -515,7 +525,7 @@ JeandleStackMap* JeandleCompiledCode::parse_stackmap(StackMapParser& stackmaps, 
 
     if (bci != InvocationEntryBci) {
       Bytecodes::Code code = _method->java_code_at_bci(bci);
-      reexecute = Interpreter::bytecode_should_reexecute(code); /* TODO: special case of multianewarray, please check GraphKit::should_reexecute_implied_by_bytecode */
+      reexecute = bytecode_should_reexecute(code); /* TODO: special case of multianewarray, please check GraphKit::should_reexecute_implied_by_bytecode */
     }
   }
 

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -89,10 +89,9 @@ DEF_JAVA_OP(safepoint_poll, 1, llvm::Type::getVoidTy(context))
                                                          llvm::PointerType::get(context, llvm::jeandle::AddrSpace::TLSAddrSpace));
   // Do poll.
   llvm::Value* poll_word = ir_builder.CreateLoad(intptr_type, poll_word_ptr, true /* is_volatile */);
-  llvm::Value* if_safepoint = ir_builder.CreateICmp(llvm::CmpInst::ICMP_EQ,
-                                                    poll_word,
-                                                    llvm::ConstantInt::get(intptr_type, ~SafepointMechanism::poll_bit()));
-  ir_builder.CreateCondBr(if_safepoint, return_block, do_safepoint_block);
+  llvm::Value* masked = ir_builder.CreateAnd(poll_word, llvm::ConstantInt::get(intptr_type, SafepointMechanism::poll_bit()));
+  llvm::Value* need_safepoint = ir_builder.CreateICmpNE(masked, llvm::ConstantInt::get(intptr_type, 0));
+  ir_builder.CreateCondBr(need_safepoint, do_safepoint_block, return_block);
 
   // ***** Do Safepoint Block *****
   ir_builder.SetInsertPoint(do_safepoint_block);

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/MissingSafepointOnSwitch.jasm
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/MissingSafepointOnSwitch.jasm
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super public class MissingSafepointOnSwitch
+	version 52:0
+{
+  public Method "<init>":"()V"
+	stack 1 locals 1
+  {
+		aload_0;
+		invokespecial	Method java/lang/Object."<init>":"()V";
+		return;
+  }
+  /* Same as:
+    public static void test(boolean flag, int v) {
+        if (flag) {
+            loop:
+            for (; ; ) {
+                switch(v) {
+                    case 0:
+                    case 1:
+                    case 2:
+                        break loop;
+                    default:
+                }
+            }
+        }
+    }
+    but with the default: set to the loop entry
+  */
+  public static Method test:"(ZI)V"
+	stack 1 locals 2
+  {
+		iload_0;
+		ifeq	L32;
+	L4:	stack_frame_type same;
+		iload_1;
+		tableswitch{ //0 to 2
+		0: L32;
+		1: L32;
+		2: L32;
+		default: L4 };
+	L32:	stack_frame_type same;
+		return;
+  }
+
+} // end Class TestMissingSafepointOnSwitch

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/MissingSafepointOnTryCatch.jasm
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/MissingSafepointOnTryCatch.jasm
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class MissingSafepointOnTryCatch version 52:0 {
+
+    static Method m:"()V" {
+        return;
+    }
+
+    static Method test1:"()V" stack 1 {
+        try t;
+            invokestatic m:"()V";
+            return;
+
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            athrow;
+        endtry t;
+    }
+
+    static Method test2:"()V" stack 1 {
+        try t0;
+            try t1;
+                invokestatic m:"()V";
+            endtry t1;
+            return;
+
+            catch t1 java/lang/Exception;
+            stack_map class java/lang/Exception;
+            return;
+
+            catch t0 java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            athrow;
+        endtry t0;
+    }
+
+    public static Method th:"()V"
+      throws java/lang/Exception
+      stack 2 locals 0
+    {
+          new	class java/lang/Exception;
+          dup;
+          invokespecial	Method java/lang/Exception."<init>":"()V";
+          athrow;
+    }
+
+    static Method test3:"()V" stack 1 locals 2 {
+        try t;
+            invokestatic m:"()V";
+            iconst_1;
+            istore_0;
+    		iconst_0;
+    		istore_1;
+            return;
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            invokestatic th:"()V";
+            return;
+        endtry t;
+    }
+
+    static Method test4:"()V" stack 2 locals 2 {
+        try t;
+            invokestatic m:"()V";
+            iconst_1;
+            istore_0;
+            iconst_0;
+            istore_1;
+            return;
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            iconst_1;
+            istore_0;
+            invokestatic th:"()V";
+            return;
+        endtry t;
+    }
+
+    static Method testInfinite:"()V" stack 1 {
+        try t;
+            invokestatic th:"()V";
+            return;
+
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            athrow;
+        endtry t;
+    }
+
+} // end Class MissingSafepointOnTryCatch

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestBusyLoop.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestBusyLoop.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @summary Verify safepoint poll is inserted at goto backward branch
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestBusyLoop::busyLoop TestBusyLoop
+ */
+
+public class TestBusyLoop {
+
+    public static void busyLoop() {
+        while (true) {}
+    }
+
+    public static void main(String[] args) throws Exception {
+        Thread loop = new Thread(() -> {
+            TestBusyLoop.busyLoop();
+        });
+        loop.setDaemon(true);
+        loop.start();
+
+        System.gc();
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestMissingSafepointOnSwitch.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestMissingSafepointOnSwitch.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @compile MissingSafepointOnSwitch.jasm
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+PrintCompilation -XX:CompileOnly=MissingSafepointOnSwitch::test TestMissingSafepointOnSwitch
+ */
+
+public class TestMissingSafepointOnSwitch {
+    public static void main(String[] args) {
+        MissingSafepointOnSwitch.test(false, 0);
+
+        Thread loop = new Thread(() -> {
+            MissingSafepointOnSwitch.test(true, 42);
+        });
+        loop.setDaemon(true);
+        loop.start();
+
+        System.gc();
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestMissingSafepointOnTryCatch.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestMissingSafepointOnTryCatch.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8313626
+ * @summary  assert(false) failed: malformed control flow to missing safepoint on backedge of a try-catch
+ * @library /test/lib
+ * @compile MissingSafepointOnTryCatch.jasm
+ * @run main/othervm -XX:CompileCommand=quiet
+ *      -XX:CompileCommand=compileonly,MissingSafepointOnTryCatch::test*
+ *      -XX:CompileCommand=dontinline,MissingSafepointOnTryCatch::m
+ *      -XX:CompileCommand=inline,MissingSafepointOnTryCatch::th
+ *      -XX:-TieredCompilation -Xcomp TestMissingSafepointOnTryCatch
+ */
+
+import jdk.test.lib.Utils;
+
+public class TestMissingSafepointOnTryCatch {
+
+    public static void infiniteLoop() {
+        try {
+            Thread thread = new Thread() {
+                public void run() {
+                    MissingSafepointOnTryCatch.testInfinite();
+                }
+            };
+            thread.setDaemon(true);
+            thread.start();
+            Thread.sleep(Utils.adjustTimeout(500));
+        } catch (Exception e) {}
+    }
+
+    public static void main(String[] args) {
+        try {
+            // to make sure java/lang/Exception class is resolved
+            MissingSafepointOnTryCatch.th();
+        } catch (Exception e) {}
+        MissingSafepointOnTryCatch.test1();
+        MissingSafepointOnTryCatch.test2();
+        MissingSafepointOnTryCatch.test3();
+        MissingSafepointOnTryCatch.test4();
+        infiniteLoop();
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestSafepointPoll.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestSafepointPoll.java
@@ -68,13 +68,14 @@ public class TestSafepointPoll {
             fileCheck.check("define private hotspotcc void @jeandle.safepoint_poll()");
             fileCheck.checkNext("entry:");
             fileCheck.checkNext("%0 = load volatile i64, ptr addrspace(2) inttoptr");
-            fileCheck.checkNext("%1 = icmp eq i64 %0, -2");
-            fileCheck.checkNext("br i1 %1, label %return, label %do_safepoint");
+            fileCheck.checkNext("%1 = and i64 %0, 1");
+            fileCheck.checkNext("%2 = icmp ne i64 %1, 0");
+            fileCheck.checkNext("br i1 %2, label %do_safepoint, label %return");
             fileCheck.checkNext("return:");
             fileCheck.checkNext("ret void");
             fileCheck.checkNext("do_safepoint:");
-            fileCheck.checkNext("%2 = call hotspotcc ptr @jeandle.current_thread()");
-            fileCheck.checkNext("call hotspotcc void @safepoint_handler(ptr %2)");
+            fileCheck.checkNext("%3 = call hotspotcc ptr @jeandle.current_thread()");
+            fileCheck.checkNext("call hotspotcc void @safepoint_handler(ptr %3)");
             fileCheck.checkNext("br label %return");
             fileCheck.checkNext("}");
         }

--- a/test/hotspot/jtreg/compiler/jeandle/fileCheck/TestFileCheck.java
+++ b/test/hotspot/jtreg/compiler/jeandle/fileCheck/TestFileCheck.java
@@ -41,7 +41,7 @@ public class TestFileCheck {
                                                 false);
             fileCheck.checkPattern("define hotspotcc i32 .*compiler_jeandle_fileCheck_TestFileCheck_add.*");
             fileCheck.checkNext("entry:");
-            fileCheck.checkNext("br label %bci_0");
+            fileCheck.check("br label %bci_0");
         }
         {
             FileCheck fileCheck = new FileCheck(currentDir,
@@ -49,7 +49,7 @@ public class TestFileCheck {
                                                 true);
             fileCheck.checkPattern("define hotspotcc i32 .*compiler_jeandle_fileCheck_TestFileCheck_add.*");
             fileCheck.checkNext("entry:");
-            fileCheck.checkNext("%2 = add i32 %1, %0");
+            fileCheck.check("%2 = add i32 %1, %0");
             fileCheck.checkNot("define private hotspotcc void @jeandle.safepoint_poll() #2 {");
         }
         {
@@ -58,7 +58,7 @@ public class TestFileCheck {
                                                 false);
             fileCheck.checkPattern("define hotspotcc i32 .*compiler_jeandle_fileCheck_TestFileCheck_add.*");
             fileCheck.checkNextPattern("entry:");
-            fileCheck.checkNextPattern("br label %bci_[0-9]+");
+            fileCheck.checkPattern("br label %bci_[0-9]+");
         }
         {
             FileCheck fileCheck = new FileCheck(currentDir,
@@ -66,7 +66,7 @@ public class TestFileCheck {
                                                 true);
             fileCheck.checkPattern("define hotspotcc i32 .*compiler_jeandle_fileCheck_TestFileCheck_add.*");
             fileCheck.checkNextPattern("entry:");
-            fileCheck.checkNextPattern("%[0-9]+ = add i32 %[0-9]+, %[0-9]+");
+            fileCheck.checkPattern("%[0-9]+ = add i32 %[0-9]+, %[0-9]+");
             fileCheck.checkNotPattern("define private hotspotcc void @jeandle\\.safepoint_poll\\(\\) #\\d+ \\{");
         }
 

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsDouble.java
@@ -60,7 +60,7 @@ public class TestAbsDouble {
         checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestAbsDouble$TestWrapper_abs_double");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         // the llvm intrinsic is used
         checker.checkNext("call double @llvm.fabs.f64(double %0)");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsFloat.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsFloat.java
@@ -59,7 +59,7 @@ public class TestAbsFloat {
         checker.check("define hotspotcc float @\"compiler_jeandle_intrinsic_TestAbsFloat$TestWrapper_abs_float");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         // the llvm intrinsic is used
         checker.checkNext("call float @llvm.fabs.f32(float %0)");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsInt.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsInt.java
@@ -59,7 +59,7 @@ public class TestAbsInt {
                 "define hotspotcc i32 @\"compiler_jeandle_intrinsic_TestAbsInt$TestWrapper_abs_int");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         // the llvm intrinsic is used
         checker.checkNext("call i32 @llvm.abs.i32(i32 %0, i1 false)");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsLong.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestAbsLong.java
@@ -59,7 +59,7 @@ public class TestAbsLong {
                 "define hotspotcc i64 @\"compiler_jeandle_intrinsic_TestAbsLong$TestWrapper_abs_long");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         // the llvm intrinsic is used
         checker.checkNext("call i64 @llvm.abs.i64(i64 %0, i1 false)");

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestCosDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestCosDouble.java
@@ -68,14 +68,14 @@ public class TestCosDouble {
         checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestCosDouble$TestWrapper_cos_double");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         if (is_riscv64) {
             checker.checkNext("call double inttoptr");
         } else {
             checker.checkNextPattern("call double @StubRoutines_dcos");
         }
-        checker.checkNext("ret double");
+        checker.check("ret double");
         // check gc-leaf-function
         if (!is_riscv64) {
             checker.checkPattern("declare double @StubRoutines_dcos.*#\\d+");
@@ -118,11 +118,11 @@ public class TestCosDouble {
             checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestCosDouble$TestWrapper_cos_double");
             // check IR
             checker.checkNext("entry:");
-            checker.checkNext("br label %bci_0");
+            checker.check("br label %bci_0");
             checker.checkNext("bci_0:");
             // check gc-leaf-function
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
-            checker.checkNext("ret double");
+            checker.check("ret double");
             checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestExpDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestExpDouble.java
@@ -66,14 +66,14 @@ public class TestExpDouble {
         checker.checkPattern("define hotspotcc double .*compiler_jeandle_intrinsic_TestExpDouble\\$TestWrapper_exp_double.*(double %0)");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         if (is_x86) {
             checker.checkNext("call double @StubRoutines_dexp");
         } else {
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
         }
-        checker.checkNext("ret double");
+        checker.check("ret double");
         // check gc-leaf-function
         if (is_x86) {
             checker.checkPattern("declare double @StubRoutines_dexp.*#\\d+");
@@ -116,11 +116,11 @@ public class TestExpDouble {
             checker.checkPattern("define hotspotcc double .*compiler_jeandle_intrinsic_TestExpDouble\\$TestWrapper_exp_double.*(double %0)");
             // check IR
             checker.checkNext("entry:");
-            checker.checkNext("br label %bci_0");
+            checker.check("br label %bci_0");
             checker.checkNext("bci_0:");
             // check gc-leaf-function
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
-            checker.checkNext("ret double");
+            checker.check("ret double");
             checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
             
         }

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestLog10Double.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestLog10Double.java
@@ -66,14 +66,14 @@ public class TestLog10Double {
         checker.checkPattern("define hotspotcc double .*compiler_jeandle_intrinsic_TestLog10Double\\$TestWrapper_log10_double.*(double %0)");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         if (is_x86) {
             checker.checkNext("call double @StubRoutines_dlog10");
         } else {
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
         }
-        checker.checkNext("ret double");
+        checker.check("ret double");
         // check gc-leaf-function
         if (is_x86) {
             checker.checkPattern("declare double @StubRoutines_dlog10.*#\\d+");
@@ -116,11 +116,11 @@ public class TestLog10Double {
             checker.checkPattern("define hotspotcc double .*compiler_jeandle_intrinsic_TestLog10Double\\$TestWrapper_log10_double.*(double %0)");
             // check IR
             checker.checkNext("entry:");
-            checker.checkNext("br label %bci_0");
+            checker.check("br label %bci_0");
             checker.checkNext("bci_0:");
             // check gc-leaf-function
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
-            checker.checkNext("ret double");
+            checker.check("ret double");
             checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestLogDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestLogDouble.java
@@ -67,14 +67,14 @@ public class TestLogDouble {
         checker.checkPattern("define hotspotcc double .*compiler_jeandle_intrinsic_TestLogDouble\\$TestWrapper_log_double.*(double %0)");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         if (is_x86) {
             checker.checkNext("call double @StubRoutines_dlog");
         } else {
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
         }
-        checker.checkNext("ret double");
+        checker.check("ret double");
         // check gc-leaf-function
         if (is_x86) {
             checker.checkPattern("declare double @StubRoutines_dlog.*#\\d+");
@@ -117,11 +117,11 @@ public class TestLogDouble {
             checker.checkPattern("define hotspotcc double .*compiler_jeandle_intrinsic_TestLogDouble\\$TestWrapper_log_double.*(double %0)");
             // check IR
             checker.checkNext("entry:");
-            checker.checkNext("br label %bci_0");
+            checker.check("br label %bci_0");
             checker.checkNext("bci_0:");
             // check gc-leaf-function
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
-            checker.checkNext("ret double");
+            checker.check("ret double");
             checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestPowDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestPowDouble.java
@@ -66,14 +66,14 @@ public class TestPowDouble {
         checker.checkPattern("define hotspotcc double .*compiler_jeandle_intrinsic_TestPowDouble\\$TestWrapper_pow_double.*(double %0, double %1)");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         if (is_x86) {
             checker.checkNext("call double @StubRoutines_dpow");
         } else {
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
         }
-        checker.checkNext("ret double");
+        checker.check("ret double");
         // check gc-leaf-function
         if (is_x86) {
             checker.checkPattern("declare double @StubRoutines_dpow.*#\\d+");
@@ -116,11 +116,11 @@ public class TestPowDouble {
             checker.checkPattern("define hotspotcc double .*compiler_jeandle_intrinsic_TestPowDouble\\$TestWrapper_pow_double.*(double %0, double %1)");
             // check IR
             checker.checkNext("entry:");
-            checker.checkNext("br label %bci_0");
+            checker.check("br label %bci_0");
             checker.checkNext("bci_0:");
             // check gc-leaf-function
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
-            checker.checkNext("ret double");
+            checker.check("ret double");
             checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestSinDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestSinDouble.java
@@ -68,14 +68,14 @@ public class TestSinDouble {
         checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestSinDouble$TestWrapper_sin_double");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         if (is_riscv64) {
             checker.checkNext("call double inttoptr");
         } else {
             checker.checkNextPattern("call double @StubRoutines_dsin");
         }
-        checker.checkNext("ret double");
+        checker.check("ret double");
         // check gc-leaf-function
         if (!is_riscv64) {
             checker.checkPattern("declare double @StubRoutines_dsin.*#\\d+");
@@ -118,11 +118,11 @@ public class TestSinDouble {
             checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestSinDouble$TestWrapper_sin_double");
             // check IR
             checker.checkNext("entry:");
-            checker.checkNext("br label %bci_0");
+            checker.check("br label %bci_0");
             checker.checkNext("bci_0:");
             // check gc-leaf-function
             checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
-            checker.checkNext("ret double");
+            checker.check("ret double");
             checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
         }
     }

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestTanDouble.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestTanDouble.java
@@ -65,10 +65,10 @@ public class TestTanDouble {
             checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestTanDouble$TestWrapper_tan_double");
             // check IR
             checker.checkNext("entry:");
-            checker.checkNext("br label %bci_0");
+            checker.check("br label %bci_0");
             checker.checkNext("bci_0:");
             checker.checkNext("call double @StubRoutines_dtan");
-            checker.checkNext("ret double");
+            checker.check("ret double");
             // check gc-leaf-function
             checker.checkPattern("declare double @StubRoutines_dtan.*#\\d+");
             checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
@@ -115,11 +115,11 @@ public class TestTanDouble {
         checker.check("define hotspotcc double @\"compiler_jeandle_intrinsic_TestTanDouble$TestWrapper_tan_double");
         // check IR
         checker.checkNext("entry:");
-        checker.checkNext("br label %bci_0");
+        checker.check("br label %bci_0");
         checker.checkNext("bci_0:");
         // check gc-leaf-function
         checker.checkNextPattern("call double inttoptr \\(i64 (\\d+) to ptr\\).*#\\d+");
-        checker.checkNext("ret double");
+        checker.check("ret double");
         checker.checkPattern("attributes #\\d+ = \\{ \"gc-leaf-function\" \\}");
     }
 


### PR DESCRIPTION
## Related issue(s):

issue #418 

## What this PR does / why we need it:

Add safepoint polls at:

- All backward branches from tableswitch/lookupswitch (where target bci ≤ current bci)
- exception handler dispatch when handler_bci <= current_bci
- Method return points (before ret)
- goto / if_* backward branches when  target_bci == current_bci