### PR TITLE
fix: TargetMachine initialization does not propagate host CPU / host feature information

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleUtils_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleUtils_aarch64.cpp
@@ -21,8 +21,24 @@
 #include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
+#include "llvm/TargetParser/SubtargetFeature.h"
 
 #include "jeandle/jeandleUtils.hpp"
+
+#include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "runtime/arguments.hpp"
+
+void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features) {
+  if (!UseLSE) {
+    features.AddFeature("lse", false);
+  }
+  if (UseSVE < 2) {
+    features.AddFeature("sve2", false);
+  }
+  if (UseSVE < 1) {
+    features.AddFeature("sve", false);
+  }
+}
 
 void JeandleFuncSig::setup_description(llvm::Function* func, bool is_stub) {
   func->setCallingConv(llvm::CallingConv::Hotspot_JIT);

--- a/src/hotspot/cpu/aarch64/jeandleUtils_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleUtils_aarch64.cpp
@@ -29,6 +29,19 @@
 #include "runtime/arguments.hpp"
 
 void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features) {
+  if (!UseAES) {
+    features.AddFeature("aes", false);
+  }
+  if (!UseSHA) {
+    features.AddFeature("sha2", false);
+    features.AddFeature("sha3", false);
+  }
+  if (!UseNeon) {
+    features.AddFeature("neon", false);
+  }
+  if (!UseCRC32) {
+    features.AddFeature("crc", false);
+  }
   if (!UseLSE) {
     features.AddFeature("lse", false);
   }

--- a/src/hotspot/cpu/riscv/jeandleUtils_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jeandleUtils_riscv.cpp
@@ -21,16 +21,50 @@
 #include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
+#include "llvm/TargetParser/SubtargetFeature.h"
 
 #include "jeandle/jeandleUtils.hpp"
+
+#include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "runtime/arguments.hpp"
+
+void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features) {
+  if (!UseRVC) {
+    features.AddFeature("c", false);
+  }
+  if (!UseRVV) {
+    features.AddFeature("v", false);
+  }
+  if (!UseZba) {
+    features.AddFeature("zba", false);
+  }
+  if (!UseZbb) {
+    features.AddFeature("zbb", false);
+  }
+  if (!UseZbs) {
+    features.AddFeature("zbs", false);
+  }
+  if (!UseZic64b) {
+    features.AddFeature("zic64b", false);
+  }
+  if (!UseZicbom) {
+    features.AddFeature("zicbom", false);
+  }
+  if (!UseZicbop) {
+    features.AddFeature("zicbop", false);
+  }
+  if (!UseZicboz) {
+    features.AddFeature("zicboz", false);
+  }
+  if (!UseZihintpause) {
+    features.AddFeature("zihintpause", false);
+  }
+}
 
 void JeandleFuncSig::setup_description(llvm::Function* func, bool is_stub) {
   func->setCallingConv(llvm::CallingConv::Hotspot_JIT);
 
   func->setGC(llvm::jeandle::JeandleGC);
-
-  // RISCV must enable extensions manually.
-  func->addFnAttr("target-features", "+i,+m,+a,+f,+d");
 
   if (!is_stub) {
     llvm::GlobalVariable* personality_func = func->getParent()->getGlobalVariable("jeandle.personality");

--- a/src/hotspot/cpu/x86/jeandleUtils_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleUtils_x86.cpp
@@ -21,8 +21,54 @@
 #include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
+#include "llvm/TargetParser/SubtargetFeature.h"
 
 #include "jeandle/jeandleUtils.hpp"
+
+#include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "runtime/arguments.hpp"
+
+void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features) {
+  // Keep LLVM codegen aligned with HotSpot's VM-flag-controlled effective ISA
+  // rather than the raw host feature set. This mirrors how C1/C2 use UseSSE
+  // and UseAVX to gate instruction selection even when the hardware supports
+  // more.
+  if (UseSSE < 1) {
+    features.AddFeature("sse", false);
+  }
+  if (UseSSE < 2) {
+    features.AddFeature("sse2", false);
+  }
+  if (UseSSE < 3) {
+    features.AddFeature("sse3", false);
+    features.AddFeature("ssse3", false);
+    features.AddFeature("sse4a", false);
+  }
+  if (UseSSE < 4) {
+    features.AddFeature("sse4.1", false);
+    features.AddFeature("sse4.2", false);
+  }
+
+  if (UseAVX < 1) {
+    features.AddFeature("avx", false);
+  }
+  if (UseAVX < 2) {
+    features.AddFeature("avx2", false);
+  }
+  if (UseAVX < 3) {
+    features.AddFeature("avx512f", false);
+    features.AddFeature("avx512dq", false);
+    features.AddFeature("avx512cd", false);
+    features.AddFeature("avx512bw", false);
+    features.AddFeature("avx512vl", false);
+    features.AddFeature("avx512vpopcntdq", false);
+    features.AddFeature("avx512vbmi", false);
+    features.AddFeature("avx512vbmi2", false);
+    features.AddFeature("avx512vnni", false);
+    features.AddFeature("avx512bitalg", false);
+    features.AddFeature("avx512ifma", false);
+  }
+}
 
 void JeandleFuncSig::setup_description(llvm::Function* func, bool is_stub) {
   func->setCallingConv(llvm::CallingConv::Hotspot_JIT);

--- a/src/hotspot/cpu/x86/jeandleUtils_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleUtils_x86.cpp
@@ -68,6 +68,31 @@ void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features) {
     features.AddFeature("avx512bitalg", false);
     features.AddFeature("avx512ifma", false);
   }
+
+  if (!UseAES) {
+    features.AddFeature("aes", false);
+  }
+  if (!UseCLMUL) {
+    features.AddFeature("pclmul", false);
+  }
+  if (!UseFMA) {
+    features.AddFeature("fma", false);
+  }
+  if (!UseBMI1Instructions) {
+    features.AddFeature("bmi", false);
+  }
+  if (!UseBMI2Instructions) {
+    features.AddFeature("bmi2", false);
+  }
+  if (!UsePopCountInstruction) {
+    features.AddFeature("popcnt", false);
+  }
+  if (!UseCountLeadingZerosInstruction) {
+    features.AddFeature("lzcnt", false);
+  }
+  if (!UseSHA) {
+    features.AddFeature("sha", false);
+  }
 }
 
 void JeandleFuncSig::setup_description(llvm::Function* func, bool is_stub) {

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -162,6 +162,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
   initialize();
 
   _llvm_module->setDataLayout(*_data_layout);
+  _llvm_module->setTargetTriple(_target_machine->getTargetTriple());
   JeandleCallVM::generate_call_VM(name, routine_address, func_type, *_llvm_module, _code);
 
   // Verify module, if failes, crashes in debug builds and only reports compilation error in release builds.
@@ -264,6 +265,7 @@ void JeandleCompilation::setup_llvm_module(llvm::MemoryBuffer* template_buffer) 
 
   _llvm_module->setModuleIdentifier(JeandleFuncSig::method_name(_method));
   _llvm_module->setDataLayout(*_data_layout);
+  _llvm_module->setTargetTriple(_target_machine->getTargetTriple());
 
   llvm::NamedMDNode* metadata_node = _llvm_module->getOrInsertNamedMetadata(llvm::jeandle::Metadata::JavaMethodCompilation);
   assert(metadata_node != nullptr, "invalid metadata node");

--- a/src/hotspot/share/jeandle/jeandleCompiler.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiler.cpp
@@ -31,6 +31,7 @@
 #include "jeandle/jeandleCompiler.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 #include "jeandle/jeandleType.hpp"
+#include "jeandle/jeandleUtils.hpp"
 #include "jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
@@ -51,62 +52,6 @@ void install_jeandle_llvm_fatal_error_handler() {
     llvm::install_fatal_error_handler(jeandle_llvm_fatal_error_handler, nullptr);
     installed = true;
   }
-}
-
-void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features) {
-#ifdef AMD64
-  // Keep LLVM codegen aligned with HotSpot's VM-flag-controlled effective ISA
-  // rather than the raw host feature set. This mirrors how C1/C2 use UseSSE
-  // and UseAVX to gate instruction selection even when the hardware supports
-  // more.
-  if (UseSSE < 1) {
-    features.AddFeature("sse", false);
-  }
-  if (UseSSE < 2) {
-    features.AddFeature("sse2", false);
-  }
-  if (UseSSE < 3) {
-    features.AddFeature("sse3", false);
-    features.AddFeature("ssse3", false);
-    features.AddFeature("sse4a", false);
-  }
-  if (UseSSE < 4) {
-    features.AddFeature("sse4.1", false);
-    features.AddFeature("sse4.2", false);
-  }
-
-  if (UseAVX < 1) {
-    features.AddFeature("avx", false);
-  }
-  if (UseAVX < 2) {
-    features.AddFeature("avx2", false);
-  }
-  if (UseAVX < 3) {
-    features.AddFeature("avx512f", false);
-    features.AddFeature("avx512dq", false);
-    features.AddFeature("avx512cd", false);
-    features.AddFeature("avx512bw", false);
-    features.AddFeature("avx512vl", false);
-    features.AddFeature("avx512vpopcntdq", false);
-    features.AddFeature("avx512vbmi", false);
-    features.AddFeature("avx512vbmi2", false);
-    features.AddFeature("avx512vnni", false);
-    features.AddFeature("avx512bitalg", false);
-    features.AddFeature("avx512ifma", false);
-  }
-#endif
-
-#ifdef AARCH64
-  if (!UseLSE) {
-    features.AddFeature("lse", false);
-  }
-  if (UseSVE < 2) {
-    features.AddFeature("sve2", false);
-  }
-  if (UseSVE < 1) {
-    features.AddFeature("sve", false);
-  }
-#endif
 }
 
 } // anonymous namespace

