### PR TITLE
test: update tier3 problemList for aarch64.

### DIFF
--- a/test/hotspot/jtreg/ProblemList-jeandle.txt
+++ b/test/hotspot/jtreg/ProblemList-jeandle.txt
@@ -356,9 +356,8 @@ gc/z/TestZNMT.java                                                              
 runtime/ClassUnload/UnloadTestWithVerifyDuringGC.java                                          linux-aarch64,linux-x64
 
 ###
-# timeout
+# Timeout
 ###
-
 compiler/loopopts/TestRemoveEmptyLoop.java                                                     linux-aarch64,linux-x64
 
 ###
@@ -487,13 +486,13 @@ serviceability/sa/TestJmapCore.java                                             
 serviceability/sa/TestJmapCoreMetaspace.java                                                   linux-aarch64,linux-x64
 
 ###
-# timeout due to unimplemented vm option `InlineUnsafeOps`
+# Timeout due to unimplemented vm option `InlineUnsafeOps`
 ###
 compiler/loopopts/superword/TestLargeScaleAndStride.java#vanilla                               linux-aarch64,linux-x64
 compiler/loopopts/superword/TestLargeScaleAndStride.java#AlignVector                           linux-aarch64,linux-x64
 
 ###
-# fails due to `Math.log` (issue #424)
+# Fails due to `Math.log` (issue #424)
 ###
 compiler/interpreter/Test6539464.java                                                          linux-aarch64
 
@@ -505,9 +504,9 @@ serviceability/jvmti/CompiledMethodLoad/Zombie.java                             
 ###
 # GC not support(tier3)
 ###
-gc/shenandoah/TestStringDedupStress.java#iu                                                    linux-x64
-gc/shenandoah/TestStringDedupStress.java#passive                                               linux-x64                     
-gc/shenandoah/TestStringDedupStress.java#default                                               linux-x64
+gc/shenandoah/TestStringDedupStress.java#iu                                                    linux-aarch64,linux-x64
+gc/shenandoah/TestStringDedupStress.java#passive                                               linux-aarch64,linux-x64                     
+gc/shenandoah/TestStringDedupStress.java#default                                               linux-aarch64,linux-x64
 
 ###
 # OSR - On Stack Replacement
@@ -517,15 +516,15 @@ compiler/whitebox/DeoptimizeMultipleOSRTest.java                                
 ###
 # CompilerControl not supported
 ###
-compiler/compilercontrol/commands/LogTest.java                                                 linux-x64
-compiler/compilercontrol/mixed/RandomValidCommandsTest.java                                    linux-x64
-compiler/compilercontrol/logcompilation/LogTest.java                                           linux-x64
+compiler/compilercontrol/commands/LogTest.java                                                 linux-aarch64,linux-x64
+compiler/compilercontrol/mixed/RandomValidCommandsTest.java                                    linux-aarch64,linux-x64
+compiler/compilercontrol/logcompilation/LogTest.java                                           linux-aarch64,linux-x64
 
 ###
 # WhiteBox API not supported
 ###
-compiler/whitebox/ForceNMethodSweepTest.java                                                   linux-x64
-compiler/whitebox/IsMethodCompilableTest.java                                                  linux-x64
+compiler/whitebox/ForceNMethodSweepTest.java                                                   linux-aarch64,linux-x64
+compiler/whitebox/IsMethodCompilableTest.java                                                  linux-aarch64,linux-x64
 
 ###
 # CodeCache stress - unexpected deoptimization not supported
@@ -536,9 +535,55 @@ compiler/codecache/stress/UnexpectedDeoptimizationAllTest.java                  
 ###
 # Compiler debug/stress options not supported
 ###
