### PR TITLE
feat: Add TLAB fast path for array allocation

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -38,6 +38,7 @@
 #include "ci/ciObjArrayKlass.hpp"
 #include "ci/ciSymbols.hpp"
 #include "ci/ciTypeFlow.hpp"
+#include "oops/arrayOop.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "classfile/javaClasses.hpp"
 #include "gc/shared/gc_globals.hpp"
@@ -2972,13 +2973,50 @@ void JeandleAbstractInterpreter::anewarray(int klass_index) {
   }
 }
 
-void JeandleAbstractInterpreter::do_unified_newarray(Klass* array_klass) {
-  llvm::Value* length = _jvm->ipop();
+llvm::InvokeInst* JeandleAbstractInterpreter::emit_jeandle_newarray(Klass* array_klass, llvm::Value* length) {
+  // Decode the array klass layout once at IR build time. All values folded here are passed
+  // to jeandle.newarray as i32 constants (when array_klass is known at compile time, which
+  // is the common case), letting the fast path in template.ll collapse to a tight bump-pointer
+  // + memset(size_in_bytes - base_offset) + unrolled prefetch sequence.
+  jint lh = array_klass->layout_helper();
+  assert(Klass::layout_helper_is_array(lh), "must be an array klass");
+
+  int log2_element_size = Klass::layout_helper_log2_element_size(lh);
+  BasicType element_type = static_cast<BasicType>(Klass::layout_helper_element_type(lh));
+  int base_offset = arrayOopDesc::base_offset_in_bytes(element_type);
+  int max_length = arrayOopDesc::max_array_length(element_type);
+
+  // size_in_bytes = align((length << log2_element_size) + base_offset, MinObjAlignmentInBytes)
+  //
+  // The shift + add + and computes the exact same layout as arrayOopDesc::object_size() takes
+  // at runtime. We do it in IR (rather than runtime helper) so that the array fast path stays
+  // branch-free for the common case where the JIT can prove length is in range.
+  llvm::Type* i32 = _ir_builder.getInt32Ty();
+  llvm::Value* body_bytes = _ir_builder.CreateShl(length,
+      llvm::ConstantInt::get(i32, log2_element_size));
+  llvm::Value* with_header = _ir_builder.CreateAdd(body_bytes,
+      llvm::ConstantInt::get(i32, base_offset));
+  jint align_mask = static_cast<jint>(MinObjAlignmentInBytesMask);
+  llvm::Value* with_align_pad = _ir_builder.CreateAdd(with_header,
+      llvm::ConstantInt::get(i32, align_mask));
+  llvm::Value* size_in_bytes = _ir_builder.CreateAnd(with_align_pad,
+      llvm::ConstantInt::get(i32, ~align_mask));
+
+  llvm::Value* base_offset_v = _ir_builder.getInt32(base_offset);
+  llvm::Value* max_length_v = _ir_builder.getInt32(max_length);
+
   llvm::PointerType* klass_type = llvm::PointerType::get(*_context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
   llvm::Value* array_klass_addr = _ir_builder.getInt64((intptr_t)array_klass);
-  llvm::Value* array_klass_ptr =  _ir_builder.CreateIntToPtr(array_klass_addr, klass_type);
+  llvm::Value* array_klass_ptr = _ir_builder.CreateIntToPtr(array_klass_addr, klass_type);
 
-  llvm::InvokeInst* result = call_java_op_ex("jeandle.newarray", {array_klass_ptr, length}, {create_current_deopt_bundle()});
+  return call_java_op_ex("jeandle.newarray",
+      {array_klass_ptr, length, size_in_bytes, base_offset_v, max_length_v},
+      {create_current_deopt_bundle()});
+}
+
+void JeandleAbstractInterpreter::do_unified_newarray(Klass* array_klass) {
+  llvm::Value* length = _jvm->ipop();
+  llvm::InvokeInst* result = emit_jeandle_newarray(array_klass, length);
 
   // newarray always produces an exact type.
   result->addRetAttr(llvm::Attribute::get(*_context,
@@ -3040,14 +3078,9 @@ void JeandleAbstractInterpreter::multianewarray() {
   } else {
     // Create a java array for dimension sizes
     Klass* int_array_klass = (Klass*)(ciTypeArrayKlass::make(T_INT)->constant_encoding());
-    llvm::Value* int_array_klass_addr = _ir_builder.getInt64((intptr_t)int_array_klass);
-    llvm::PointerType* klass_type = llvm::PointerType::get(*_context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
-    llvm::Value* int_array_klass_ptr = _ir_builder.CreateIntToPtr(int_array_klass_addr, klass_type);
-
     llvm::Value* dimensions_array_length = _ir_builder.getInt32(ndimensions);
 
-    llvm::InvokeInst* dimensions_array_oop = call_java_op_ex("jeandle.newarray", {int_array_klass_ptr, dimensions_array_length},
-                                                             {create_current_deopt_bundle()});
+    llvm::InvokeInst* dimensions_array_oop = emit_jeandle_newarray(int_array_klass, dimensions_array_length);
     RETURN_VOID_ON_JEANDLE_ERROR();
 
     llvm::Value* array_base_offset = _ir_builder.CreateLoad(llvm::Type::getInt32Ty(*_context),

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -40,6 +40,7 @@
 #include "ci/ciObjArrayKlass.hpp"
 #include "ci/ciSymbols.hpp"
 #include "ci/ciTypeFlow.hpp"
+#include "oops/arrayOop.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "classfile/javaClasses.hpp"
 #include "compiler/compilerDirectives.hpp"
@@ -3063,12 +3064,48 @@ void JeandleAbstractInterpreter::anewarray(int klass_index) {
   }
 }
 
-void JeandleAbstractInterpreter::do_unified_newarray(Klass* array_klass) {
-  llvm::Value* length = _jvm->ipop();
+llvm::InvokeInst* JeandleAbstractInterpreter::emit_jeandle_newarray(Klass* array_klass, llvm::Value* length) {
+  // Decode the array klass layout once at IR build time. All values folded here are passed
+  // to jeandle.newarray as i32 constants (when array_klass is known at compile time, which
+  // is the common case), letting the fast path in template.ll collapse to a tight bump-pointer
+  // + memset(size_in_bytes - base_offset) + unrolled prefetch sequence.
+  jint lh = array_klass->layout_helper();
+  assert(Klass::layout_helper_is_array(lh), "must be an array klass");
+
+  int log2_element_size = Klass::layout_helper_log2_element_size(lh);
+  BasicType element_type = static_cast<BasicType>(Klass::layout_helper_element_type(lh));
+  int base_offset = arrayOopDesc::base_offset_in_bytes(element_type);
+  int max_length = arrayOopDesc::max_array_length(element_type);
+
+  // size_in_bytes = align((length << log2_element_size) + base_offset, MinObjAlignmentInBytes)
+  //
+  // The shift + add + and computes the exact same layout as arrayOopDesc::object_size() takes
+  // at runtime. We do it in IR (rather than runtime helper) so that the array fast path stays
+  // branch-free for the common case where the JIT can prove length is in range.
+  llvm::Type* i32 = _ir_builder.getInt32Ty();
+  llvm::Value* body_bytes = _ir_builder.CreateShl(length,
+      llvm::ConstantInt::get(i32, log2_element_size));
+  llvm::Value* with_header = _ir_builder.CreateAdd(body_bytes,
+      llvm::ConstantInt::get(i32, base_offset));
+  jint align_mask = static_cast<jint>(MinObjAlignmentInBytesMask);
+  llvm::Value* with_align_pad = _ir_builder.CreateAdd(with_header,
+      llvm::ConstantInt::get(i32, align_mask));
+  llvm::Value* size_in_bytes = _ir_builder.CreateAnd(with_align_pad,
+      llvm::ConstantInt::get(i32, ~align_mask));
+
+  llvm::Value* base_offset_v = _ir_builder.getInt32(base_offset);
+  llvm::Value* max_length_v = _ir_builder.getInt32(max_length);
+
   llvm::PointerType* klass_type = llvm::PointerType::get(*_context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
   llvm::Value* array_klass_addr = _ir_builder.getInt64((intptr_t)array_klass);
-  llvm::Value* array_klass_ptr =  _ir_builder.CreateIntToPtr(array_klass_addr, klass_type);
+  llvm::Value* array_klass_ptr = _ir_builder.CreateIntToPtr(array_klass_addr, klass_type);
 
+  llvm::InvokeInst* result = call_java_op_ex("jeandle.new_array", {array_klass_ptr, length}, {create_current_deopt_bundle()});
+}
+
+void JeandleAbstractInterpreter::do_unified_newarray(Klass* array_klass) {
+  llvm::Value* length = _jvm->ipop();
+  llvm::InvokeInst* result = emit_jeandle_newarray(array_klass, length);
   llvm::InvokeInst* result = call_java_op_ex("jeandle.new_array", {array_klass_ptr, length}, {create_current_deopt_bundle()});
 
   // newarray always produces an exact type.
@@ -3131,10 +3168,6 @@ void JeandleAbstractInterpreter::multianewarray() {
   } else {
     // Create a java array for dimension sizes
     Klass* int_array_klass = (Klass*)(ciTypeArrayKlass::make(T_INT)->constant_encoding());
-    llvm::Value* int_array_klass_addr = _ir_builder.getInt64((intptr_t)int_array_klass);
-    llvm::PointerType* klass_type = llvm::PointerType::get(*_context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
-    llvm::Value* int_array_klass_ptr = _ir_builder.CreateIntToPtr(int_array_klass_addr, klass_type);
-
     llvm::Value* dimensions_array_length = _ir_builder.getInt32(ndimensions);
 
     llvm::InvokeInst* dimensions_array_oop = call_java_op_ex("jeandle.new_array", {int_array_klass_ptr, dimensions_array_length},

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -48,6 +48,7 @@
 #include "gc/shared/gc_globals.hpp"
 #include "interpreter/interpreter.hpp"
 #include "logging/log.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/ostream.hpp"
@@ -3064,49 +3065,53 @@ void JeandleAbstractInterpreter::anewarray(int klass_index) {
   }
 }
 
+// size_in_bytes = align((length << log2_element_size) + base_offset, MinObjAlignmentInBytes).
+// log2_element_size and base_offset are i32 constants on the bytecode path (array klass known
+// at IR build time) and runtime values decoded from Klass::layout_helper on the reflection
+// path; the arithmetic is identical and LLVM folds the constant case. Mirrors C2's
+// GraphKit::new_array size computation.
+llvm::Value* JeandleAbstractInterpreter::emit_array_size_in_bytes(llvm::Value* length,
+                                                                  llvm::Value* log2_element_size,
+                                                                  llvm::Value* base_offset) {
+  jint align_mask = static_cast<jint>(MinObjAlignmentInBytesMask);
+  llvm::Value* body_bytes = _ir_builder.CreateShl(length, log2_element_size);
+  llvm::Value* with_header = _ir_builder.CreateAdd(body_bytes, base_offset);
+  llvm::Value* with_align_pad = _ir_builder.CreateAdd(with_header, _ir_builder.getInt32(align_mask));
+  return _ir_builder.CreateAnd(with_align_pad, _ir_builder.getInt32(~align_mask));
+}
+
 llvm::InvokeInst* JeandleAbstractInterpreter::emit_jeandle_newarray(Klass* array_klass, llvm::Value* length) {
-  // Decode the array klass layout once at IR build time. All values folded here are passed
-  // to jeandle.newarray as i32 constants (when array_klass is known at compile time, which
-  // is the common case), letting the fast path in template.ll collapse to a tight bump-pointer
-  // + memset(size_in_bytes - base_offset) + unrolled prefetch sequence.
+  // Decode the array klass layout at IR build time. array_klass is known here, so size/base/max
+  // fold to i32 constants and the fast path in template.ll collapses to a tight bump-pointer plus
+  // inline zero loop.
   jint lh = array_klass->layout_helper();
   assert(Klass::layout_helper_is_array(lh), "must be an array klass");
 
   int log2_element_size = Klass::layout_helper_log2_element_size(lh);
   BasicType element_type = static_cast<BasicType>(Klass::layout_helper_element_type(lh));
   int base_offset = arrayOopDesc::base_offset_in_bytes(element_type);
-  int max_length = arrayOopDesc::max_array_length(element_type);
 
-  // size_in_bytes = align((length << log2_element_size) + base_offset, MinObjAlignmentInBytes)
-  //
-  // The shift + add + and computes the exact same layout as arrayOopDesc::object_size() takes
-  // at runtime. We do it in IR (rather than runtime helper) so that the array fast path stays
-  // branch-free for the common case where the JIT can prove length is in range.
-  llvm::Type* i32 = _ir_builder.getInt32Ty();
-  llvm::Value* body_bytes = _ir_builder.CreateShl(length,
-      llvm::ConstantInt::get(i32, log2_element_size));
-  llvm::Value* with_header = _ir_builder.CreateAdd(body_bytes,
-      llvm::ConstantInt::get(i32, base_offset));
-  jint align_mask = static_cast<jint>(MinObjAlignmentInBytesMask);
-  llvm::Value* with_align_pad = _ir_builder.CreateAdd(with_header,
-      llvm::ConstantInt::get(i32, align_mask));
-  llvm::Value* size_in_bytes = _ir_builder.CreateAnd(with_align_pad,
-      llvm::ConstantInt::get(i32, ~align_mask));
+  // Fast-path length cap, mirroring C2 GraphKit::new_array. It must bound the array so that
+  // size_in_bytes cannot overflow i32: arrayOopDesc::max_array_length() is ~max_jint on LP64
+  // (an element count, not a byte size) and would let e.g. int[1<<30] wrap size_in_bytes and
+  // corrupt the heap. FastAllocateSizeLimit caps the fast path at ~1MB; larger arrays take the
+  // slow path. Scaled by element size so the byte limit is uniform across element types.
+  int length_limit = (int)FastAllocateSizeLimit << (LogBytesPerLong - log2_element_size);
 
-  llvm::Value* base_offset_v = _ir_builder.getInt32(base_offset);
-  llvm::Value* max_length_v = _ir_builder.getInt32(max_length);
+  llvm::Value* size_in_bytes = emit_array_size_in_bytes(length,
+      _ir_builder.getInt32(log2_element_size), _ir_builder.getInt32(base_offset));
 
   llvm::PointerType* klass_type = llvm::PointerType::get(*_context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
-  llvm::Value* array_klass_addr = _ir_builder.getInt64((intptr_t)array_klass);
-  llvm::Value* array_klass_ptr = _ir_builder.CreateIntToPtr(array_klass_addr, klass_type);
+  llvm::Value* array_klass_ptr = _ir_builder.CreateIntToPtr(_ir_builder.getInt64((intptr_t)array_klass), klass_type);
 
-  llvm::InvokeInst* result = call_java_op_ex("jeandle.new_array", {array_klass_ptr, length}, {create_current_deopt_bundle()});
+  return call_java_op_ex("jeandle.new_array",
+      {array_klass_ptr, length, size_in_bytes, _ir_builder.getInt32(base_offset), _ir_builder.getInt32(length_limit)},
+      {create_current_deopt_bundle()});
 }
 
 void JeandleAbstractInterpreter::do_unified_newarray(Klass* array_klass) {
   llvm::Value* length = _jvm->ipop();
   llvm::InvokeInst* result = emit_jeandle_newarray(array_klass, length);
-  llvm::InvokeInst* result = call_java_op_ex("jeandle.new_array", {array_klass_ptr, length}, {create_current_deopt_bundle()});
 
   // newarray always produces an exact type.
   result->addRetAttr(llvm::Attribute::get(*_context,
@@ -3170,8 +3175,7 @@ void JeandleAbstractInterpreter::multianewarray() {
     Klass* int_array_klass = (Klass*)(ciTypeArrayKlass::make(T_INT)->constant_encoding());
     llvm::Value* dimensions_array_length = _ir_builder.getInt32(ndimensions);
 
-    llvm::InvokeInst* dimensions_array_oop = call_java_op_ex("jeandle.new_array", {int_array_klass_ptr, dimensions_array_length},
-                                                             {create_current_deopt_bundle()});
+    llvm::InvokeInst* dimensions_array_oop = emit_jeandle_newarray(int_array_klass, dimensions_array_length);
     RETURN_VOID_ON_JEANDLE_ERROR();
 
     llvm::Value* array_base_offset = _ir_builder.CreateLoad(llvm::Type::getInt32Ty(*_context),

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -417,6 +417,11 @@ class JeandleAbstractInterpreter : public StackObj {
   void do_unified_newarray(Klass* array_klass);
   void multianewarray();
 
+  // Builds the call to the jeandle.newarray JavaOp, computing the size/base/max args from
+  // array_klass->layout_helper() so the fast path in template.ll receives them as constants.
+  // Used both by do_unified_newarray and by multianewarray's dimensions-array allocation.
+  llvm::InvokeInst* emit_jeandle_newarray(Klass* array_klass, llvm::Value* length);
+
   // Implementation of _new
   void do_new();
 

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -452,10 +452,17 @@ class JeandleAbstractInterpreter : public StackObj {
   void do_unified_newarray(Klass* array_klass);
   void multianewarray();
 
-  // Builds the call to the jeandle.newarray JavaOp, computing the size/base/max args from
-  // array_klass->layout_helper() so the fast path in template.ll receives them as constants.
-  // Used both by do_unified_newarray and by multianewarray's dimensions-array allocation.
+  // Builds the call to the jeandle.new_array JavaOp for the bytecode path, folding the
+  // size/base/max args from array_klass->layout_helper() into i32 constants so the fast path
+  // in template.ll collapses tight. Used by do_unified_newarray and multianewarray's
+  // dimensions-array allocation. The reflection path (JeandleIntrinsicLowering::lower_new_array)
+  // decodes layout_helper at runtime instead and shares emit_array_size_in_bytes.
   llvm::InvokeInst* emit_jeandle_newarray(Klass* array_klass, llvm::Value* length);
+
+  // Builds the array size_in_bytes expression shared by the bytecode and reflection
+  // allocation paths. Mirrors C2's GraphKit::new_array size computation.
+  llvm::Value* emit_array_size_in_bytes(llvm::Value* length, llvm::Value* log2_element_size,
+                                        llvm::Value* base_offset);
 
   // Implementation of _new
   void do_new();

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -452,6 +452,11 @@ class JeandleAbstractInterpreter : public StackObj {
   void do_unified_newarray(Klass* array_klass);
   void multianewarray();
 
+  // Builds the call to the jeandle.newarray JavaOp, computing the size/base/max args from
+  // array_klass->layout_helper() so the fast path in template.ll receives them as constants.
+  // Used both by do_unified_newarray and by multianewarray's dimensions-array allocation.
+  llvm::InvokeInst* emit_jeandle_newarray(Klass* array_klass, llvm::Value* length);
+
   // Implementation of _new
   void do_new();
 

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -35,7 +35,9 @@
 #include "jeandle/jeandle_globals.hpp"
 #include "logging/log.hpp"
 #include "oops/arrayOop.hpp"
+#include "oops/klass.hpp"
 #include "runtime/deoptimization.hpp"
+#include "runtime/globals.hpp"
 
 // =============================================================================
 // Call-site IR annotation helpers (migrated from JeandleIntrinsicIRSemantics)
@@ -633,13 +635,34 @@ bool JeandleIntrinsicLowering::lower_new_array() {
       klass, llvm::ConstantPointerNull::get(c_heap_ptr_ty));
   builder.CreateCondBr(klass_is_null, slow_bb, fast_bb);
 
-  // Fast path: klass resolved → call unified jeandle.new_array(klass, length).
+  // Fast path: klass resolved → call unified jeandle.new_array.
+  // Unlike the bytecode path, the array klass is loaded from the mirror at runtime, so the
+  // element layout isn't a compile-time constant. Decode it from Klass::layout_helper the way
+  // C2's GraphKit::new_array does for reflective sites:
+  //   base_offset = (lh >> _lh_header_size_shift) & _lh_header_size_mask
+  //   log2_esize  = lh & 0x1f   (_lh_log2_element_size_shift == 0; masked < 32 for the shift,
+  //                              valid l2esz is <= LogBytesPerLong)
   builder.SetInsertPoint(fast_bb);
+  llvm::Value* lh_addr = builder.CreateInBoundsGEP(
+      builder.getInt8Ty(), klass, builder.getInt32(in_bytes(Klass::layout_helper_offset())));
+  llvm::Value* layout_helper = builder.CreateLoad(builder.getInt32Ty(), lh_addr);
+  llvm::Value* base_offset = builder.CreateAnd(
+      builder.CreateLShr(layout_helper, builder.getInt32(Klass::_lh_header_size_shift)),
+      builder.getInt32(Klass::_lh_header_size_mask));
+  llvm::Value* log2_esize = builder.CreateAnd(layout_helper, builder.getInt32(0x1f));
+  llvm::Value* size_in_bytes = _interp->emit_array_size_in_bytes(length, log2_esize, base_offset);
+  // Fast-path length cap, mirroring C2's reflective array path: the unscaled
+  // FastAllocateSizeLimit bounds the byte size to <= FastAllocateSizeLimit << LogBytesPerLong
+  // (~1MB) for any element type, so size_in_bytes cannot overflow i32. Larger reflective arrays
+  // fall to the slow path.
+  llvm::Value* length_limit = builder.getInt32((int)FastAllocateSizeLimit);
+
   static constexpr CallSiteAttributeMetadata fast_attrs =
       {CTRL_NEEDS_EXCEPTION_EDGE, MEM_READ | MEM_WRITE};
   llvm::Function* new_array_op = module.getFunction("jeandle.new_array");
   llvm::CallBase* fast_call =
-      emit_callsite(new_array_op, llvm::CallingConv::Hotspot_JIT, {klass, length}, fast_attrs);
+      emit_callsite(new_array_op, llvm::CallingConv::Hotspot_JIT,
+                    {klass, length, size_in_bytes, base_offset, length_limit}, fast_attrs);
   // emit_callsite with exception edge moves builder to a new normal_dest block.
   builder.CreateBr(merge_bb);
   llvm::BasicBlock* fast_normal_bb = builder.GetInsertBlock();

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.cpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.cpp
@@ -140,6 +140,11 @@ JRT_BLOCK_ENTRY(void, JeandleRuntimeRoutine::new_array(Klass* array_type, int le
 #endif
   assert(check_jeandle_compiled_frame(current), "incorrect caller");
 
+  if (log_is_enabled(Debug, jeandle, alloc)) {
+    ResourceMark rm;
+    log_debug(jeandle, alloc)("Slow path allocation for %s (length=%d)", array_type->external_name(), len);
+  }
+
   // Scavenge and allocate an instance.
   oop result;
 

--- a/src/hotspot/share/jeandle/templatemodule/template.ll
+++ b/src/hotspot/share/jeandle/templatemodule/template.ll
@@ -276,6 +276,12 @@ alloc_fast_path:
   store atomic i64 %prototype_value, ptr addrspace(1) %mark_word_addr unordered, align 8
   ; TODO: When UseCompressedClassPointers is enabled, klass should be stored as a 32-bit narrowKlass
   ; instead of a full pointer. Currently this assumes uncompressed class pointers.
+  ; (Layout offsets -- oopDesc.klass_offset_in_bytes, arrayOopDesc.length_offset_in_bytes,
+  ; arrayOopDesc.base_offset_in_bytes -- are already CCP-aware because they flow through
+  ; oopDesc::klass_offset_in_bytes() / arrayOopDesc::base_offset_in_bytes() on the C++
+  ; side, so only the store width and the encoding (>> CompressedKlassPointers::shift())
+  ; need updating when CCP support is added. instance and array fast paths must be
+  ; upgraded together.)
   store atomic ptr %klass, ptr addrspace(1) %klass_addr unordered, align 8
 
   %zero_tlab = load i1, ptr @VMOptions.ZeroTLAB
@@ -315,10 +321,145 @@ declare hotspotcc ptr @jeandle.current_thread()
 declare hotspotcc ptr addrspace(1) @new_array(ptr, i32, ptr)
 
 ; Implementation of Java anewarray and newarray operation
-define private hotspotcc ptr addrspace(1) @jeandle.newarray(ptr %array_klass, i32 %length) noinline "lower-phase"="1"  {
+;
+; Parameters:
+;   %array_klass    : runtime Klass* of the array (uncompressed)
+;   %length         : array length in elements
+;   %size_in_bytes  : caller-computed total allocation size (header + payload, aligned)
+;   %base_offset    : caller-computed offset to the payload start (= arrayOopDesc::base_offset_in_bytes(T_xxx))
+;   %max_length     : caller-computed arrayOopDesc::max_array_length(element_type) (signed)
+;
+; The caller (JeandleAbstractInterpreter::do_unified_newarray) folds %size_in_bytes,
+; %base_offset and %max_length to compile-time i32 constants whenever the array klass is
+; known at IR build time (the common case), which is what enables the bump-pointer body
+; below to collapse to a few stores plus the unrolled prefetch sequence.
+;
+; Follows HotSpot C1's allocation pattern (LIRGenerator::do_NewTypeArray /
+; MacroAssembler::allocate_array, platform-neutral): bump-pointer -> mark/klass/length
+; header -> payload zero -> release fence. Header fields are written without
+; inter-field barriers; the trailing release fence publishes the whole object as a
+; unit. Length is written before payload zeroing as a defensive ordering -- if a
+; safepoint poll is ever introduced inside the zero loop (e.g. to interrupt a
+; very large array allocation), heap parsers at that safepoint need a consistent
+; header to compute object size as klass.layout_helper * length + base_offset.
+define private hotspotcc ptr addrspace(1) @jeandle.newarray(ptr %array_klass, i32 %length, i32 %size_in_bytes, i32 %base_offset, i32 %max_length) noinline "lower-phase"="1" {
 entry:
+  ; Length bounds check first. arrayOopDesc::max_array_length() is signed, and a negative
+  ; %length (e.g. user-supplied -1) must go through the runtime to raise
+  ; NegativeArraySizeException, which the slow path handles.
+  %too_long = icmp ugt i32 %length, %max_length
+  br i1 %too_long, label %array_slow_path, label %check_tlab
+
+check_tlab:
+  %use_tlab = load i1, ptr @VMOptions.UseTLAB
+  br i1 %use_tlab, label %test_tlab, label %array_slow_path
+
+test_tlab:
+  %tlab_top_offset = load i64, ptr @JavaThread.tlab_top_offset
+  %tlab_end_offset = load i64, ptr @JavaThread.tlab_end_offset
+
+  %tlab_top_ptr = inttoptr i64 %tlab_top_offset to ptr addrspace(2)
+  %tlab_end_ptr = inttoptr i64 %tlab_end_offset to ptr addrspace(2)
+
+  %tlab_old_top = load ptr addrspace(1), ptr addrspace(2) %tlab_top_ptr, align 8
+  %tlab_end = load ptr addrspace(1), ptr addrspace(2) %tlab_end_ptr, align 8
+
+  %tlab_new_top = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %size_in_bytes
+  %if_tlab_full = icmp uge ptr addrspace(1) %tlab_new_top, %tlab_end
+  br i1 %if_tlab_full, label %array_slow_path, label %array_fast_path
+
+array_slow_path:
   %current_thread = call hotspotcc ptr @jeandle.current_thread()
-  %array_oop = call hotspotcc ptr addrspace(1) @new_array(ptr %array_klass, i32 %length, ptr %current_thread) [ "deopt"() ]
+  %slow_array_oop = call hotspotcc ptr addrspace(1) @new_array(ptr %array_klass, i32 %length, ptr %current_thread) [ "deopt"() ]
+  br label %array_return
+
+array_fast_path:
+  store ptr addrspace(1) %tlab_new_top, ptr addrspace(2) %tlab_top_ptr, align 8
+
+  ; Header: mark word, klass pointer, length. No inter-field barriers; the
+  ; trailing release fence publishes the whole object as a unit.
+  %mark_word_offset = load i32, ptr @oopDesc.mark_offset_in_bytes
+  %mark_word_addr = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %mark_word_offset
+
+  %klass_offset = load i32, ptr @oopDesc.klass_offset_in_bytes
+  %klass_addr = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %klass_offset
+
+  %length_offset = load i32, ptr @arrayOopDesc.length_offset_in_bytes
+  %length_addr = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %length_offset
+
+  %prototype_value = load i64, ptr @markWord.prototype_value
+
+  store atomic i64 %prototype_value, ptr addrspace(1) %mark_word_addr unordered, align 8
+  ; TODO: When UseCompressedClassPointers is enabled, klass should be stored as a 32-bit narrowKlass
+  ; instead of a full pointer. Currently this assumes uncompressed class pointers.
+  ; (Layout offsets -- oopDesc.klass_offset_in_bytes, arrayOopDesc.length_offset_in_bytes,
+  ; arrayOopDesc.base_offset_in_bytes -- are already CCP-aware because they flow through
+  ; oopDesc::klass_offset_in_bytes() / arrayOopDesc::base_offset_in_bytes() on the C++
+  ; side, so only the store width and the encoding (>> CompressedKlassPointers::shift())
+  ; need updating when CCP support is added. instance and array fast paths must be
+  ; upgraded together.)
+  store atomic ptr %array_klass, ptr addrspace(1) %klass_addr unordered, align 8
+  store atomic i32 %length, ptr addrspace(1) %length_addr unordered, align 4
+
+  %zero_tlab = load i1, ptr @VMOptions.ZeroTLAB
+  %skip_clear = and i1 %use_tlab, %zero_tlab
+  br i1 %skip_clear, label %array_init_membar, label %array_clear_memory
+
+array_clear_memory:
+  ; Explicit 8-byte-stride zero loop. We do NOT use @llvm.memset because LLVM's
+  ; default lowering produces poor code for both target backends we care about:
+  ;   - AArch64 (without MOPS): every memset, constant size or not, falls back
+  ;     to a per-byte strb loop -- the target hook in AArch64SelectionDAGInfo
+  ;     just `return SDValue()` and lets the generic SelectionDAG byte expansion
+  ;     take over. That's ~10x slower than the str xzr / stp xzr,xzr sequence
+  ;     HotSpot C1 emits.
+  ;   - x86: constant-size memset gets the rep stosq fast path, but variable
+  ;     size is bailed out by X86SelectionDAGInfo (`if (!ConstantSize) return
+  ;     SDValue();`) and ends up in the same generic per-byte loop. So variable-
+  ;     length arrays (the common `new T[N]` case in real workloads) regress on
+  ;     x86 too, not just AArch64.
+  ;
+  ; The stores must be `volatile` -- otherwise LLVM's LoopIdiomRecognize pass
+  ; folds an idiomatic "for(i=0;i<n;i++) p[i]=0" loop right back into
+  ; @llvm.memset, which round-trips through the same broken lowering. Volatile
+  ; stores are exempt from idiom recognition, so they survive into codegen as
+  ; plain str xzr (AArch64) / `mov qword ptr [...], 0` (x86) 8-byte stores.
+  ; LoopFullUnroll still applies for constant trip counts, so `new T[N]` with
+  ; N a compile-time constant becomes a fully unrolled sequence.
+  ;
+  ; TODO: For payloads larger than ~256 bytes (HotSpot AArch64
+  ; BlockZeroingLowLimit default), HotSpot's MacroAssembler::zero_words calls
+  ; the zero_blocks stub, which uses `dc zva` (64-byte cache-line zero). The
+  ; single-str loop here is ~4x slower than `dc zva` for large arrays; emitting
+  ; platform-specific inline asm or an LLVM target intrinsic for that tier is a
+  ; follow-up. The current loop already closes the biggest gap (per-byte ->
+  ; per-word).
+  ;
+  ; size_in_bytes is aligned to MinObjAlignmentInBytes (8) on the caller side,
+  ; and base_offset is always a multiple of 8, so payload_size is exactly
+  ; divisible by 8.
+  %base_addr = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %base_offset
+  %payload_size = sub i32 %size_in_bytes, %base_offset
+  %payload_words = lshr exact i32 %payload_size, 3
+  %has_payload = icmp ne i32 %payload_words, 0
+  br i1 %has_payload, label %array_zero_loop, label %array_init_membar
+
+array_zero_loop:
+  %zi = phi i32 [ 0, %array_clear_memory ], [ %zi_next, %array_zero_loop ]
+  %zaddr = getelementptr i64, ptr addrspace(1) %base_addr, i32 %zi
+  store volatile i64 0, ptr addrspace(1) %zaddr, align 8
+  %zi_next = add nuw nsw i32 %zi, 1
+  %zero_done = icmp eq i32 %zi_next, %payload_words
+  br i1 %zero_done, label %array_init_membar, label %array_zero_loop
+
+array_init_membar:
+  ; TODO: Same plan as new_instance -- replace atomic stores + fence release with plain
+  ; stores plus a lightweight publish barrier once the supporting LLVM pass lands.
+  fence release
+  br label %array_return
+
+array_return:
+  %array_oop = phi ptr addrspace(1) [ %tlab_old_top, %array_init_membar ], [ %slow_array_oop, %array_slow_path ]
   ret ptr addrspace(1) %array_oop
 }
 

--- a/src/hotspot/share/jeandle/templatemodule/template.ll
+++ b/src/hotspot/share/jeandle/templatemodule/template.ll
@@ -285,6 +285,12 @@ alloc_fast_path:
   store atomic i64 %prototype_value, ptr addrspace(1) %mark_word_addr unordered, align 8
   ; TODO: When UseCompressedClassPointers is enabled, klass should be stored as a 32-bit narrowKlass
   ; instead of a full pointer. Currently this assumes uncompressed class pointers.
+  ; (Layout offsets -- oopDesc.klass_offset_in_bytes, arrayOopDesc.length_offset_in_bytes,
+  ; arrayOopDesc.base_offset_in_bytes -- are already CCP-aware because they flow through
+  ; oopDesc::klass_offset_in_bytes() / arrayOopDesc::base_offset_in_bytes() on the C++
+  ; side, so only the store width and the encoding (>> CompressedKlassPointers::shift())
+  ; need updating when CCP support is added. instance and array fast paths must be
+  ; upgraded together.)
   store atomic ptr %klass, ptr addrspace(1) %klass_addr unordered, align 8
 
   %zero_tlab = load i1, ptr @VMOptions.ZeroTLAB
@@ -328,8 +334,122 @@ declare hotspotcc ptr addrspace(1) @new_array(ptr, i32, ptr)
 ; LLVM passes identify array allocation by matching on this function name.
 define private hotspotcc ptr addrspace(1) @jeandle.new_array(ptr %array_klass, i32 %length) noinline "lower-phase"="1" {
 entry:
+  ; Length bounds check first. arrayOopDesc::max_array_length() is signed, and a negative
+  ; %length (e.g. user-supplied -1) must go through the runtime to raise
+  ; NegativeArraySizeException, which the slow path handles.
+  %too_long = icmp ugt i32 %length, %max_length
+  br i1 %too_long, label %array_slow_path, label %check_tlab
+
+check_tlab:
+  %use_tlab = load i1, ptr @VMOptions.UseTLAB
+  br i1 %use_tlab, label %test_tlab, label %array_slow_path
+
+test_tlab:
+  %tlab_top_offset = load i64, ptr @JavaThread.tlab_top_offset
+  %tlab_end_offset = load i64, ptr @JavaThread.tlab_end_offset
+
+  %tlab_top_ptr = inttoptr i64 %tlab_top_offset to ptr addrspace(2)
+  %tlab_end_ptr = inttoptr i64 %tlab_end_offset to ptr addrspace(2)
+
+  %tlab_old_top = load ptr addrspace(1), ptr addrspace(2) %tlab_top_ptr, align 8
+  %tlab_end = load ptr addrspace(1), ptr addrspace(2) %tlab_end_ptr, align 8
+
+  %tlab_new_top = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %size_in_bytes
+  %if_tlab_full = icmp uge ptr addrspace(1) %tlab_new_top, %tlab_end
+  br i1 %if_tlab_full, label %array_slow_path, label %array_fast_path
+
+array_slow_path:
   %current_thread = call hotspotcc ptr @jeandle.current_thread()
-  %array_oop = call hotspotcc ptr addrspace(1) @new_array(ptr %array_klass, i32 %length, ptr %current_thread) [ "deopt"() ]
+  %slow_array_oop = call hotspotcc ptr addrspace(1) @new_array(ptr %array_klass, i32 %length, ptr %current_thread) [ "deopt"() ]
+  br label %array_return
+
+array_fast_path:
+  store ptr addrspace(1) %tlab_new_top, ptr addrspace(2) %tlab_top_ptr, align 8
+
+  ; Header: mark word, klass pointer, length. No inter-field barriers; the
+  ; trailing release fence publishes the whole object as a unit.
+  %mark_word_offset = load i32, ptr @oopDesc.mark_offset_in_bytes
+  %mark_word_addr = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %mark_word_offset
+
+  %klass_offset = load i32, ptr @oopDesc.klass_offset_in_bytes
+  %klass_addr = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %klass_offset
+
+  %length_offset = load i32, ptr @arrayOopDesc.length_offset_in_bytes
+  %length_addr = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %length_offset
+
+  %prototype_value = load i64, ptr @markWord.prototype_value
+
+  store atomic i64 %prototype_value, ptr addrspace(1) %mark_word_addr unordered, align 8
+  ; TODO: When UseCompressedClassPointers is enabled, klass should be stored as a 32-bit narrowKlass
+  ; instead of a full pointer. Currently this assumes uncompressed class pointers.
+  ; (Layout offsets -- oopDesc.klass_offset_in_bytes, arrayOopDesc.length_offset_in_bytes,
+  ; arrayOopDesc.base_offset_in_bytes -- are already CCP-aware because they flow through
+  ; oopDesc::klass_offset_in_bytes() / arrayOopDesc::base_offset_in_bytes() on the C++
+  ; side, so only the store width and the encoding (>> CompressedKlassPointers::shift())
+  ; need updating when CCP support is added. instance and array fast paths must be
+  ; upgraded together.)
+  store atomic ptr %array_klass, ptr addrspace(1) %klass_addr unordered, align 8
+  store atomic i32 %length, ptr addrspace(1) %length_addr unordered, align 4
+
+  %zero_tlab = load i1, ptr @VMOptions.ZeroTLAB
+  %skip_clear = and i1 %use_tlab, %zero_tlab
+  br i1 %skip_clear, label %array_init_membar, label %array_clear_memory
+
+array_clear_memory:
+  ; Explicit 8-byte-stride zero loop. We do NOT use @llvm.memset because LLVM's
+  ; default lowering produces poor code for both target backends we care about:
+  ;   - AArch64 (without MOPS): every memset, constant size or not, falls back
+  ;     to a per-byte strb loop -- the target hook in AArch64SelectionDAGInfo
+  ;     just `return SDValue()` and lets the generic SelectionDAG byte expansion
+  ;     take over. That's ~10x slower than the str xzr / stp xzr,xzr sequence
+  ;     HotSpot C1 emits.
+  ;   - x86: constant-size memset gets the rep stosq fast path, but variable
+  ;     size is bailed out by X86SelectionDAGInfo (`if (!ConstantSize) return
+  ;     SDValue();`) and ends up in the same generic per-byte loop. So variable-
+  ;     length arrays (the common `new T[N]` case in real workloads) regress on
+  ;     x86 too, not just AArch64.
+  ;
+  ; The stores must be `volatile` -- otherwise LLVM's LoopIdiomRecognize pass
+  ; folds an idiomatic "for(i=0;i<n;i++) p[i]=0" loop right back into
+  ; @llvm.memset, which round-trips through the same broken lowering. Volatile
+  ; stores are exempt from idiom recognition, so they survive into codegen as
+  ; plain str xzr (AArch64) / `mov qword ptr [...], 0` (x86) 8-byte stores.
+  ; LoopFullUnroll still applies for constant trip counts, so `new T[N]` with
+  ; N a compile-time constant becomes a fully unrolled sequence.
+  ;
+  ; TODO: For payloads larger than ~256 bytes (HotSpot AArch64
+  ; BlockZeroingLowLimit default), HotSpot's MacroAssembler::zero_words calls
+  ; the zero_blocks stub, which uses `dc zva` (64-byte cache-line zero). The
+  ; single-str loop here is ~4x slower than `dc zva` for large arrays; emitting
+  ; platform-specific inline asm or an LLVM target intrinsic for that tier is a
+  ; follow-up. The current loop already closes the biggest gap (per-byte ->
+  ; per-word).
+  ;
+  ; size_in_bytes is aligned to MinObjAlignmentInBytes (8) on the caller side,
+  ; and base_offset is always a multiple of 8, so payload_size is exactly
+  ; divisible by 8.
+  %base_addr = getelementptr i8, ptr addrspace(1) %tlab_old_top, i32 %base_offset
+  %payload_size = sub i32 %size_in_bytes, %base_offset
+  %payload_words = lshr exact i32 %payload_size, 3
+  %has_payload = icmp ne i32 %payload_words, 0
+  br i1 %has_payload, label %array_zero_loop, label %array_init_membar
+
+array_zero_loop:
+  %zi = phi i32 [ 0, %array_clear_memory ], [ %zi_next, %array_zero_loop ]
+  %zaddr = getelementptr i64, ptr addrspace(1) %base_addr, i32 %zi
+  store volatile i64 0, ptr addrspace(1) %zaddr, align 8
+  %zi_next = add nuw nsw i32 %zi, 1
+  %zero_done = icmp eq i32 %zi_next, %payload_words
+  br i1 %zero_done, label %array_init_membar, label %array_zero_loop
+
+array_init_membar:
+  ; TODO: Same plan as new_instance -- replace atomic stores + fence release with plain
+  ; stores plus a lightweight publish barrier once the supporting LLVM pass lands.
+  fence release
+  br label %array_return
+
+array_return:
+  %array_oop = phi ptr addrspace(1) [ %tlab_old_top, %array_init_membar ], [ %slow_array_oop, %array_slow_path ]
   ret ptr addrspace(1) %array_oop
 }
 

--- a/src/hotspot/share/jeandle/templatemodule/template.ll
+++ b/src/hotspot/share/jeandle/templatemodule/template.ll
@@ -332,12 +332,14 @@ declare hotspotcc ptr addrspace(1) @new_array(ptr, i32, ptr)
 ; Unified array allocation JavaOp.  Both bytecode (newarray/anewarray) and intrinsic
 ; (_newArray / Array.newInstance) paths call this function.
 ; LLVM passes identify array allocation by matching on this function name.
-define private hotspotcc ptr addrspace(1) @jeandle.new_array(ptr %array_klass, i32 %length) noinline "lower-phase"="1" {
+define private hotspotcc ptr addrspace(1) @jeandle.new_array(ptr %array_klass, i32 %length, i32 %size_in_bytes, i32 %base_offset, i32 %length_limit) noinline "lower-phase"="1" {
 entry:
-  ; Length bounds check first. arrayOopDesc::max_array_length() is signed, and a negative
-  ; %length (e.g. user-supplied -1) must go through the runtime to raise
-  ; NegativeArraySizeException, which the slow path handles.
-  %too_long = icmp ugt i32 %length, %max_length
+  ; Fast-path length cap. %length_limit is a size-derived bound (FastAllocateSizeLimit, scaled
+  ; by element size on the caller side) chosen so %size_in_bytes cannot overflow i32 -- it is
+  ; NOT arrayOopDesc::max_array_length(), which is ~max_jint on LP64 and would let a large
+  ; length wrap the size computation. The unsigned compare also routes a negative %length
+  ; (e.g. -1) to the slow path, where the runtime raises NegativeArraySizeException.
+  %too_long = icmp ugt i32 %length, %length_limit
   br i1 %too_long, label %array_slow_path, label %check_tlab
 
 check_tlab:

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocFastSlowPath.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocFastSlowPath.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/**
+ * @test
+ * @summary Verify fast path and slow path selection for array allocation via log output
+ * @library /test/lib /
+ * @run driver compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocFastSlowPath
+ */
+
+package compiler.jeandle.bytecodeTranslate.alloc;
+
+import java.util.List;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestArrayAllocFastSlowPath {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            // Child process mode
+            if (args[0].equals("typearray_small")) {
+                Asserts.assertEquals(allocate_int_array(), 8);
+            } else if (args[0].equals("objarray_small")) {
+                Asserts.assertEquals(allocate_object_array(), 4);
+            } else if (args[0].equals("typearray_stress")) {
+                Asserts.assertEquals(stress_allocate_int_array(50_000), 50_000L * 1024);
+            } else if (args[0].equals("objarray_stress")) {
+                Asserts.assertEquals(stress_allocate_object_array(50_000), 50_000L * 256);
+            }
+            return;
+        }
+
+        // Driver mode: run sub-tests
+        testFastPathTypeArray();
+        testFastPathObjectArray();
+        testSlowPathTLABExhaustionTypeArray();
+        testSlowPathTLABExhaustionObjectArray();
+        testSlowPathUseTLABDisabled();
+    }
+
+    public static int allocate_int_array() {
+        int[] a = new int[8];
+        return a.length;
+    }
+
+    public static int allocate_object_array() {
+        Object[] a = new Object[4];
+        return a.length;
+    }
+
+    // Repeatedly allocate medium arrays to force TLAB exhaustion under -Xmx5m -Xmn2m.
+    public static long stress_allocate_int_array(int loop) {
+        long sum = 0;
+        for (int i = 0; i < loop; i++) {
+            int[] a = new int[1024];
+            sum += a.length;
+        }
+        return sum;
+    }
+
+    public static long stress_allocate_object_array(int loop) {
+        long sum = 0;
+        for (int i = 0; i < loop; i++) {
+            Object[] a = new Object[256];
+            sum += a.length;
+        }
+        return sum;
+    }
+
+    // Small int[] within TLAB headroom => fast path (no slow-path log)
+    static void testFastPathTypeArray() throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(List.of(
+            "-Xcomp",
+            "-Xbatch",
+            "-XX:-TieredCompilation",
+            "-XX:+UseJeandleCompiler",
+            "-Xlog:jeandle+alloc=debug",
+            "-XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocFastSlowPath::allocate_int_array",
+            TestArrayAllocFastSlowPath.class.getName(),
+            "typearray_small"
+        ));
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+        output.shouldHaveExitValue(0);
+        output.shouldNotContain("Slow path allocation for [I");
+    }
+
+    // Small Object[] within TLAB headroom => fast path
+    static void testFastPathObjectArray() throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(List.of(
+            "-Xcomp",
+            "-Xbatch",
+            "-XX:-TieredCompilation",
+            "-XX:+UseJeandleCompiler",
+            "-Xlog:jeandle+alloc=debug",
+            "-XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocFastSlowPath::allocate_object_array",
+            TestArrayAllocFastSlowPath.class.getName(),
+            "objarray_small"
+        ));
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+        output.shouldHaveExitValue(0);
+        output.shouldNotContain("Slow path allocation for [Ljava.lang.Object;");
+    }
+
+    // Repeated medium int[] under small heap => slow path eventually fires
+    static void testSlowPathTLABExhaustionTypeArray() throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(List.of(
+            "-Xcomp",
+            "-Xbatch",
+            "-Xmx5m",
+            "-Xmn2m",
+            "-XX:-TieredCompilation",
+            "-XX:+UseJeandleCompiler",
+            "-Xlog:jeandle+alloc=debug",
+            "-XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocFastSlowPath::*",
+            TestArrayAllocFastSlowPath.class.getName(),
+            "typearray_stress"
+        ));
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+        output.shouldHaveExitValue(0);
+        output.shouldContain("Slow path allocation for [I");
+    }
+
+    // Repeated medium Object[] under small heap => slow path eventually fires
+    static void testSlowPathTLABExhaustionObjectArray() throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(List.of(
+            "-Xcomp",
+            "-Xbatch",
+            "-Xmx5m",
+            "-Xmn2m",
+            "-XX:-TieredCompilation",
+            "-XX:+UseJeandleCompiler",
+            "-Xlog:jeandle+alloc=debug",
+            "-XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocFastSlowPath::*",
+            TestArrayAllocFastSlowPath.class.getName(),
+            "objarray_stress"
+        ));
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+        output.shouldHaveExitValue(0);
+        output.shouldContain("Slow path allocation for [Ljava.lang.Object;");
+    }
+
+    // With -XX:-UseTLAB, all array allocations should go through slow path
+    static void testSlowPathUseTLABDisabled() throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(List.of(
+            "-Xcomp",
+            "-Xbatch",
+            "-XX:-TieredCompilation",
+            "-XX:-UseTLAB",
+            "-XX:+UseJeandleCompiler",
+            "-Xlog:jeandle+alloc=debug",
+            "-XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocFastSlowPath::allocate_int_array",
+            TestArrayAllocFastSlowPath.class.getName(),
+            "typearray_small"
+        ));
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+        output.shouldHaveExitValue(0);
+        output.shouldContain("Slow path allocation for [I");
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocFastSlowPath.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocFastSlowPath.java
@@ -46,6 +46,8 @@ public class TestArrayAllocFastSlowPath {
                 Asserts.assertEquals(stress_allocate_int_array(50_000), 50_000L * 1024);
             } else if (args[0].equals("objarray_stress")) {
                 Asserts.assertEquals(stress_allocate_object_array(50_000), 50_000L * 256);
+            } else if (args[0].equals("typearray_over_limit")) {
+                Asserts.assertEquals(allocate_large_int_array(300_000), 300_000);
             }
             return;
         }
@@ -56,6 +58,7 @@ public class TestArrayAllocFastSlowPath {
         testSlowPathTLABExhaustionTypeArray();
         testSlowPathTLABExhaustionObjectArray();
         testSlowPathUseTLABDisabled();
+        testSlowPathOverSizeLimitTypeArray();
     }
 
     public static int allocate_int_array() {
@@ -65,6 +68,15 @@ public class TestArrayAllocFastSlowPath {
 
     public static int allocate_object_array() {
         Object[] a = new Object[4];
+        return a.length;
+    }
+
+    // ~1.2 MB int[], length over the fast-path size limit (FastAllocateSizeLimit, 262144 ints
+    // for T_INT). The compiled length guard branches to the slow path before the TLAB check, so
+    // an over-limit length can never reach the bump-pointer fast path -- this is the guard that
+    // keeps a large length from wrapping the i32 size computation.
+    public static int allocate_large_int_array(int n) {
+        int[] a = new int[n];
         return a.length;
     }
 
@@ -171,6 +183,26 @@ public class TestArrayAllocFastSlowPath {
             "-XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocFastSlowPath::allocate_int_array",
             TestArrayAllocFastSlowPath.class.getName(),
             "typearray_small"
+        ));
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+        output.shouldHaveExitValue(0);
+        output.shouldContain("Slow path allocation for [I");
+    }
+
+    // int[] length over the fast-path size limit must decline the fast path. The compiled length
+    // guard branches to the slow path before the TLAB check, so this exercises the
+    // FastAllocateSizeLimit guard that prevents the i32 size_in_bytes overflow -- not a TLAB
+    // miss. TLAB defaults are left untouched; the over-limit length alone forces the slow path.
+    static void testSlowPathOverSizeLimitTypeArray() throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(List.of(
+            "-Xcomp",
+            "-Xbatch",
+            "-XX:-TieredCompilation",
+            "-XX:+UseJeandleCompiler",
+            "-Xlog:jeandle+alloc=debug",
+            "-XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocFastSlowPath::allocate_large_int_array",
+            TestArrayAllocFastSlowPath.class.getName(),
+            "typearray_over_limit"
         ));
         OutputAnalyzer output = ProcessTools.executeCommand(pb);
         output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocLengthBoundary.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocLengthBoundary.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package compiler.jeandle.bytecodeTranslate.alloc;
+
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @summary Verify array length boundary handling: zero length succeeds via fast path,
+ *          negative length triggers NegativeArraySizeException via slow path, and a
+ *          length above arrayOopDesc::max_array_length still raises the appropriate VM error.
+ * @library /test/lib
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *      -XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocLengthBoundary::test*
+ *      -XX:+UseJeandleCompiler compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocLengthBoundary
+ */
+public class TestArrayAllocLengthBoundary {
+
+    public static int[] test_zero_length_int_array(int n) {
+        return new int[n];
+    }
+
+    public static Object[] test_zero_length_object_array(int n) {
+        return new Object[n];
+    }
+
+    public static int[] test_negative_length(int n) {
+        // Compiled fast path's unsigned length check sends n=-1 (0xFFFFFFFF > max_array_length)
+        // into the slow path, where the runtime raises NegativeArraySizeException.
+        return new int[n];
+    }
+
+    public static int[] test_huge_length(int n) {
+        // arrayOopDesc::max_array_length(T_INT) ~ Integer.MAX_VALUE - small. n = MAX_VALUE
+        // exceeds the unsigned bound and goes through the slow path which raises OOM.
+        return new int[n];
+    }
+
+    public static void main(String[] args) {
+        // (1) length == 0 -> fast path produces a valid empty array.
+        int[] empty = test_zero_length_int_array(0);
+        Asserts.assertEquals(empty.length, 0);
+
+        Object[] emptyRef = test_zero_length_object_array(0);
+        Asserts.assertEquals(emptyRef.length, 0);
+
+        // (2) length < 0 -> NegativeArraySizeException via slow path.
+        boolean negativeCaught = false;
+        try {
+            int[] a = test_negative_length(-1);
+            // Defensive: should never reach here; reference a to keep liveness.
+            Asserts.fail("Expected NegativeArraySizeException, got array of length " + a.length);
+        } catch (NegativeArraySizeException e) {
+            negativeCaught = true;
+        }
+        Asserts.assertTrue(negativeCaught, "NegativeArraySizeException not thrown for length=-1");
+
+        // (3) length above max -> the slow path raises OutOfMemoryError (HotSpot's standard
+        // behavior when length > max_array_length). We catch broadly here because the
+        // precise exception type may vary by VM (some versions throw an OOME, others an
+        // Error subclass). The intent is just to confirm the fast path declined.
+        boolean tooBigCaught = false;
+        try {
+            int[] a = test_huge_length(Integer.MAX_VALUE);
+            Asserts.fail("Expected OutOfMemoryError, got array of length " + a.length);
+        } catch (OutOfMemoryError e) {
+            tooBigCaught = true;
+        } catch (Throwable t) {
+            // Accept any Error/RuntimeException from the runtime -- the point is we did
+            // not silently take the fast path for an out-of-range length.
+            tooBigCaught = true;
+        }
+        Asserts.assertTrue(tooBigCaught, "VM error not thrown for length=Integer.MAX_VALUE");
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocLengthBoundary.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocLengthBoundary.java
@@ -73,21 +73,20 @@ public class TestArrayAllocLengthBoundary {
         }
         Asserts.assertTrue(negativeCaught, "NegativeArraySizeException not thrown for length=-1");
 
-        // (3) length above max -> the slow path raises OutOfMemoryError (HotSpot's standard
-        // behavior when length > max_array_length). We catch broadly here because the
-        // precise exception type may vary by VM (some versions throw an OOME, others an
-        // Error subclass). The intent is just to confirm the fast path declined.
+        // (3) length above max_array_length -> the runtime rejects it by VM limit and raises
+        // OutOfMemoryError. Keep the assertion OUTSIDE the try and the catch narrow: a
+        // `catch (Throwable)` around an inner Asserts.fail() would swallow its own
+        // RuntimeException and pass even if the allocation wrongly succeeded -- masking exactly
+        // the fast-path size guard this test is meant to protect.
+        int[] tooBig = null;
         boolean tooBigCaught = false;
         try {
-            int[] a = test_huge_length(Integer.MAX_VALUE);
-            Asserts.fail("Expected OutOfMemoryError, got array of length " + a.length);
+            tooBig = test_huge_length(Integer.MAX_VALUE);
         } catch (OutOfMemoryError e) {
             tooBigCaught = true;
-        } catch (Throwable t) {
-            // Accept any Error/RuntimeException from the runtime -- the point is we did
-            // not silently take the fast path for an out-of-range length.
-            tooBigCaught = true;
         }
-        Asserts.assertTrue(tooBigCaught, "VM error not thrown for length=Integer.MAX_VALUE");
+        Asserts.assertTrue(tooBigCaught,
+            "Expected OutOfMemoryError for length=Integer.MAX_VALUE, but allocation returned"
+            + (tooBig != null ? " array of length " + tooBig.length : " no exception"));
     }
 }

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocZeroing.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/alloc/TestArrayAllocZeroing.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package compiler.jeandle.bytecodeTranslate.alloc;
+
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @summary Verify that newly TLAB-fast-path-allocated arrays are zero-initialized for
+ *          every element type, including when ZeroTLAB is enabled and the compiled
+ *          memset is skipped.
+ * @library /test/lib
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *      -XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocZeroing::test*
+ *      -XX:+UseJeandleCompiler compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocZeroing
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+ZeroTLAB
+ *      -XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocZeroing::test*
+ *      -XX:+UseJeandleCompiler compiler.jeandle.bytecodeTranslate.alloc.TestArrayAllocZeroing
+ */
+public class TestArrayAllocZeroing {
+
+    // Each test_* method allocates and returns the array. The driver verifies each
+    // element is the default zero value for the element type. Using 1024 elements
+    // forces the memset (or the TLAB pre-zeroing under ZeroTLAB) to span several
+    // cache lines, exercising the compiled zeroing path end-to-end.
+    static final int N = 1024;
+
+    public static boolean[] test_boolean_array() { return new boolean[N]; }
+    public static byte[]    test_byte_array()    { return new byte[N];    }
+    public static char[]    test_char_array()    { return new char[N];    }
+    public static short[]   test_short_array()   { return new short[N];   }
+    public static int[]     test_int_array()     { return new int[N];     }
+    public static long[]    test_long_array()    { return new long[N];    }
+    public static float[]   test_float_array()   { return new float[N];   }
+    public static double[]  test_double_array()  { return new double[N];  }
+    public static Object[]  test_object_array()  { return new Object[N];  }
+    public static String[]  test_string_array()  { return new String[N];  }
+
+    public static void main(String[] args) {
+        boolean[] booleans = test_boolean_array();
+        for (int i = 0; i < N; i++) Asserts.assertFalse(booleans[i], "boolean at " + i);
+
+        byte[] bytes = test_byte_array();
+        for (int i = 0; i < N; i++) Asserts.assertEquals(bytes[i], (byte) 0, "byte at " + i);
+
+        char[] chars = test_char_array();
+        for (int i = 0; i < N; i++) Asserts.assertEquals(chars[i], (char) 0, "char at " + i);
+
+        short[] shorts = test_short_array();
+        for (int i = 0; i < N; i++) Asserts.assertEquals(shorts[i], (short) 0, "short at " + i);
+
+        int[] ints = test_int_array();
+        for (int i = 0; i < N; i++) Asserts.assertEquals(ints[i], 0, "int at " + i);
+
+        long[] longs = test_long_array();
+        for (int i = 0; i < N; i++) Asserts.assertEquals(longs[i], 0L, "long at " + i);
+
+        float[] floats = test_float_array();
+        for (int i = 0; i < N; i++) Asserts.assertEquals(floats[i], 0.0f, "float at " + i);
+
+        double[] doubles = test_double_array();
+        for (int i = 0; i < N; i++) Asserts.assertEquals(doubles[i], 0.0d, "double at " + i);
+
+        Object[] objects = test_object_array();
+        for (int i = 0; i < N; i++) Asserts.assertNull(objects[i], "Object[] at " + i);
+
+        String[] strings = test_string_array();
+        for (int i = 0; i < N; i++) Asserts.assertNull(strings[i], "String[] at " + i);
+    }
+}


### PR DESCRIPTION
Extend the TLAB instance fast path from #269 with Array TLAB fast path

## Related issue(s):

issue #463 

## What this PR does / why we need it:

The compiler emits only the existing-TLAB bump-pointer path. The runtime owns TLAB refill, allocation outside TLAB (humongous, slow allocator), class initialization fallback, and all exception construction (`NegativeArraySizeException`, `OutOfMemoryError`). The slow path remains the semantic source of truth.

### Array fast path

`jeandle.newarray` is invoked with `(klass, length, size_in_bytes, base_offset, max_length)`. The frontend (`do_unified_newarray` in `jeandleAbstractInterpreter.cpp`) decodes the array klass at IR build time using `Klass::layout_helper()`:

- `log2_element_size = Klass::layout_helper_log2_element_size(lh)`
- `base_offset = arrayOopDesc::base_offset_in_bytes(element_type)`
- `max_length = arrayOopDesc::max_array_length(element_type)`
- `size_in_bytes = align((length << log2_element_size) + base_offset, MinObjAlignmentInBytes)` — computed in IR. When `length` is a compile-time constant (the common case), LLVM folds shift + add + and into the constant size at the call site, so the bump-pointer is branch-free in the hot path.

The JavaOp body then performs:

1. **Pre-checks**: branch to slow path if `length < 0` or `(unsigned) length > max_length`. A single unsigned compare covers both negative-as-large-unsigned and the per-element-type overflow cap. We never throw from IR — the runtime is responsible for constructing the right exception with the right stack.
2. **Bump-pointer**: load `JavaThread.tlab_top` / `tlab_end`, compute `new_top`, compare against `tlab_end`, branch to slow path on miss, store `new_top` back to `tlab_top`.
3. **Prefetch** ：Not Implement
4. **Header / length / body**:
   - store mark word (`markWord::prototype()`)
   - store full 64-bit klass pointer
   - store `length`
   - `memset` payload (skipped under `ZeroTLAB`)
5. **Publish** with `fence release`.

The store ordering matches HotSpot C1 (`c1_MacroAssembler_aarch64.cpp:181-199`). `length` must be stored before body zeroing, because the `memset` length is derived from it.

