### PR TITLE
feat: Support invokevirtual and invokeinterface CHA optimization.

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -405,6 +405,15 @@ ciInstanceKlass* ciEnv::get_box_klass_for_primitive_type(BasicType type) {
   }
 }
 
+ciInstanceKlass* ciEnv::get_instance_klass_for_klass(Klass* klass) {
+  if (klass == nullptr) {
+    return nullptr;
+  }
+  assert(klass->is_instance_klass(), "must be instance klass");
+  VM_ENTRY_MARK;
+  return get_instance_klass(klass);
+}
+
 ciInstance* ciEnv::ArrayIndexOutOfBoundsException_instance() {
   if (_ArrayIndexOutOfBoundsException_instance == nullptr) {
     _ArrayIndexOutOfBoundsException_instance

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -423,6 +423,7 @@ public:
   ciInstance* unloaded_ciinstance();
 
   ciInstanceKlass* get_box_klass_for_primitive_type(BasicType type);
+  ciInstanceKlass* get_instance_klass_for_klass(Klass* klass);
 
   ciKlass*  find_system_klass(ciSymbol* klass_name);
 

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -26,13 +26,14 @@
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/Jeandle/Attributes.h"
+#include "llvm/IR/Jeandle/Deoptimization.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
 #include "llvm/IR/Jeandle/JavaType.h"
 #include "llvm/IR/Jeandle/Metadata.h"
 
-
 #include "jeandle/jeandleAbstractInterpreter.hpp"
 #include "jeandle/jeandleCompiledCall.hpp"
+#include "jeandle/jeandleCompiledCode.hpp"
 #include "jeandle/jeandleIntrinsicLowering.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 #include "jeandle/jeandleType.hpp"
@@ -56,6 +57,9 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/ostream.hpp"
+
+using llvm::jeandle::DeoptValueEncoding;
+using llvm::jeandle::HotspotBasicType;
 
 JeandleVMState::JeandleVMState(int max_stack, int max_locals, llvm::LLVMContext *context) :
                                _stack(), _locals(max_locals), _locks(), _context(context) {
@@ -256,10 +260,10 @@ llvm::SmallVector<llvm::Value*> JeandleVMState::deopt_args(llvm::IRBuilder<>& bu
   /* TODO: scalar */
 
   if (parse_context.is_inlinee()) {
-    uint64_t encode = DeoptValueEncoding(0, DeoptValueEncoding::MethodType, T_METADATA).encode();
+    uint64_t encode = DeoptValueEncoding(0, DeoptValueEncoding::MethodType, llvm::jeandle::T_METADATA).encode();
 #ifdef ASSERT
     if (log_is_enabled(Trace, jeandle)) {
-      DeoptValueEncoding::decode(encode).print();
+      print_deopt_value(DeoptValueEncoding::decode(encode));
     }
 #endif
     args.push_back(builder.getInt64(encode));
@@ -287,10 +291,11 @@ llvm::SmallVector<llvm::Value*> JeandleVMState::deopt_args(llvm::IRBuilder<>& bu
     // slots (one per word) so the two-slot layout of later locals stays aligned.
     bool dead = !_locals[i].is_null() && liveness.is_valid() && !liveness.at(i);
     if (!_locals[i].is_null() && !dead) {
-      uint64_t encode = DeoptValueEncoding(i, DeoptValueEncoding::LocalType, _locals[i].computational_type()).encode();
+      uint64_t encode = DeoptValueEncoding(i, DeoptValueEncoding::LocalType, 
+          static_cast<HotspotBasicType>(_locals[i].computational_type())).encode();
 #ifdef ASSERT
       if (log_is_enabled(Trace, jeandle)) {
-        DeoptValueEncoding::decode(encode).print();
+        print_deopt_value(DeoptValueEncoding::decode(encode));
       }
 #endif
       args.push_back(builder.getInt64(encode));
@@ -303,10 +308,11 @@ llvm::SmallVector<llvm::Value*> JeandleVMState::deopt_args(llvm::IRBuilder<>& bu
       // A dead double-word local takes two illegal slots, indexed i and i+1.
       int slots = (!_locals[i].is_null() && is_double_word) ? 2 : 1;
       for (int s = 0; s < slots; s++) {
-        uint64_t encode = DeoptValueEncoding(i + s, DeoptValueEncoding::LocalType, T_ILLEGAL).encode();
+        uint64_t encode = DeoptValueEncoding(i + s, DeoptValueEncoding::LocalType, 
+            llvm::jeandle::T_ILLEGAL).encode();
 #ifdef ASSERT
         if (log_is_enabled(Trace, jeandle)) {
-          DeoptValueEncoding::decode(encode).print();
+          print_deopt_value(DeoptValueEncoding::decode(encode));
         }
 #endif
         args.push_back(builder.getInt64(encode));
@@ -319,10 +325,11 @@ llvm::SmallVector<llvm::Value*> JeandleVMState::deopt_args(llvm::IRBuilder<>& bu
   }
   for (size_t i = 0; i < _stack.size(); i++) {
     if (!_stack[i].is_null()) {
-      uint64_t encode = DeoptValueEncoding(i, DeoptValueEncoding::StackType, stack_computational_type_at(i)).encode();
+      uint64_t encode = DeoptValueEncoding(i, DeoptValueEncoding::StackType,
+          static_cast<HotspotBasicType>(stack_computational_type_at(i))).encode();
 #ifdef ASSERT
       if (log_is_enabled(Trace, jeandle)) {
-        DeoptValueEncoding::decode(encode).print();
+        print_deopt_value(DeoptValueEncoding::decode(encode));
       }
 #endif
       args.push_back(builder.getInt64(encode));
@@ -332,10 +339,10 @@ llvm::SmallVector<llvm::Value*> JeandleVMState::deopt_args(llvm::IRBuilder<>& bu
       }
     } else {
       // replace with {T_ILLEGAL, 0}
-      uint64_t encode = DeoptValueEncoding(i, DeoptValueEncoding::StackType, T_ILLEGAL).encode();
+      uint64_t encode = DeoptValueEncoding(i, DeoptValueEncoding::StackType, llvm::jeandle::T_ILLEGAL).encode();
 #ifdef ASSERT
       if (log_is_enabled(Trace, jeandle)) {
-        DeoptValueEncoding::decode(encode).print();
+        print_deopt_value(DeoptValueEncoding::decode(encode));
       }
 #endif
       args.push_back(builder.getInt64(encode));
@@ -347,10 +354,11 @@ llvm::SmallVector<llvm::Value*> JeandleVMState::deopt_args(llvm::IRBuilder<>& bu
     TypedValue obj = _locks[i].object();
     assert(obj.computational_type() == T_OBJECT, "should be object type");
     llvm::Value* lock = _locks[i].lock();
-    uint64_t encode = DeoptValueEncoding(i, DeoptValueEncoding::MonitorType, obj.computational_type()).encode();
+    uint64_t encode = DeoptValueEncoding(i, DeoptValueEncoding::MonitorType,
+                                        static_cast<HotspotBasicType>(obj.computational_type())).encode();
 #ifdef ASSERT
     if (log_is_enabled(Trace, jeandle)) {
-      DeoptValueEncoding::decode(encode).print();
+      print_deopt_value(DeoptValueEncoding::decode(encode));
     }
 #endif
     args.push_back(builder.getInt64(encode));
@@ -360,10 +368,10 @@ llvm::SmallVector<llvm::Value*> JeandleVMState::deopt_args(llvm::IRBuilder<>& bu
   if (parse_context.is_root()) {
     llvm::Value* orig_pc_slot = JeandleCompilation::current()->compiled_code()->orig_pc_slot();
     assert(orig_pc_slot != nullptr, "sanity");
-    uint64_t encode = DeoptValueEncoding(0, DeoptValueEncoding::OrigPcSlotType, T_ADDRESS).encode();
+    uint64_t encode = DeoptValueEncoding(0, DeoptValueEncoding::OrigPcSlotType, llvm::jeandle::T_ADDRESS).encode();
 #ifdef ASSERT
     if (log_is_enabled(Trace, jeandle)) {
-      DeoptValueEncoding::decode(encode).print();
+      print_deopt_value(DeoptValueEncoding::decode(encode));
     }
 #endif
     args.push_back(builder.getInt64(encode));
@@ -2067,9 +2075,9 @@ void JeandleAbstractInterpreter::invoke() {
   llvm::Function* func = llvm::cast<llvm::Function>(callee.getCallee());
   func->setCallingConv(llvm::CallingConv::Hotspot_JIT);
   func->setGC(llvm::jeandle::JeandleGC);
-  func->addFnAttr(llvm::Attribute::get(func->getContext(),
-                                       llvm::jeandle::Attribute::JavaMethod,
-                                       std::to_string((uintptr_t)target)));
+  func->addFnAttr(llvm::Attribute::get(*_context,
+      llvm::jeandle::Attribute::JavaMethod,
+      std::to_string(reinterpret_cast<uintptr_t>(target))));
   // Accessor-only inlining may be decided before LLVM asks the VM to parse the
   // callee body, so declarations must carry the same marker as definitions.
   if (target->is_accessor()) {
@@ -2145,8 +2153,16 @@ void JeandleAbstractInterpreter::invoke() {
   llvm::Attribute patch_bytes_attr = llvm::Attribute::get(*_context,
                                                  llvm::jeandle::Attribute::StatepointNumPatchBytes,
                                                  std::to_string(JeandleCompiledCall::call_site_patch_size(call_type)));
+  llvm::Attribute bc_attr = llvm::Attribute::get(*_context,
+                                                 llvm::jeandle::Attribute::Bytecode,
+                                                 Bytecodes::name(bc));
+  llvm::Attribute declared_holder_attr = llvm::Attribute::get(*_context,
+                                                 llvm::jeandle::Attribute::DeclaredHolder,
+                                                 std::to_string(reinterpret_cast<uintptr_t>(ciEnv::get_instance_klass_for_declared_method_holder(holder))));
   invoke->addFnAttr(id_attr);
   invoke->addFnAttr(patch_bytes_attr);
+  invoke->addFnAttr(bc_attr);
+  invoke->addFnAttr(declared_holder_attr);
   if (target->can_be_statically_bound()) {
     invoke->addFnAttr(llvm::Attribute::get(*_context,
                                             llvm::jeandle::Attribute::MonomorphicTarget));

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -18,17 +18,20 @@
  *
  */
 
+#include "compiler/compilerDefinitions.hpp"
 #include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Jeandle/Jeandle.h"
 #include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/Jeandle/Attributes.h"
 #include "llvm/IR/Jeandle/GCStrategy.h"
 #include "llvm/IR/Jeandle/Metadata.h"
 #include "llvm/IR/Jeandle/VMCallbackLog.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Metadata.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"
@@ -173,7 +176,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                        _inline_tree_root(nullptr),
                                        _oops(),
                                        _oop_idx(0),
-                                       _code(env, method),
+                                       _code(env, method, entry_bci != InvocationEntryBci),
                                        _error_msg(nullptr),
                                        _has_monitors(false),
                                        _const_section_alignment(-1) {
@@ -343,7 +346,8 @@ bool JeandleCompilation::over_inlining_cutoff() const {
     return true;
   }
 
-  std::string root_name = JeandleFuncSig::method_name_with_signature(_method);
+  std::string root_name = JeandleFuncSig::method_name_with_signature(
+      _method, is_osr_compilation());
   llvm::Function* root = _llvm_module->getFunction(root_name);
   assert(root != nullptr, "root Java method function must exist");
 
@@ -965,7 +969,7 @@ void JeandleCompilation::dump_inline_callee_replay_module() {
   assert(_llvm_module != nullptr, "llvm module must exist");
   std::unique_ptr<llvm::Module> replay_module = llvm::CloneModule(*_llvm_module);
   assert(replay_module != nullptr, "failed to clone inline callee replay module");
-  std::string root_name = JeandleFuncSig::method_name_with_signature(_method);
+  std::string root_name = JeandleFuncSig::method_name_with_signature(_method, is_osr_compilation());
 
   // Keep only non-root Java method bodies for replay. Calls inside those methods
   // may still reference helper/runtime declarations, so non-replay functions are
@@ -1070,6 +1074,13 @@ void JeandleCompilation::setup_llvm_module(llvm::MemoryBuffer* template_buffer) 
 
   llvm::NamedMDNode* metadata_node = _llvm_module->getOrInsertNamedMetadata(llvm::jeandle::Metadata::JavaMethodCompilation);
   assert(metadata_node != nullptr, "invalid metadata node");
+  llvm::NamedMDNode* patch_node = _llvm_module->getOrInsertNamedMetadata(llvm::jeandle::Metadata::StaticCallPatchSize);
+  assert(patch_node != nullptr, "invalid patch node");
+  llvm::Metadata* patch_size_md =
+    llvm::ConstantAsMetadata::get(
+      llvm::ConstantInt::get(llvm::Type::getInt32Ty(*_context),
+                                JeandleCompiledCall::call_site_patch_size(JeandleCompiledCall::STATIC_CALL)));
+  patch_node->addOperand(llvm::MDNode::get(*_context, patch_size_md));
 }
 
 static std::string construct_dump_path(const std::string& method_name,

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -1074,13 +1074,6 @@ void JeandleCompilation::setup_llvm_module(llvm::MemoryBuffer* template_buffer) 
 
   llvm::NamedMDNode* metadata_node = _llvm_module->getOrInsertNamedMetadata(llvm::jeandle::Metadata::JavaMethodCompilation);
   assert(metadata_node != nullptr, "invalid metadata node");
-  llvm::NamedMDNode* patch_node = _llvm_module->getOrInsertNamedMetadata(llvm::jeandle::Metadata::StaticCallPatchSize);
-  assert(patch_node != nullptr, "invalid patch node");
-  llvm::Metadata* patch_size_md =
-    llvm::ConstantAsMetadata::get(
-      llvm::ConstantInt::get(llvm::Type::getInt32Ty(*_context),
-                                JeandleCompiledCall::call_site_patch_size(JeandleCompiledCall::STATIC_CALL)));
-  patch_node->addOperand(llvm::MDNode::get(*_context, patch_size_md));
 }
 
 static std::string construct_dump_path(const std::string& method_name,

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -177,7 +177,7 @@ class JeandleCompilation : public StackObj {
 
   const std::string name() { return _name; }
 
-  bool is_osr_compilation() { return _entry_bci != InvocationEntryBci; }
+  bool is_osr_compilation() const { return _entry_bci != InvocationEntryBci; }
   bool over_inlining_cutoff() const;
   void* replay_inline_data() const { return _replay_inline_data; }
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -505,7 +505,7 @@ void JeandleCompiledCode::fill_one_scope_value(const StackMapParser& stackmaps,
                                                GrowableArray<ScopeValue*>* array) {
   assert(array != nullptr, "sanity");
   bool is_constant = StackMapUtil::is_constant(location);
-  switch (encode._basic_type) {
+  switch (static_cast<BasicType>(encode.basicType())) {
   case T_INT: {
     if (is_constant) {
       jint const_int = JeandleBitCast::bit_cast<jint>(StackMapUtil::getConstantUint(stackmaps, location));
@@ -576,7 +576,7 @@ void JeandleCompiledCode::fill_one_monitor_value(const StackMapParser& stackmaps
                                                  const StackMapParser::LocationAccessor& lock,
                                                  GrowableArray<MonitorValue*>* array) {
   assert(array != nullptr, "sanity");
-  assert(encode._basic_type == T_OBJECT, "should be");
+  assert(static_cast<BasicType>(encode.basicType()) == T_OBJECT, "should be");
 
   bool is_constant = StackMapUtil::is_constant(object);
   ScopeValue* locked_object = nullptr;
@@ -679,11 +679,11 @@ JeandleStackMap* JeandleCompiledCode::parse_stackmap(StackMapParser& stackmaps,
 
     uint64_t encode = StackMapUtil::getConstantUlong(stackmaps, encode_location);
     DeoptValueEncoding enc = DeoptValueEncoding::decode(encode);
-    int type = enc._value_type;
+    int type = enc.valueType();
 
 #ifdef ASSERT
     if (log_is_enabled(Trace, jeandle)) {
-      enc.print();
+      print_deopt_value(enc);
     }
 #endif
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -27,6 +27,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/IR/Statepoint.h"
+#include "llvm/IR/Jeandle/Deoptimization.h"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Object/StackMapParser.h"
 #include "llvm/Support/DynamicLibrary.h"
@@ -38,7 +39,6 @@
 #include "jeandle/jeandleReadELF.hpp"
 #include "jeandle/jeandleResourceObj.hpp"
 #include "jeandle/jeandleUtils.hpp"
-#include "llvm/IR/Jeandle/Deoptimization.h"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "asm/codeBuffer.hpp"

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -38,6 +38,7 @@
 #include "jeandle/jeandleReadELF.hpp"
 #include "jeandle/jeandleResourceObj.hpp"
 #include "jeandle/jeandleUtils.hpp"
+#include "llvm/IR/Jeandle/Deoptimization.h"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "asm/codeBuffer.hpp"
@@ -50,70 +51,29 @@
 
 class JeandleReloc;
 
-class DeoptValueEncoding {
-  friend class JeandleCompiledCode;
-public:
-  enum DeoptValueType {
-    LocalType = 0,
-    StackType = 1,
-    ArgumentType = 2,
-    MonitorType = 3,
-    ScalarValueType = 4,
-    OrigPcSlotType = 5,
-    MethodType = 6,
-    NarrowOopMarkerType = 7,
-    LastType = NarrowOopMarkerType + 1
-  };
-  DeoptValueEncoding(int index, DeoptValueType value_type, BasicType basic_type):
-    _index(index), _value_type(value_type), _basic_type(basic_type) {
-    assert(_value_type == LocalType || _value_type == StackType ||
-           _value_type == MonitorType || _value_type == OrigPcSlotType ||
-           _value_type == MethodType || _value_type == NarrowOopMarkerType,
-           "Unsupported value type");
-  }
-
-  uint64_t encode() {
-    // encode format
-    // |--- index ---|--- value_type ---|--- basic_type ---|
-    // |0          31|32              47|48              63|
-    return ((uint64_t)_index << 32) | ((uint64_t)(_value_type << 16)) | (uint64_t)(_basic_type);
-  }
-
-  static DeoptValueEncoding decode(uint64_t encode) {
-    int index = (int)(encode >> 32);
-    assert(index >= 0, "must be");
-    int val_type = (int)((encode & 0xffff0000UL) >> 16);
-    assert(val_type >= 0 && val_type < DeoptValueType::LastType, "must be");
-    int basic_type = (int)((encode & 0xffffUL));
-    assert(basic_type >= 0 && basic_type <= BasicType::T_ILLEGAL, "must be");
-    return {index, (DeoptValueType)(val_type), (BasicType)(basic_type)};
-  }
+using llvm::jeandle::DeoptValueEncoding;
 
 #ifdef ASSERT
-  const char* value_type_name(DeoptValueType t) {
-    switch (t) {
-      case LocalType: return "LocalType";
-      case StackType: return "StackType";
-      case ArgumentType: return "ArgumentType";
-      case MonitorType: return "MonitorType";
-      case ScalarValueType: return "ScalarValueType";
-      case OrigPcSlotType: return "OrigPcSlotType";
-      case MethodType: return "MethodType";
-      case NarrowOopMarkerType: return "NarrowOopMarkerType";
-      default: return "Unknown";
-    }
+// The print helper function for print_deopt_value should have same ASSERT macro with the usage.
+// So we keep them in jdk side instead of a method in DeoptValueEncoding.
+static inline const char* value_type_name(DeoptValueEncoding::DeoptValueType t) {
+  switch (t) {
+    case DeoptValueEncoding::LocalType: return "LocalType";
+    case DeoptValueEncoding::StackType: return "StackType";
+    case DeoptValueEncoding::ArgumentType: return "ArgumentType";
+    case DeoptValueEncoding::MonitorType: return "MonitorType";
+    case DeoptValueEncoding::ScalarValueType: return "ScalarValueType";
+    case DeoptValueEncoding::OrigPcSlotType: return "OrigPcSlotType";
+    default: return "Unknown";
   }
-  void print() {
-    ttyLocker ttyl;
-    tty->print_cr("  DeoptValueEncoding: index: %d value_type: %s, basic_type: %s",
-                  _index, value_type_name(_value_type), type2name(_basic_type));
-  }
+}
+
+static inline void print_deopt_value(DeoptValueEncoding deopt_value) {
+  ttyLocker ttyl;
+  tty->print_cr("DeoptValueEncoding: index: %d value_type: %s, basic_type: %s",
+                deopt_value.index(), value_type_name(deopt_value.valueType()), type2name(static_cast<BasicType>(deopt_value.basicType())));
+}
 #endif
-private:
-  int _index;
-  DeoptValueType _value_type;
-  BasicType _basic_type;
-};
 
 class CallSiteInfo : public JeandleCompilationResourceObj {
  public:
@@ -136,8 +96,10 @@ class CallSiteInfo : public JeandleCompilationResourceObj {
 
 
   JeandleCompiledCall::Type type() const { return _type; }
+  void set_type(JeandleCompiledCall::Type type) { _type = type; }
   uint64_t statepoint_id() const { return _statepoint_id; }
   address target() const { return _target; }
+  void set_target(address target) { _target = target; }
   bool is_method_handle_invoke() const { return _is_method_handle_invoke; }
 
  private:
@@ -193,7 +155,8 @@ class JeandleCompiledCode : public StackObj {
  public:
   // For compiled Java methods.
   JeandleCompiledCode(ciEnv* env,
-                      ciMethod* method) :
+                      ciMethod* method,
+                      bool is_osr_entry) :
                       _obj(nullptr),
                       _elf(nullptr),
                       _code_buffer("JeandleCompiledCode"),
@@ -211,7 +174,7 @@ class JeandleCompiledCode : public StackObj {
                       _env(env),
                       _method(method),
                       _routine_entry(nullptr),
-                      _func_name(JeandleFuncSig::method_name_with_signature(_method)),
+                      _func_name(JeandleFuncSig::method_name_with_signature(_method, is_osr_entry)),
                       _orig_pc_slot(nullptr),
                       _orig_pc_offset_in_bytes(-1),
                       _interpreter_frame_size_in_bytes(0),
@@ -262,6 +225,7 @@ class JeandleCompiledCode : public StackObj {
                                                 new_statepoint_id));
     return static_cast<int64_t>(new_statepoint_id);
   }
+  llvm::SmallVector<CallSiteInfo*>& non_routine_call_sites() { return _non_routine_call_sites; }
 
   int find_or_insert_oop(ciObject* oop);
   ciObject* oop_at(int oop_id);

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -103,7 +103,7 @@ void attach_java_klass_ret_attr(llvm::CallBase* call,
 }
 
 llvm::Function* JeandleFuncSig::create_llvm_func(ciMethod* method, llvm::Module& target_module, bool is_osr_entry) {
-  std::string func_name = method_name_with_signature(method);
+  std::string func_name = method_name_with_signature(method, is_osr_entry);
 
   llvm::Function* existing = target_module.getFunction(func_name);
   if (existing != nullptr) {
@@ -138,6 +138,9 @@ llvm::Function* JeandleFuncSig::create_llvm_func(ciMethod* method, llvm::Module&
                                                 llvm::Function::ExternalLinkage,
                                                 func_name,
                                                 target_module);
+  func->addFnAttr(llvm::Attribute::get(context,
+      llvm::jeandle::Attribute::JavaMethod,
+      std::to_string(reinterpret_cast<uintptr_t>(method))));
 
   if (!is_osr_entry) {
     // Attach java-klass type attributes to parameters.
@@ -211,9 +214,13 @@ std::string JeandleFuncSig::method_name(ciMethod* method) {
   return class_name + "_" + method_name;
 }
 
-std::string JeandleFuncSig::method_name_with_signature(ciMethod* method) {
+std::string JeandleFuncSig::method_name_with_signature(ciMethod* method, bool is_osr_entry) {
   std::string signature = std::string(method->signature()->as_symbol()->as_utf8());
-  return method_name(method) + signature;
+  signature = method_name(method) + signature;
+  if (is_osr_entry) {
+    signature = "__jeandle_osr." + signature;
+  }
+  return signature;
 }
 
 bool is_jeandle_compiler_thread(Thread* t) {

--- a/src/hotspot/share/jeandle/jeandleUtils.hpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.hpp
@@ -42,7 +42,7 @@ class JeandleFuncSig : public AllStatic {
   // Create a llvm function according to the Java method.
   static llvm::Function* create_llvm_func(ciMethod* method, llvm::Module& target_module, bool is_osr_entry);
   static std::string method_name(ciMethod* method);
-  static std::string method_name_with_signature(ciMethod* method);
+  static std::string method_name_with_signature(ciMethod* method, bool is_osr_entry = false);
   static void setup_description(llvm::Function* func, ciMethod* method, bool is_stub = false);
 };
 

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -21,20 +21,30 @@
 #include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/IR/Jeandle/VMCallback.h"
 #include "llvm/IR/Jeandle/VMCallbackLog.h"
+#include "llvm/IR/Jeandle/InvokeType.h"
+#include "llvm/Transforms/Jeandle/CHADevirtualization.h"
 
 #include "jeandle/jeandleAbstractInterpreter.hpp"
 #include "jeandle/jeandleCompilation.hpp"
 #include "jeandle/jeandleUtils.hpp"
 #include "jeandle/jeandleVMCallback.hpp"
 #include "jeandle/jeandleCompilation.hpp"
+#include "jeandle/jeandleCompiledCall.hpp"
+#include "jeandle/jeandleCompiledCode.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "ci/ciClassList.hpp"
+#include "ci/ciEnv.hpp"
+#include "ci/ciInstanceKlass.hpp"
+#include "ci/ciKlass.hpp"
+#include "ci/ciSymbols.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
 #include "ci/ciField.hpp"
 #include "ci/ciInstance.hpp"
 #include "ci/ciInstanceKlass.hpp"
 #include "ci/ciObject.hpp"
+#include "logging/log.hpp"
 #include "oops/fieldInfo.inline.hpp"
 #include "oops/fieldStreams.inline.hpp"
 #include "oops/instanceMirrorKlass.hpp"
@@ -42,7 +52,11 @@
 #include "oops/klass.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaThread.hpp"
+#include "runtime/sharedRuntime.hpp"
 #include "utilities/globalDefinitions.hpp"
+
+#include <cstdint>
+#include <utility>
 
 namespace {
 
@@ -166,6 +180,16 @@ int64_t jeandle_get_constant_field_value(int oop_id, int offset) {
   assert(foldable, "jeandle_get_constant_field_value called on a non-foldable "
                    "field; caller must verify via jeandle_get_constant_field_info");
 
+  if (field->is_call_site_target()) {
+    ciObject* base_oop = jeandle_oop_by_id(oop_id);
+    assert(base_oop != nullptr && base_oop->is_call_site(), "bad CallSite holder");
+    ciCallSite* call_site = base_oop->as_call_site();
+    if (!call_site->is_fully_initialized_constant_call_site()) {
+      ciMethodHandle* target = con.as_object()->as_method_handle();
+      ciEnv::current()->dependencies()->assert_call_site_target_value(call_site, target);
+    }
+  }
+
   switch (field->layout_type()) {
   case T_BOOLEAN:
   case T_BYTE:
@@ -202,7 +226,7 @@ int jeandle_get_constant_field_info(int oop_id, int offset) {
   return field->layout_type();
 }
 
-const char* jeandle_get_oop_handle_name(int oop_id) {
+std::string jeandle_get_oop_handle_name(int oop_id) {
   JeandleCompilation* compilation = JeandleCompilation::current();
   assert(compilation != nullptr, "no active compilation");
   JeandleCompiledCode* cc = compilation->compiled_code();
@@ -212,7 +236,7 @@ const char* jeandle_get_oop_handle_name(int oop_id) {
   // the vector reallocates.
   auto it = cc->oop_handles().find(cc->oop_handle_name(oop_id));
   assert(it != cc->oop_handles().end(), "oop handle name missing from map");
-  return it->getKeyData();
+  return it->getKey().str();
 }
 
 uintptr_t jeandle_get_oop_klass(int oop_id) {
@@ -308,6 +332,142 @@ bool jeandle_record_inlining_complete() {
   return true;
 }
 
+// Change a virtual callsite to opt virtual call site.
+bool update_to_static_opt_virtual_call(int64_t id) {
+  JeandleCompilation* compilation = JeandleCompilation::current();
+  assert(compilation != nullptr, "no active compilation");
+  JeandleCompiledCode* cc = compilation->compiled_code();
+  if (static_cast<size_t>(id) >= cc->non_routine_call_sites().size()) {
+    return false;
+  }
+  CallSiteInfo* call_site = cc->non_routine_call_sites()[id];
+  call_site->set_type(JeandleCompiledCall::STATIC_CALL);
+  call_site->set_target(SharedRuntime::get_resolve_opt_virtual_call_stub());
+  return true;
+}
+
+llvm::jeandle::CHAOptInfo optimize_invokeinterface(ciMethod* caller,
+                              ciMethod* callee, ciInstanceKlass* holder) {
+  ciInstanceKlass* singleton = holder->unique_implementor();
+  if (singleton == nullptr) {
+    return {};
+  }
+  assert(singleton != holder, "not a unique implementor");
+  ciMethod* cha_monomorphic_target =
+    callee->find_monomorphic_target(caller->holder(), holder, singleton);
+
+  if (cha_monomorphic_target != nullptr &&
+      cha_monomorphic_target->holder() != ciEnv::current()->Object_klass()) { // subtype check against Object is useless
+    ciKlass* constraint = cha_monomorphic_target->holder();
+    constraint = (constraint->is_subclass_of(singleton) ? constraint : singleton);
+    ciEnv::current()->dependencies()->assert_unique_implementor(holder, singleton);
+    ciEnv::current()->dependencies()->assert_unique_concrete_method(holder, cha_monomorphic_target, holder, callee);
+    return {reinterpret_cast<uintptr_t>(constraint->constant_encoding()),
+      reinterpret_cast<uintptr_t>(cha_monomorphic_target),
+      llvm::jeandle::Deoptimization::Reason_class_check,
+      JeandleFuncSig::method_name_with_signature(cha_monomorphic_target)};
+  }
+  return {};
+}
+
+llvm::jeandle::CHAOptInfo optimize_virtual_call(ciMethod* caller,
+                            ciMethod* callee, ciInstanceKlass* holder,
+                            Klass* receiver_klass, bool is_exact) {
+  ciEnv* env = ciEnv::current();
+
+  // Same fast paths as C2's Compile::optimize_inlining.
+  if (callee->can_be_statically_bound()) {
+    return {};
+  }
+
+  if (receiver_klass == nullptr)
+    return {};
+
+  if (receiver_klass->is_array_klass()) {
+    if (callee->holder() == env->Object_klass() &&
+        callee->name() != ciSymbols::finalize_method_name()) {
+      return {reinterpret_cast<uintptr_t>(callee->holder()->constant_encoding()),
+        reinterpret_cast<uintptr_t>(callee),
+        llvm::jeandle::Deoptimization::Reason_receiver_constraint,
+        JeandleFuncSig::method_name_with_signature(callee)};
+    }
+    return {};
+  }
+
+  if (!receiver_klass->is_instance_klass()) {
+    return {};
+  }
+
+  ciInstanceKlass* receiver_inst_klass = ciEnv::current()->get_instance_klass_for_klass(receiver_klass);
+  ciInstanceKlass* actual_receiver = holder;
+  bool actual_receiver_is_exact = false;
+  if (receiver_inst_klass->is_loaded() && receiver_inst_klass->is_initialized() &&
+      !receiver_inst_klass->is_interface() &&
+      (receiver_inst_klass == actual_receiver || receiver_inst_klass->is_subtype_of(actual_receiver))) {
+    actual_receiver = receiver_inst_klass;
+    actual_receiver_is_exact = is_exact;
+  }
+
+  ciMethod* cha_monomorphic_target =
+    callee->find_monomorphic_target(caller->holder(), holder, actual_receiver);
+  if (cha_monomorphic_target != nullptr) {
+    assert(!callee->can_be_statically_bound(), "should have been handled above");
+    assert(!cha_monomorphic_target->is_abstract(), "");
+    if (!cha_monomorphic_target->can_be_statically_bound(actual_receiver)) {
+      env->dependencies()->assert_unique_concrete_method(actual_receiver,
+        cha_monomorphic_target,
+        holder, callee);
+    }
+    return {reinterpret_cast<uintptr_t>(cha_monomorphic_target->holder()->constant_encoding()),
+      reinterpret_cast<uintptr_t>(cha_monomorphic_target),
+      llvm::jeandle::Deoptimization::Reason_receiver_constraint,
+      JeandleFuncSig::method_name_with_signature(cha_monomorphic_target)};
+  }
+
+  if (actual_receiver_is_exact) {
+    ciMethod* exact_method = callee->resolve_invoke(caller->holder(), actual_receiver);
+    if (exact_method != nullptr) {
+      return {reinterpret_cast<uintptr_t>(exact_method->holder()->constant_encoding()),
+        reinterpret_cast<uintptr_t>(exact_method),
+        llvm::jeandle::Deoptimization::Reason_receiver_constraint,
+        JeandleFuncSig::method_name_with_signature(exact_method)};
+    }
+  }
+
+  return {};
+}
+
+std::string jeandle_get_cha_opt_info(uintptr_t caller_ptr, uintptr_t callee_ptr,
+                                     uintptr_t holder_ptr, uintptr_t receiver_klass_ptr,
+                                     bool is_exact, int bytecode) {
+  if (caller_ptr == 0 || callee_ptr == 0 || holder_ptr == 0) {
+    return "";
+  }
+
+  ciMethod* caller = reinterpret_cast<ciMethod*>(caller_ptr);
+  ciMethod* callee = reinterpret_cast<ciMethod*>(callee_ptr);
+  ciInstanceKlass* holder = reinterpret_cast<ciInstanceKlass*>(holder_ptr);
+  Klass* receiver_klass = reinterpret_cast<Klass*>(receiver_klass_ptr);
+
+  llvm::jeandle::CHAOptInfo opt_info;
+  log_debug(jeandle)("jeandle_get_cha_constraint::callee name: %s, callee holder: %s", callee->name()->as_utf8(), holder->name()->as_utf8());
+  if (bytecode == llvm::jeandle::InvokeInterface || bytecode == llvm::jeandle::InvokeVirtual) {
+    log_debug(jeandle)("jeandle_get_cha_constraint::invokevirtual");
+    opt_info = optimize_virtual_call(caller, callee, holder, receiver_klass, is_exact);
+  }
+
+  if (!opt_info.Constraint && bytecode == llvm::jeandle::InvokeInterface) {
+    log_debug(jeandle)("jeandle_get_cha_constraint::invokeinterface");
+    opt_info = optimize_invokeinterface(caller, callee, holder);
+  }
+
+  if (opt_info.Constraint) {
+    log_debug(jeandle)("jeandle_get_cha_constraint::constraint, " PTR_FORMAT, (long unsigned int)(opt_info.Constraint));
+    return opt_info.encode();
+  }
+  return "";
+}
+
 } // anonymous namespace
 
 void register_jeandle_vm_callbacks() {
@@ -327,6 +487,8 @@ void register_jeandle_vm_callbacks() {
   callbacks.IsOkToInline = &jeandle_is_ok_to_inline;
   callbacks.RecordInlineSuccess = &jeandle_record_inline_success;
   callbacks.RecordInliningComplete = &jeandle_record_inlining_complete;
+  callbacks.GetCHAOptInfo = &jeandle_get_cha_opt_info;
+  callbacks.UpdateToStaticOptVirtualCall = &update_to_static_opt_virtual_call;
   llvm::jeandle::registerVMCallbacks(callbacks);
 
   if (JeandleRecordVMCallbacks) {

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -375,11 +375,6 @@ llvm::jeandle::CHAOptInfo optimize_virtual_call(ciMethod* caller,
                             Klass* receiver_klass, bool is_exact) {
   ciEnv* env = ciEnv::current();
 
-  // Same fast paths as C2's Compile::optimize_inlining.
-  if (callee->can_be_statically_bound()) {
-    return {};
-  }
-
   if (receiver_klass == nullptr)
     return {};
 

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -25,6 +25,7 @@
 #include "jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.hpp"
 #include "jeandle/jeandleRuntimeRoutine.hpp"
 #include "jeandle/jeandleRegister.hpp"
+#include "jeandle/jeandleCompiledCall.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciUtilities.hpp"
@@ -491,6 +492,17 @@ void RuntimeDefinedJavaOps::define_metadata(llvm::Module& template_module) {
     llvm::MDNode* heap_base_register = llvm::MDNode::get(context, {llvm::MDString::get(context, JeandleRegister::get_heap_base_pointer())});
     llvm::NamedMDNode* metadata_node = template_module.getOrInsertNamedMetadata(llvm::jeandle::Metadata::HeapBase);
     metadata_node->addOperand(heap_base_register);
+  }
+
+  // Static call patch size.
+  {
+    llvm::NamedMDNode* patch_node = template_module.getOrInsertNamedMetadata(llvm::jeandle::Metadata::StaticCallPatchSize);
+    assert(patch_node != nullptr, "invalid patch node");
+    llvm::Metadata* patch_size_md =
+      llvm::ConstantAsMetadata::get(
+        llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
+                                  JeandleCompiledCall::call_site_patch_size(JeandleCompiledCall::STATIC_CALL)));
+    patch_node->addOperand(llvm::MDNode::get(context, patch_size_md));
   }
 }
 

--- a/test/hotspot/jtreg/ProblemList-jeandle.txt
+++ b/test/hotspot/jtreg/ProblemList-jeandle.txt
@@ -347,7 +347,6 @@ compiler/loopopts/TestRemoveEmptyLoop.java                                      
 ###
 compiler/cha/AbstractRootMethod.java                                                           linux-aarch64,linux-x64
 compiler/cha/DefaultRootMethod.java                                                            linux-aarch64,linux-x64
-compiler/cha/StrengthReduceInterfaceCall.java                                                  linux-aarch64,linux-x64
 
 ###
 # CodeEntryAlignment


### PR DESCRIPTION
## Related issue(s):

issue #468

## What this PR does / why we need it:
This PR implements CHA optimization and deopt for normal invoke (invokevirtual and invokeinterface bytecode). invokehandle support need constant propagation, will be support later.

## Test
| testcase | passed |
| -- | -- |
| compiler/cha/StrengthReduceInterfaceCall.java | ✅ | 
| compiler/cha/AbstractRootMethod.java | passed normal invoke part, **failed at MethodHandle.invokeExact** |
| compiler/cha/DefaultRootMethod.java | passed normal invoke part, **failed at MethodHandle.invokeExact** |