--- a/src/hotspot/share/jeandle/jeandleCompiler.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiler.cpp
@@ -53,6 +53,62 @@ void install_jeandle_llvm_fatal_error_handler() {
   }
 }
 
+void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features) {
+#ifdef AMD64
+  // Keep LLVM codegen aligned with HotSpot's VM-flag-controlled effective ISA
+  // rather than the raw host feature set. This mirrors how C1/C2 use UseSSE
+  // and UseAVX to gate instruction selection even when the hardware supports
+  // more.
+  if (UseSSE < 1) {
+    features.AddFeature("sse", false);
+  }
+  if (UseSSE < 2) {
+    features.AddFeature("sse2", false);
+  }
+  if (UseSSE < 3) {
+    features.AddFeature("sse3", false);
+    features.AddFeature("ssse3", false);
+    features.AddFeature("sse4a", false);
+  }
+  if (UseSSE < 4) {
+    features.AddFeature("sse4.1", false);
+    features.AddFeature("sse4.2", false);
+  }
+
+  if (UseAVX < 1) {
+    features.AddFeature("avx", false);
+  }
+  if (UseAVX < 2) {
+    features.AddFeature("avx2", false);
+  }
+  if (UseAVX < 3) {
+    features.AddFeature("avx512f", false);
+    features.AddFeature("avx512dq", false);
+    features.AddFeature("avx512cd", false);
+    features.AddFeature("avx512bw", false);
+    features.AddFeature("avx512vl", false);
+    features.AddFeature("avx512vpopcntdq", false);
+    features.AddFeature("avx512vbmi", false);
+    features.AddFeature("avx512vbmi2", false);
+    features.AddFeature("avx512vnni", false);
+    features.AddFeature("avx512bitalg", false);
+    features.AddFeature("avx512ifma", false);
+  }
+#endif
+
+#ifdef AARCH64
+  if (!UseLSE) {
+    features.AddFeature("lse", false);
+  }
+  if (UseSVE < 2) {
+    features.AddFeature("sve2", false);
+  }
+  if (UseSVE < 1) {
+    features.AddFeature("sve", false);
+  }
+#endif
+}
+
 } // anonymous namespace
 
 THREAD_LOCAL llvm::TargetMachine* JeandleCompiler::_target_machine = nullptr;
