### PR TITLE
fix: support x86 const oop relocations

### DIFF
--- a/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleAssembler_x86.cpp
@@ -262,7 +262,10 @@ void JeandleAssembler::emit_oop_reloc(int offset, jobject oop_handle, int64_t ad
 }
 
 void JeandleAssembler::emit_oop_addr_reloc(int offset, jobject oop_handle) {
-  Unimplemented();
+  int index = __ oop_recorder()->find_index(oop_handle);
+  RelocationHolder rspec = jeandle_oop_addr_Relocation::spec(index);
+  address at_address = __ code()->consts()->start() + offset;
+  __ code()->consts()->relocate(at_address, rspec);
 }
 
 int JeandleAssembler::fixup_call_inst_offset(int offset) {
@@ -275,8 +278,7 @@ bool JeandleAssembler::is_oop_reloc(LinkSymbol& target, LinkKind kind) {
 }
 
 bool JeandleAssembler::is_oop_addr_reloc(LinkSymbol& target, LinkKind kind) {
-  // Unimplemented
-  return false;
+  return !target.isDefined() && kind == LinkKind_x86_64::Pointer64;
 }
 
 bool JeandleAssembler::is_routine_call_reloc(LinkSymbol& target, LinkKind kind) {

--- a/src/hotspot/cpu/x86/relocInfo_x86.cpp
+++ b/src/hotspot/cpu/x86/relocInfo_x86.cpp
@@ -145,6 +145,26 @@ void Relocation::pd_set_call_destination(address x) {
 
 void Relocation::pd_set_jeandle_data_value(address x, int addend, bool verify_only) {
 #ifdef AMD64
+  if (addr_in_const()) {
+    if (type() == relocInfo::jeandle_oop_addr_type) {
+      if (verify_only) {
+        guarantee(*(address*)addr() == x, "instructions must match");
+      } else {
+        *(address*)addr() = x;
+      }
+      return;
+    }
+
+    assert(type() == relocInfo::jeandle_section_word_type, "unexpected relocation in const section");
+    address disp = addr();
+    if (verify_only) {
+      guarantee(*(int32_t*)disp == (x - disp + addend), "instructions must match");
+    } else {
+      *(int32_t*)disp = x - disp + addend;
+    }
+    return;
+  }
+
   typedef Assembler::WhichOperand WhichOperand;
   WhichOperand which = (WhichOperand) format();
   assert(which == Assembler::disp32_operand, "format unpacks ok");
@@ -223,7 +243,11 @@ void trampoline_stub_Relocation::pd_fix_owner_after_move() {
 #endif // JEANDLE
 
 void jeandle_oop_addr_Relocation::fix_relocation_after_move(const CodeBuffer* src, CodeBuffer* dest) {
-  Unimplemented();
+  assert(addr_in_const(), "must in const section");
+  address old_addr = *(address*)addr();
+  int delta = dest - src;
+  address new_addr = old_addr + delta;
+  set_value(new_addr);
 }
 
 bool jeandle_oop_Relocation::pd_pack_data_to(CodeSection* dest) {

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -325,11 +325,10 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
             reloc_section = CodeBuffer::SECT_INSTS;
           } else {
             assert(target.getSection().getName().compare(".text") == 0, "invalid target section");
-            assert(block->getSection().getName().starts_with(".rodata"), "invalid reloc section");
             target_addr = _code_buffer.insts()->start();
-            address reloc_base = lookup_const_section(block->getSection().getName(), assembler);
+            address reloc_site = resolve_const_reloc_site(*block, edge, assembler);
             RETURN_VOID_ON_JEANDLE_ERROR();
-            reloc_offset = reloc_base + edge.getOffset() - _code_buffer.consts()->start();
+            reloc_offset = reloc_site - _code_buffer.consts()->start();
             reloc_section = CodeBuffer::SECT_CONSTS;
           }
           relocs.push_back(new JeandleSectionWordReloc(reloc_offset, edge, target_addr, reloc_section));
@@ -346,7 +345,10 @@ void JeandleCompiledCode::resolve_reloc_info(JeandleAssembler& assembler) {
           assert((target_name).starts_with("oop_handle"), "invalid oop relocation name");
           auto oop_it = _oop_handles.find(target_name);
           JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(oop_it != _oop_handles.end(), "missing oop handle in relocation");
-          relocs.push_back(new JeandleOopAddrReloc(static_cast<int>(block->getAddress().getValue() + edge.getOffset()), oop_it->getValue()));
+          address reloc_site = resolve_const_reloc_site(*block, edge, assembler);
+          RETURN_VOID_ON_JEANDLE_ERROR();
+          relocs.push_back(new JeandleOopAddrReloc(static_cast<int>(reloc_site - _code_buffer.consts()->start()),
+                                                   oop_it->getValue()));
         } else {
           // Unhandled relocations
           ShouldNotReachHere();
@@ -408,6 +410,21 @@ address JeandleCompiledCode::lookup_const_section(llvm::StringRef name, JeandleA
   }
 
   return it->getValue();
+}
+
+address JeandleCompiledCode::resolve_const_reloc_site(LinkBlock& block, LinkEdge& edge, JeandleAssembler& assembler) {
+  llvm::StringRef section_name = block.getSection().getName();
+  assert(section_name.starts_with(".rodata") || section_name.starts_with(".data.rel.ro"),
+         "invalid const relocation section");
+
+  address section_base = lookup_const_section(section_name, assembler);
+  if (section_base == nullptr) {
+    return nullptr;
+  }
+
+  llvm::jitlink::SectionRange range(block.getSection());
+  uint64_t offset_in_section = block.getAddress() - range.getFirstBlock()->getAddress();
+  return section_base + offset_in_section + edge.getOffset();
 }
 
 address JeandleCompiledCode::resolve_const_edge(LinkBlock& block, LinkEdge& edge, JeandleAssembler& assembler) {

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -328,6 +328,7 @@ class JeandleCompiledCode : public StackObj {
 
   // Lookup address of const section in CodeBuffer.
   address lookup_const_section(llvm::StringRef name, JeandleAssembler& assembler);
+  address resolve_const_reloc_site(LinkBlock& block, LinkEdge& edge, JeandleAssembler& assembler);
   address resolve_const_edge(LinkBlock& block, LinkEdge& edge, JeandleAssembler& assembler);
 
   JeandleStackMap* parse_stackmap(StackMapParser& stackmaps, StackMapParser::record_iterator& record, CallSiteInfo* call_info);


### PR DESCRIPTION
## What this PR does / why we need it:
LLVM pipeline can emit x86 const-section relocations, such as `R_X86_64_64 oop_handle_*` and jump-table Delta32 entries. The x86 Jeandle backend only handled instruction-side oop relocations.

This PR adds x86 support for Pointer64 oop-address relocations in const sections, emits the corresponding HotSpot relocation, and patches const-section oop addresses and section-word entries correctly during relocation.
