### PR TITLE
enhance: keep the first compilation error msg during error reporting

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -62,7 +62,7 @@ class JeandleCompilation : public StackObj {
 
   // Error related:
   void report_error(const char* msg) {
-    if (msg != nullptr) {
+    if (msg != nullptr && _error_msg == nullptr) {
       _error_msg = msg;
     }
   }


### PR DESCRIPTION
## Related issue(s):

issue #489

## What this PR does / why we need it:

Fixes #489

add `_error_msg == nullptr` to make sure the `_error_msg` is first error msg