@@ -73,7 +129,21 @@ bool JeandleCompiler::initialize_target_machine() {
   llvm::SubtargetFeatures features;
   options.EmitStackSizeSection = true;
 
-  _target_machine = target->createTargetMachine(target_triple, ""/* CPU */, features.getString(), options,
+  std::string cpu = llvm::sys::getHostCPUName().str();
+  if (cpu.empty()) {
+    cpu = "generic";
+  }
+
+  llvm::StringMap<bool> host_features = llvm::sys::getHostCPUFeatures();
+  for (const auto& feature : host_features) {
+    if (feature.second) {
+      features.AddFeature(feature.first());
+    }
+  }
+
+  apply_vm_flag_feature_overrides(features);
+
+  _target_machine = target->createTargetMachine(target_triple, cpu, features.getString(), options,
                                                 llvm::Reloc::Model::PIC_, llvm::CodeModel::Model::Small,
                                                 llvm::CodeGenOptLevel::Aggressive, true/* JIT */);
   return _target_machine != nullptr;

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -74,12 +74,6 @@ std::string JeandleFuncSig::method_name_with_signature(ciMethod* method) {
   return method_name(method) + signature;
 }
 
-#if !defined(AMD64) && !defined(AARCH64)
-void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features) {
-  (void)features;
-}
-#endif
-
 bool is_jeandle_compiler_thread(Thread* t) {
   if (t == nullptr || !t->is_Compiler_thread()) {
     return false;

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -21,6 +21,7 @@
 #include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
+#include "llvm/TargetParser/SubtargetFeature.h"
 
 #include "jeandle/jeandleType.hpp"
 #include "jeandle/jeandleUtils.hpp"
@@ -72,6 +73,12 @@ std::string JeandleFuncSig::method_name_with_signature(ciMethod* method) {
   std::string signature = std::string(method->signature()->as_symbol()->as_utf8());
   return method_name(method) + signature;
 }
+
+#if !defined(AMD64) && !defined(AARCH64)
+void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features) {
+  (void)features;
+}
+#endif
 
 bool is_jeandle_compiler_thread(Thread* t) {
   if (t == nullptr || !t->is_Compiler_thread()) {

--- a/src/hotspot/share/jeandle/jeandleUtils.hpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.hpp
@@ -22,12 +22,15 @@
 #define SHARE_JEANDLE_UTILS_HPP
 
 #include "jeandle/__llvmHeadersBegin__.hpp"
-#include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciMethod.hpp"
 
+namespace llvm {
+class SubtargetFeatures;
+}
 
 class JeandleFuncSig : public AllStatic {
  public:
@@ -37,6 +40,8 @@ class JeandleFuncSig : public AllStatic {
   static std::string method_name_with_signature(ciMethod* method);
   static void setup_description(llvm::Function* func, bool is_stub = false);
 };
+
+void apply_vm_flag_feature_overrides(llvm::SubtargetFeatures& features);
 
 bool is_jeandle_compiler_thread(Thread* t);
 


### PR DESCRIPTION
## Related issue(s): 

issue #425 

## What this PR does / why we need it:

This would allow Jeandle to construct a host-accurate JIT TargetMachine, improving code generation quality and enabling expected target-specific instruction selection for host-supported features.