-compiler/debug/TestGenerateStressSeed.java                                                     linux-x64
+compiler/debug/TestGenerateStressSeed.java                                                     linux-aarch64,linux-x64
+compiler/debug/TestStressCM.java                                                               linux-aarch64
+
+###
+# Compiler replay
+###
+compiler/ciReplay/TestDumpReplayCommandLine.java                                               linux-aarch64
+compiler/ciReplay/TestIncrementalInlining.java                                                 linux-aarch64
+compiler/ciReplay/TestInlining.java                                                            linux-aarch64
+compiler/ciReplay/TestInliningProtectionDomain.java                                            linux-aarch64
+compiler/ciReplay/TestLambdas.java                                                             linux-aarch64
+compiler/ciReplay/TestNoClassFile.java                                                         linux-aarch64
+compiler/ciReplay/TestUnresolvedClasses.java                                                   linux-aarch64
+
+###
+# Jeandle compiler has no ideal graph phase
+###
+compiler/oracle/PrintIdealPhaseTest.java                                                       linux-aarch64
+
+###
+# Vectorapi not supported.
+###
+compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java                                          linux-aarch64
+compiler/vectorapi/TestVectorMaskTrueCount.java                                                linux-aarch64
+compiler/vectorapi/TestVectorMulAddSub.java                                                    linux-aarch64
+compiler/vectorapi/TestVectorTest.java                                                         linux-aarch64
+compiler/vectorapi/VectorAbsDiffTest.java                                                      linux-aarch64
+compiler/vectorapi/VectorCompareWithZeroTest.java                                              linux-aarch64
+compiler/vectorapi/VectorLogicalOpIdentityTest.java                                            linux-aarch64
+compiler/vectorapi/VectorMaskCastTest.java                                                     linux-aarch64
+compiler/vectorapi/VectorReverseBytesTest.java                                                 linux-aarch64
+compiler/vectorapi/reshape/TestVectorCastNeon.java                                             linux-aarch64
+compiler/vectorapi/reshape/TestVectorReinterpret.java                                          linux-aarch64
+compiler/vectorapi/TestReverseByteTransforms.java                                              linux-aarch64
+compiler/vectorapi/VectorCastShape64Test.java                                                  linux-aarch64
+compiler/vectorapi/VectorCastShape128Test.java                                                 linux-aarch64
+compiler/vectorapi/VectorReplicateLongSpecialImmTest.java                                      linux-aarch64
+
+###
+# Crash when RepeatCompilation=1.
+###
+runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java                               linux-aarch64
+
+###
+# Signal problem.
+###
+runtime/signal/TestSigiot.java                                                                 linux-aarch64
 
 ###
 # CTW - Compile The World module compilation failure
 ###
-applications/ctw/modules/java_desktop.java                                                     linux-x64
+applications/ctw/modules/java_desktop.java                                                     linux-aarch64,linux-x64

--- a/test/jdk/ProblemList-jeandle.txt
+++ b/test/jdk/ProblemList-jeandle.txt
@@ -33,36 +33,38 @@ java/math/BigInteger/largeMemory/SymmetricRangeTests.java                  linux
 ###
 # GC not support
 ###
-jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMajor.java                       linux-x64
-jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMinor.java                       linux-x64
-jdk/jfr/event/gc/collection/TestGCCauseWithParallelOld.java                                 linux-x64
-jdk/jfr/event/gc/collection/TestZOldGarbageCollectionEvent.java                             linux-x64
-jdk/jfr/event/gc/collection/TestZYoungGarbageCollectionEvent.java                           linux-x64
-jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWith32BitOops.java               linux-x64
-jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWithHeapBasedOops.java           linux-x64
-jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWithZeroBasedOops.java           linux-x64
-jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java#id2                                    linux-x64
-jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java#ZGenerational                          linux-x64
-jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java#ZSinglegen                             linux-x64
-jdk/jfr/event/gc/detailed/TestShenandoahHeapRegionInformationEvent.java                     linux-x64
-jdk/jfr/event/gc/detailed/TestShenandoahHeapRegionStateChangeEvent.java                     linux-x64
-jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java#ZGenerational                      linux-x64
-jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java#ZSinglegen                         linux-x64
-jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java#ZGenerational                       linux-x64
-jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java#ZSinglegen                          linux-x64
-jdk/jfr/event/gc/detailed/TestZRelocationSetEvent.java#ZGenerational                        linux-x64
-jdk/jfr/event/gc/detailed/TestZRelocationSetEvent.java#ZSinglegen                           linux-x64
-jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java#ZGenerational                   linux-x64
-jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java#ZSinglegen                      linux-x64
-jdk/jfr/event/gc/detailed/TestZUnmapEvent.java#ZGenerational                                linux-x64
-jdk/jfr/event/gc/detailed/TestZUnmapEvent.java#ZSinglegen                                   linux-x64
-jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventPSParOld.java                              linux-x64
+jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMajor.java                       linux-aarch64, linux-x64
+jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMinor.java                       linux-aarch64, linux-x64
+jdk/jfr/event/gc/collection/TestGCCauseWithParallelOld.java                                 linux-aarch64, linux-x64
+jdk/jfr/event/gc/collection/TestZOldGarbageCollectionEvent.java                             linux-aarch64, linux-x64
+jdk/jfr/event/gc/collection/TestZYoungGarbageCollectionEvent.java                           linux-aarch64, linux-x64
+jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWith32BitOops.java               linux-aarch64, linux-x64
+jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWithHeapBasedOops.java           linux-aarch64, linux-x64
+jdk/jfr/event/gc/configuration/TestGCHeapConfigurationEventWithZeroBasedOops.java           linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java#id2                                    linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java#ZGenerational                          linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java#ZSinglegen                             linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestShenandoahHeapRegionInformationEvent.java                     linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestShenandoahHeapRegionStateChangeEvent.java                     linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java#ZGenerational                      linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java#ZSinglegen                         linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java#ZGenerational                       linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java#ZSinglegen                          linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZRelocationSetEvent.java#ZGenerational                        linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZRelocationSetEvent.java#ZSinglegen                           linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java#ZGenerational                   linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java#ZSinglegen                      linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZUnmapEvent.java#ZGenerational                                linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZUnmapEvent.java#ZSinglegen                                   linux-aarch64, linux-x64
+jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventPSParOld.java                              linux-aarch64, linux-x64
 jdk/jfr/event/gc/objectcount/TestObjectCountAfterGCEventWithParallelOld.java                linux-x64
-jdk/jfr/event/gc/stacktrace/TestMetaspaceParallelGCAllocationPendingStackTrace.java         linux-x64
-jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java           linux-x64
-jdk/jfr/event/gc/stacktrace/TestParallelScavengeAllocationPendingStackTrace.java            linux-x64
-java/lang/management/MemoryMXBean/MemoryTest.java#ZGenerational                             linux-x64
-java/lang/management/MemoryMXBean/MemoryTest.java#ZSinglegen                                linux-x64
+jdk/jfr/event/gc/stacktrace/TestMetaspaceParallelGCAllocationPendingStackTrace.java         linux-aarch64, linux-x64
+jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java           linux-aarch64, linux-x64
+jdk/jfr/event/gc/stacktrace/TestParallelScavengeAllocationPendingStackTrace.java            linux-aarch64, linux-x64
+jdk/jfr/event/gc/detailed/TestZUncommitEvent.java#ZGenerational                             linux-aarch64
+jdk/jfr/event/gc/detailed/TestZUncommitEvent.java#ZSinglegen                                linux-aarch64
+java/lang/management/MemoryMXBean/MemoryTest.java#ZGenerational                             linux-aarch64, linux-x64
+java/lang/management/MemoryMXBean/MemoryTest.java#ZSinglegen                                linux-aarch64, linux-x64
 
 ###
 jdk/jfr/event/gc/configuration/TestGCConfigurationEvent.java               linux-aarch64,linux-x64
@@ -175,29 +177,61 @@ sun/security/util/math/TestIntegerModuloP.java#P521OrderField              linux
 ###
 jdk/jfr/api/consumer/streaming/TestBaseRepositoryAfterStart.java          linux-x64
 jdk/jfr/api/consumer/streaming/TestBaseRepositoryLastModified.java        linux-x64
