### PR TITLE
fix: Jeandle decompile count tracking

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1292,7 +1292,7 @@ bool nmethod::is_maybe_on_stack() {
 }
 
 void nmethod::inc_decompile_count() {
-  if (!is_compiled_by_c2() && !is_compiled_by_jvmci()) return;
+  if (!is_compiled_by_c2() && !is_compiled_by_jvmci() && !is_compiled_by_jeandle()) return;
   // Could be gated by ProfileTraps, but do not bother...
   Method* m = method();
   if (m == nullptr)  return;

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -139,6 +139,11 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
   initialize();
   setup_llvm_module(template_buffer);
 
+  if (ProfileTraps) {
+    // Match C2: make sure decompile_count can be tracked for recompilation cutoffs.
+    method->ensure_method_data();
+  }
+
   if (error_occurred()) {
     _env->record_method_not_compilable(_error_msg);
     return;

--- a/test/hotspot/jtreg/ProblemList-jeandle.txt
+++ b/test/hotspot/jtreg/ProblemList-jeandle.txt
@@ -514,7 +514,6 @@ compiler/compilercontrol/logcompilation/LogTest.java                            
 # WhiteBox API not supported
 ###
 compiler/whitebox/ForceNMethodSweepTest.java                                                   linux-aarch64,linux-x64
-compiler/whitebox/IsMethodCompilableTest.java                                                  linux-aarch64,linux-x64
 
 ###
 # CodeCache stress - unexpected deoptimization not supported


### PR DESCRIPTION
## Related issue(s):

issue #520

## What this PR does / why we need it:
This PR fixes decompile count tracking for Jeandle-compiled methods.

Previously, nmethod::inc_decompile_count() only counted C2/JVMCI nmethods, so repeated deoptimizations of Jeandle nmethods did not update MethodData::decompile_count(). This meant PerMethodRecompilationCutoff was not honored for Jeandle methods.

The fix aligns Jeandle with C2 by including Jeandle nmethods in decompile count tracking and ensuring MethodData is created during Jeandle compilation when ProfileTraps is enabled.
