### PR TITLE
fix: initialize _has_monitors in JeandleCompilation constructors to avoid UB

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -125,6 +125,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                        _context(std::make_unique<llvm::LLVMContext>()),
                                        _code(env, method),
                                        _error_msg(nullptr),
+                                       _has_monitors(false),
                                        _const_section_alignment(-1) {
 
   const char* reason = check_can_parse(method);
@@ -175,6 +176,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                        _llvm_module(std::make_unique<llvm::Module>(name, *_context)),
                                        _code(_env, name),
                                        _error_msg(nullptr),
+                                       _has_monitors(false),
                                        _const_section_alignment(-1) {
   initialize();
 


### PR DESCRIPTION
Verified with clang-tidy (cppcoreguidelines-pro-type-member-init):

- After fix:  `_has_monitors` no longer appears in the warning output


## Test 

`clang-tidy \
  -p /data/jeandle-jdk \
  -checks='-*,cppcoreguidelines-pro-type-member-init' \
  src/hotspot/share/jeandle/jeandleCompilation.cpp`
  ### output
`
/data/jeandle-jdk/src/hotspot/share/jeandle/jeandleCompilation.cpp:112:1: warning: constructor does not initialize these fields: _arena, _name, _context, _llvm_module, _comp_start_time, _trap_hist [cppcoreguidelines-pro-type-member-init]
`