### PR TITLE
fix: stackmap parser crash caused by merged deopt bundles in inlined Java uncommon traps

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -1860,6 +1860,27 @@ void JeandleAbstractInterpreter::invoke() {
   llvm::InvokeInst* invoke = _ir_builder.CreateInvoke(callee, dispatched._normal_dest, dispatched._unwind_dest, args,
                                                       {create_current_deopt_bundle()});
 
+  // If the callee contains any calls with "deopt" operand bundles, inlining
+  // would cause the parent's deopt bundle to be prepended to the child's,
+  // breaking the deopt state encoding.  Prevent inlining in that case.
+  if (auto *callee_func = llvm::dyn_cast<llvm::Function>(callee.getCallee())) {
+    if (!callee_func->isDeclaration()) {
+      bool has_deopt = false;
+      for (auto &BB : *callee_func) {
+        for (auto &I : BB) {
+          if (auto *CB = llvm::dyn_cast<llvm::CallBase>(&I)) {
+            if (CB->getOperandBundle(llvm::LLVMContext::OB_deopt)) {
+              has_deopt = true;
+              break;
+            }
+          }
+        }
+        if (has_deopt) break;
+      }
+      if (has_deopt) invoke->setIsNoInline();
+    }
+  }
+
   // Continue to interpret the remaining bytecodes in the current JeandleBasicBlock at dispatched._normal_dest.
   _ir_builder.SetInsertPoint(dispatched._normal_dest);
 

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -25,6 +25,7 @@
 #include "llvm/IR/Jeandle/GCStrategy.h"
 #include "llvm/IR/Jeandle/JavaType.h"
 #include "llvm/IR/Jeandle/Metadata.h"
+#include "llvm/IR/InstIterator.h"
 
 
 #include "jeandle/jeandleAbstractInterpreter.hpp"
@@ -1865,19 +1866,14 @@ void JeandleAbstractInterpreter::invoke() {
   // breaking the deopt state encoding.  Prevent inlining in that case.
   if (auto *callee_func = llvm::dyn_cast<llvm::Function>(callee.getCallee())) {
     if (!callee_func->isDeclaration()) {
-      bool has_deopt = false;
-      for (auto &BB : *callee_func) {
-        for (auto &I : BB) {
-          if (auto *CB = llvm::dyn_cast<llvm::CallBase>(&I)) {
-            if (CB->getOperandBundle(llvm::LLVMContext::OB_deopt)) {
-              has_deopt = true;
-              break;
-            }
+      for (auto &I : instructions(callee_func)) {
+        if (auto *CB = llvm::dyn_cast<llvm::CallBase>(&I)) {
+          if (CB->getOperandBundle(llvm::LLVMContext::OB_deopt)) {
+            invoke->setIsNoInline();
+            break;
           }
         }
-        if (has_deopt) break;
       }
-      if (has_deopt) invoke->setIsNoInline();
     }
   }
 

--- a/test/jdk/ProblemList-jeandle.txt
+++ b/test/jdk/ProblemList-jeandle.txt
@@ -36,18 +36,6 @@ java/math/BigInteger/largeMemory/SymmetricRangeTests.java                  linux
 jdk/jfr/event/gc/configuration/TestGCConfigurationEvent.java               linux-aarch64,linux-x64
 
 ###
-# Bug - JVM crash in Jeandle implementation
-###
-# JVM crash (SIGABRT, exit code 134) during HTTP client test
-java/net/httpclient/ShortResponseBodyGet.java                              linux-aarch64
-
-# JVM crash (SIGSEGV, exit code 139) during HTTP client test
-java/net/httpclient/ShortResponseBodyPost.java                             linux-aarch64,linux-x64
-
-# JVM crash (SIGABRT, exit code 134) during HTTP client test
-java/net/httpclient/ShortResponseBodyPostWithRetry.java                    linux-aarch64,linux-x64
-
-###
 # Environment/Infrastructure issues (not Jeandle-specific)
 ###
 # Network interface aliasing in container (eth0/p0 share same IP/MAC)


### PR DESCRIPTION

## Related issue(s):

issue #462 

## What this PR does / why we need it:
plz refer #462 