-jdk/jfr/event/compiler/TestCompilerInlining.java                          linux-x64
+jdk/jfr/event/compiler/TestCompilerInlining.java                          linux-aarch64, linux-x64
 jdk/jfr/event/compiler/TestCompilerPhase.java                             linux-x64
 jdk/jfr/event/compiler/TestDeoptimization.java                            linux-x64
-jdk/jfr/event/runtime/TestVMOperation.java                                linux-x64
+jdk/jfr/event/runtime/TestVMOperation.java                                linux-aarch64, linux-x64
 
 ###
 # JVMTI / Instrumentation not support
 ###
-java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id0                 linux-x64
-java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id1                 linux-x64
-java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id2                 linux-x64
-java/lang/instrument/NativeMethodPrefixAgent.java                         linux-x64
+java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id0                 linux-aarch64, linux-x64
+java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id1                 linux-aarch64, linux-x64
+java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id2                 linux-aarch64, linux-x64
+java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id3                 linux-aarch64
+java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id4                 linux-aarch64
+java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id5                 linux-aarch64
+java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id6                 linux-aarch64
+java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id7                 linux-aarch64
+java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id8                 linux-aarch64
+java/lang/instrument/NativeMethodPrefixAgent.java                         linux-aarch64, linux-x64
+jdk/jfr/event/compiler/TestCompilerPhase.java                             linux-aarch64
+jdk/jfr/event/compiler/TestDeoptimization.java                            linux-aarch64
+jdk/jfr/event/io/TestInstrumentation.java                                 linux-aarch64
+jdk/jfr/event/io/TestSocketChannelEvents.java                             linux-aarch64
 
 ###
 # JDI not support
 ###
-com/sun/jdi/EATests.java#id0                                              linux-x64
+com/sun/jdi/EATests.java#id0                                              linux-aarch64, linux-x64
 com/sun/jdi/JdbOptions.java                                               linux-x64
+com/sun/jdi/JdwpAllowTest.java                                            linux-aarch64
+com/sun/jdi/JdwpAttachTest.java                                           linux-aarch64
+com/sun/jdi/JdwpListenTest.java                                           linux-aarch64
+com/sun/jdi/JdwpNetProps.java                                             linux-aarch64
 
 ###
 # Vector API not support
 ###
+jdk/incubator/vector/AddTest.java                                         linux-aarch64
+jdk/incubator/vector/Byte128VectorTests.java                              linux-aarch64
+jdk/incubator/vector/Byte256VectorTests.java                              linux-aarch64
+jdk/incubator/vector/Byte512VectorTests.java                              linux-aarch64
+jdk/incubator/vector/Byte64VectorTests.java                               linux-aarch64
+jdk/incubator/vector/Double64VectorTests.java                             linux-aarch64
+jdk/incubator/vector/Float64VectorTests.java                              linux-aarch64
+jdk/incubator/vector/Int64VectorTests.java                                linux-aarch64
+jdk/incubator/vector/Long64VectorTests.java                               linux-aarch64
 jdk/incubator/vector/LoadJsvmlTest.java                                   linux-x64
+jdk/incubator/vector/Short128VectorTests.java                             linux-aarch64
+jdk/incubator/vector/Short64VectorTests.java                              linux-aarch64
+jdk/incubator/vector/Vector128ConversionTests.java                        linux-aarch64
+jdk/incubator/vector/Vector256ConversionTests.java                        linux-aarch64
+jdk/incubator/vector/Vector64ConversionTests.java#id0                     linux-aarch64
+jdk/incubator/vector/VectorMaxConversionTests.java#ZGenerational          linux-aarch64
+jdk/incubator/vector/VectorMaxConversionTests.java#ZSinglegen             linux-aarch64
+jdk/incubator/vector/VectorMaxConversionTests.java#id0                    linux-aarch64
+jdk/incubator/vector/VectorReshapeTests.java                              linux-aarch64
 
 ###
 # JMX / Management not support


### PR DESCRIPTION
## What this PR does / why we need it:
Update the test/jdk/ProblemList-jeandle.txt and test/hotspot/jtreg/ProblemList-jeandle.txt files by adding the test cases that failed in tier3 testing for aarch64 architecture.
