### PR TITLE
fix: bytecode putfield on boolean field does not narrow out‑of‑range integer

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -2131,7 +2131,11 @@ void JeandleAbstractInterpreter::store_to_address(llvm::Value* addr, llvm::Value
   assert(value->getType() == expected_ty, "Value type must match field type");
 
   switch (type) {
-    case T_BOOLEAN: // fall through
+    case T_BOOLEAN: {
+      value = _ir_builder.CreateTrunc(value, llvm::Type::getInt8Ty(*_context));
+      value = _ir_builder.CreateAnd(value, _ir_builder.getInt8(1));
+      break;
+    }
     case T_BYTE: {
       value = _ir_builder.CreateTrunc(value, llvm::Type::getInt8Ty(*_context));
       break;

--- a/test/hotspot/jtreg/ProblemList-jeandle.txt
+++ b/test/hotspot/jtreg/ProblemList-jeandle.txt
@@ -514,9 +514,6 @@ serviceability/sa/ClhsdbScanOops.java#id0                                       
 ###
 # Bug - JVM crash or wrong result in Jeandle implementation
 ###
-# Wrong result in implicit narrowing conversion at putfield
-compiler/conversions/TestPrimitiveConversions.java                                             linux-aarch64,linux-x64
-
 # JVM crash (SIGSEGV): PHI node predecessor mismatch in exception dispatch
 compiler/parsing/TestExceptionBlockWithPredecessorsMain.java                                   linux-aarch64,linux-x64
 


### PR DESCRIPTION
## Related issue(s):

issue #447 