### PR TITLE
fix: support address scope values

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -381,10 +381,13 @@ static VMReg resolve_vmreg(const StackMapParser::LocationAccessor& location, Sta
   if (kind == StackMapParser::LocationKind::Register) {
     Register reg = JeandleRegister::decode_dwarf_register(location.getDwarfRegNum());
     return reg->as_VMReg();
-  } else if (kind == StackMapParser::LocationKind::Indirect) {
+  } else if (kind == StackMapParser::LocationKind::Indirect ||
+             kind == StackMapParser::LocationKind::Direct) {
 #ifdef ASSERT
-    Register reg = JeandleRegister::decode_dwarf_register(location.getDwarfRegNum());
-    assert(JeandleRegister::is_stack_pointer(reg), "register of indirect kind must be stack pointer");
+    if (kind == StackMapParser::LocationKind::Indirect) {
+      Register reg = JeandleRegister::decode_dwarf_register(location.getDwarfRegNum());
+      assert(JeandleRegister::is_stack_pointer(reg), "register of indirect kind must be stack pointer");
+    }
 #endif
     int offset = location.getOffset();
 
@@ -460,6 +463,15 @@ void JeandleCompiledCode::fill_one_scope_value(const StackMapParser& stackmaps,
       }
     } else {
       array->append(new_location_value(location, Location::oop));
+    }
+    break;
+  }
+  case T_ADDRESS: {
+    if (is_constant) {
+      jlong const_addr = JeandleBitCast::bit_cast<jlong>(StackMapUtil::getConstantUlong(stackmaps, location));
+      array->append(new ConstantLongValue(const_addr));
+    } else {
+      array->append(new_location_value(location, Location::lng));
     }
     break;
   }
@@ -593,7 +605,7 @@ JeandleStackMap* JeandleCompiledCode::parse_stackmap(StackMapParser& stackmaps, 
         auto orig_pc_location = *(location++);
         assert(StackMapUtil::is_stack(orig_pc_location), "orig pc slot must be stack allocated");
         set_real_orig_pc_offset_in_bytes(StackMapUtil::stack_offset(orig_pc_location));
-        num_deopts -= 2;
+        num_deopts = 0;
         break;
       }
       default:
@@ -604,33 +616,48 @@ JeandleStackMap* JeandleCompiledCode::parse_stackmap(StackMapParser& stackmaps, 
 
   // build oop map
   OopMap* oop_map = new OopMap(frame_size_in_slots(), 0);
-  for (; location != record->location_end(); location++) {
+  GrowableArray<int> seen_regs;
+  auto mark_reg = [&](VMReg reg) -> bool {
+    int v = reg->value();
+    if (seen_regs.contains(v)) return false;
+    seen_regs.append(v);
+    return true;
+  };
+  for (auto it = location; it != record->location_end();) {
     // Extract location of base pointer.
-    auto base_location = *location;
+    auto base_location = *(it++);
     StackMapParser::LocationKind base_kind = base_location.getKind();
 
-    if (base_kind != StackMapParser::LocationKind::Register &&
-        base_kind != StackMapParser::LocationKind::Indirect) {
-          continue;
+    bool base_is_ptr = base_kind == StackMapParser::LocationKind::Register ||
+                       base_kind == StackMapParser::LocationKind::Indirect ||
+                       base_kind == StackMapParser::LocationKind::Direct;
+
+    if (it == record->location_end()) {
+      if (base_is_ptr) {
+        VMReg reg = resolve_vmreg(base_location, base_kind);
+        if (mark_reg(reg)) { oop_map->set_oop(reg); }
+      }
+      break;
     }
 
     // Extract location of derived pointer.
-    location++;
-    auto derived_location = *location;
+    auto derived_location = *(it++);
     StackMapParser::LocationKind derived_kind = derived_location.getKind();
 
-    assert(base_kind != StackMapParser::LocationKind::Direct, "invalid location kind");
+    if (!base_is_ptr) {
+      continue;
+    }
 
     VMReg reg_base = resolve_vmreg(base_location, base_kind);
-    VMReg reg_derived = resolve_vmreg(derived_location, derived_kind);
+    if (mark_reg(reg_base)) { oop_map->set_oop(reg_base); }
 
-    if(reg_base == reg_derived) {
-      // No derived pointer.
-      oop_map->set_oop(reg_base);
-    } else {
-      // Derived pointer.
-      oop_map->set_derived_oop(reg_derived, reg_base);
-    }
+    bool derived_is_ptr = derived_kind == StackMapParser::LocationKind::Register ||
+                          derived_kind == StackMapParser::LocationKind::Indirect ||
+                          derived_kind == StackMapParser::LocationKind::Direct;
+    if (!derived_is_ptr) { continue; }
+
+    VMReg reg_derived = resolve_vmreg(derived_location, derived_kind);
+    if (mark_reg(reg_derived)) { oop_map->set_derived_oop(reg_derived, reg_base); }
   }
   return new JeandleStackMap(oop_map, locals, stack, monitors, reexecute);
 }

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -649,15 +649,22 @@ JeandleStackMap* JeandleCompiledCode::parse_stackmap(StackMapParser& stackmaps, 
     }
 
     VMReg reg_base = resolve_vmreg(base_location, base_kind);
-    if (mark_reg(reg_base)) { oop_map->set_oop(reg_base); }
 
     bool derived_is_ptr = derived_kind == StackMapParser::LocationKind::Register ||
                           derived_kind == StackMapParser::LocationKind::Indirect ||
                           derived_kind == StackMapParser::LocationKind::Direct;
-    if (!derived_is_ptr) { continue; }
+
+    if (!derived_is_ptr) {
+      if (mark_reg(reg_base)) { oop_map->set_oop(reg_base); }
+      continue;
+    }
 
     VMReg reg_derived = resolve_vmreg(derived_location, derived_kind);
-    if (mark_reg(reg_derived)) { oop_map->set_derived_oop(reg_derived, reg_base); }
+    if (reg_base == reg_derived) {
+      if (mark_reg(reg_base)) { oop_map->set_oop(reg_base); }
+    } else {
+      if (mark_reg(reg_derived)) { oop_map->set_derived_oop(reg_derived, reg_base); }
+    }
   }
   return new JeandleStackMap(oop_map, locals, stack, monitors, reexecute);
 }

