### PR TITLE
feat: Support EA analysis procedure

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -20,6 +20,7 @@
 
 #include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Analysis/Jeandle/PartialEscapeAnalysis.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Jeandle/Jeandle.h"
 #include "llvm/IR/CallingConv.h"
@@ -51,6 +52,7 @@
 #include "jeandle/jeandleCompiler.hpp"
 #include "jeandle/jeandleType.hpp"
 #include "jeandle/jeandleUtils.hpp"
+#include "jeandle/jeandle_globals.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciUtilities.inline.hpp"
@@ -291,6 +293,8 @@ void JeandleCompilation::compile_java_method() {
   // Optimize.
   {
     JeandleTraceTime tt_optimize("Jeandle LLVM Optimize", llvm_optimizer_timer);
+    llvm::jeandle::PEAConfig::setEnabled(JeandleDoPartialEscapeAnalysis);
+    llvm::jeandle::PEAConfig::setMaxArrayLength(JeandlePEAMaxArrayLength);
     llvm::jeandle::optimize(*_llvm_module, llvm::OptimizationLevel::O3);
   }
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -586,6 +586,23 @@ JeandleStackMap* JeandleCompiledCode::parse_stackmap(StackMapParser& stackmaps, 
 
   }
 
+  // TODO(PEA-Deopt): Parse lazy_object operand bundles and materialize virtual objects
+  // When deoptimization occurs with scalar-replaced (virtual) objects:
+  // 1. Check for "lazy_object" operand bundles in the call instruction
+  // 2. For each lazy_object bundle:
+  //    - Extract: alloc_id, klass (uintptr_t), field_count, field_values
+  //    - Allocate new object using klass (invoke interpreter's new_instance logic)
+  //    - Initialize object fields with recorded field_values
+  //    - Create ScopeValue representing the materialized object
+  // 3. Replace lazy_object reference in ScopeValue with real object pointer
+  // 4. Resume execution in interpreter with fully materialized objects
+  //
+  // Implementation steps:
+  // - Modify deopt bundle format to include lazy_object metadata
+  // - Add DeoptValueEncoding::LazyObjectType for lazy_object references
+  // - Implement materialization logic in deoptimization handler
+  // - Coordinate with LLVM PEATransformer for bundle generation
+
   // build oop map
   OopMap* oop_map = new OopMap(frame_size_in_slots(), 0);
   for (; location != record->location_end(); location++) {

--- a/src/hotspot/share/jeandle/jeandle_globals.hpp
+++ b/src/hotspot/share/jeandle/jeandle_globals.hpp
@@ -56,7 +56,13 @@
   product(ccstr, JeandleLLVMOptions, nullptr,                               \
           "Additional LLVM command line options")                           \
                                                                             \
-
+  product(bool, JeandleDoPartialEscapeAnalysis, true,                       \
+          "Enable partial escape analysis optimization")                    \
+                                                                            \
+  product(int, JeandlePEAMaxArrayLength, 32,                                \
+          "Maximum array length for PEA")                                   \
+          range(0, 256)                                                     \
+                                                                            \
 // end of JEANDLE_FLAGS
 
 DECLARE_FLAGS(JEANDLE_FLAGS)


### PR DESCRIPTION
## Related issue(s):

issue #438 

## What this PR does / why we need it:
This PR supports EA analysis procedure in the side of JDK. 

The main logic is in LLVM, see https://github.com/jeandle/jeandle-llvm/pull/65

Here I only define two arguments to provide some control, and remain a TODO to remind deoptimization handle of lazy_object bundle.
