### PR TITLE
fix: hide dynamic invoke target from LLVM

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -1829,7 +1829,12 @@ void JeandleAbstractInterpreter::invoke() {
   // Declare callee function type.
   BasicType return_type = method_signature->return_type()->basic_type();
   llvm::FunctionType* func_type = llvm::FunctionType::get(JeandleType::java2llvm(return_type, *_context), args_type, false);
-  llvm::FunctionCallee callee = _module.getOrInsertFunction(JeandleFuncSig::method_name_with_signature(target), func_type);
+  std::string callee_name = JeandleFuncSig::method_name_with_signature(target);
+  if ((bc == Bytecodes::_invokevirtual || bc == Bytecodes::_invokeinterface) &&
+      !target->can_be_statically_bound()) {
+    callee_name = std::string("__jeandle_dynamic_call.") + callee_name;
+  }
+  llvm::FunctionCallee callee = _module.getOrInsertFunction(callee_name, func_type);
   llvm::Function* func = llvm::cast<llvm::Function>(callee.getCallee());
   func->setCallingConv(llvm::CallingConv::Hotspot_JIT);
   func->setGC(llvm::jeandle::JeandleGC);

--- a/test/hotspot/jtreg/ProblemList-jeandle.txt
+++ b/test/hotspot/jtreg/ProblemList-jeandle.txt
@@ -504,11 +504,6 @@ gc/shenandoah/TestStringDedupStress.java#passive                                
 gc/shenandoah/TestStringDedupStress.java#default                                               linux-aarch64,linux-x64
 
 ###
-# OSR - On Stack Replacement
-###
-compiler/whitebox/DeoptimizeMultipleOSRTest.java                                               linux-x64
-
-###
 # CompilerControl not supported
 ###
 compiler/compilercontrol/commands/LogTest.java                                                 linux-aarch64,linux-x64

--- a/test/jdk/ProblemList-jeandle.txt
+++ b/test/jdk/ProblemList-jeandle.txt
@@ -194,7 +194,6 @@ java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id5                 linux-
 java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id6                 linux-aarch64
 java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id7                 linux-aarch64
 java/lang/instrument/GetObjectSizeIntrinsicsTest.java#id8                 linux-aarch64
-java/lang/instrument/NativeMethodPrefixAgent.java                         linux-aarch64, linux-x64
 jdk/jfr/event/compiler/TestCompilerPhase.java                             linux-aarch64
 jdk/jfr/event/compiler/TestDeoptimization.java                            linux-aarch64
 jdk/jfr/event/io/TestInstrumentation.java                                 linux-aarch64


### PR DESCRIPTION
## Related issue(s):

issue #514 

## What this PR does / why we need it:
This PR fixes Jeandle IR generation for invokevirtual/invokeinterface calls that aren't statically bound.

Before, Jeandle exposed these dynamic Java calls to LLVM as direct calls to the resolved Java method, which could make LLVM treat them like normal direct calls and wrongly fold return values. This caused test/jdk/java/lang/instrument/NativeMethodPrefixAgent.java and test/hotspot/jtreg/compiler/whitebox/DeoptimizeMultipleOSRTest.java to crash in Jeandle.

Now, this PR uses a __jeandle_dynamic_call. placeholder as the LLVM callee for dynamic virtual/interface calls, while still recording the HotSpot call site as DYNAMIC_CALL. This keeps Java's dynamic dispatch behavior and avoids bad LLVM optimizations.