--- a/test/hotspot/jtreg/compiler/jeandle/deoptimize/TestFormatterScopeValue.java
+++ b/test/hotspot/jtreg/compiler/jeandle/deoptimize/TestFormatterScopeValue.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @summary Test scope value encoding when compiling Formatter$FormatSpecifier::print.
+ * @library /test/lib
+ * @run driver compiler.jeandle.deoptimize.TestFormatterScopeValue
+ */
+
+package compiler.jeandle.deoptimize;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Locale;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestFormatterScopeValue {
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            runTest();
+            return;
+        }
+
+        test();
+    }
+
+    private static void runTest() throws Exception {
+        ArrayList<String> commandArgs = new ArrayList<>(List.of(
+            "-Xcomp",
+            "-Xbatch",
+            "-XX:-TieredCompilation",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+UseJeandleCompiler",
+            "-XX:CompileCommand=compileonly,java.util.Formatter$FormatSpecifier::print",
+            TestFormatterScopeValue.class.getName(),
+            "test"
+        ));
+
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(commandArgs);
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+
+        output.shouldHaveExitValue(0);
+    }
+
+    private static void test() {
+        Calendar cal = new GregorianCalendar(2026, Calendar.MAY, 31, 12, 34, 56);
+        LocalDateTime time = LocalDateTime.of(2026, 5, 31, 12, 34, 56);
+        for (int i = 0; i < 500; i++) {
+            String s = String.format(Locale.US,
+                "%04d %s %.2f %,(d %020d %,.4f %tF %tT %tZ %tA %tB %tY %tH:%tM:%tS %tQ %tN %s %s%n",
+                i, "jeandle", i / 3.0, -i, BigInteger.valueOf(i).pow(5), new BigDecimal("123456789.1234"),
+                cal, cal, cal, cal, cal, cal, cal, cal, cal, cal, time, time, time);
+            if (s.isEmpty()) {
+                throw new AssertionError("empty formatter result");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Related issue(s):

issue #467

## What this PR does / why we need it:

Jeandle can currently hit `Unimplemented()` in `JeandleCompiledCode::fill_one_scope_value` when a deopt scope value has type `T_ADDRESS`, which was observed while running Renaissance with `-Xcomp -XX:-TieredCompilation`.

This PR adds `T_ADDRESS` handling for scope value encoding:
- constant address values are recorded as `ConstantLongValue` on LP64 and `ConstantIntValue` otherwise
- non-constant address values use `Location::lng` on LP64 and `Location::normal` otherwise

A focused regression test is added for compiling `java.util.Formatter$FormatSpecifier::print`, which matches the failing path from the issue.

## Testing

- `git diff --check origin/main..HEAD`
- `make CONF=linux-x86_64-server-fastdebug hotspot`
- `make CONF=linux-x86_64-server-fastdebug images`
- `make CONF=linux-x86_64-server-fastdebug test TEST=jtreg:test/hotspot/jtreg/compiler/jeandle/deoptimize/TestFormatterScopeValue.java`
- `make CONF=linux-x86_64-server-fastdebug test TEST=jtreg:test/hotspot/jtreg/compiler/jeandle/deoptimize`