### PR TITLE
test: remove passing safepoint test from ProblemList

### DIFF
--- a/test/hotspot/jtreg/ProblemList-jeandle.txt
+++ b/test/hotspot/jtreg/ProblemList-jeandle.txt
@@ -514,9 +514,6 @@ serviceability/sa/ClhsdbScanOops.java#id0                                       
 ###
 # Bug - JVM crash or wrong result in Jeandle implementation
 ###
-# JVM crash (SIGSEGV): failed to update handler's VM state in exception dispatch
-compiler/parsing/TestMissingSafepointOnTryCatch.java                                           linux-aarch64,linux-x64
-
 # JVM crash (SIGABRT): assert(_stack_guard_state == stack_guard_reserved_disabled) failed
 runtime/ReservedStack/ReservedStackTest.java                                                   linux-aarch64,linux-x64
 


### PR DESCRIPTION
This removes `compiler/parsing/TestMissingSafepointOnTryCatch.java` from `test/hotspot/jtreg/ProblemList-jeandle.txt`.

The test was previously problem-listed for a Jeandle crash in exception dispatch when updating the handler VM state. I re-ran the focused jtreg test against the current Jeandle JDK build and it now passes, so the ProblemList entry is stale.

Validation:

```bash
JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 jtreg \
  -jdk:build/linux-x86_64-server-release/jdk \
  -w:/home/wangh/jeandle-work/jtreg-work-pr-459-release \
  -r:/home/wangh/jeandle-work/jtreg-report-pr-459-release \
  test/hotspot/jtreg/compiler/parsing/TestMissingSafepointOnTryCatch.java
```

Result:

```text
Test results: passed: 1
```