### PR TITLE
fix: support goto_w bytecode in Jeandle

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -1416,7 +1416,7 @@ void JeandleAbstractInterpreter::interpret_block(JeandleBasicBlock* block) {
       case Bytecodes::_ifnull: if_null(llvm::CmpInst::ICMP_EQ); break;
       case Bytecodes::_ifnonnull: if_null(llvm::CmpInst::ICMP_NE); break;
 
-      case Bytecodes::_goto_w: Unimplemented(); break;
+      case Bytecodes::_goto_w: goto_bci(_bytecodes.get_far_dest()); break;
       case Bytecodes::_jsr_w: Unimplemented(); break;
 
       // Reserved:

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/GotoWTarget.jasm
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/GotoWTarget.jasm
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package compiler/jeandle/bytecodeTranslate;
+
+super public class GotoWTarget {
+    public static Method gotoW:"()I" stack 1 locals 0 {
+        goto_w L1;
+        iconst_0;
+        ireturn;
+    L1:
+        iconst_1;
+        ireturn;
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/TestGotoW.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/TestGotoW.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @summary Test goto_w bytecode translation
+ * @library /test/lib
+ * @build jdk.test.lib.Asserts
+ * @build jdk.test.whitebox.WhiteBox
+ * @compile GotoWTarget.jasm TestGotoW.java
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -XX:-TieredCompilation -Xbatch
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.GotoWTarget::gotoW
+ *      -XX:+UseJeandleCompiler compiler.jeandle.bytecodeTranslate.TestGotoW
+ */
+
+package compiler.jeandle.bytecodeTranslate;
+
+import java.lang.reflect.Method;
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+public class TestGotoW {
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) throws Exception {
+        Method method = GotoWTarget.class.getDeclaredMethod("gotoW");
+
+        Asserts.assertEquals(GotoWTarget.gotoW(), 1);
+        compile(method);
+        Asserts.assertEquals(GotoWTarget.gotoW(), 1);
+    }
+
+    private static void compile(Method method) {
+        if (!WB.enqueueMethodForCompilation(method, 4)) {
+            throw new RuntimeException("Enqueue " + method + " failed");
+        }
+        while (!WB.isMethodCompiled(method)) {
+            Thread.yield();
+        }
+    }
+}


### PR DESCRIPTION
## Related issue

Fixes #478

## Summary

Add Jeandle bytecode translation support for `_goto_w`, the wide-offset form of the JVM `goto` bytecode.

## Changes

- Dispatch `_goto_w` through the same translation path as `_goto`.
- Use `get_far_dest()` to read the 4-byte branch target used by `goto_w`.
- Add a jtreg regression test that generates a class containing `goto_w` with `BasicClassBuilder`.
- Verify both interpreted execution and Jeandle-compiled execution through WhiteBox-triggered compilation.

## Testing

```bash
~/jtreg/bin/jtreg \
  -jdk:build/linux-aarch64-jeandle-release/images/jdk \
  -vmoption:-XX:UseSVE=0 \
  -verbose:summary \
  test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/TestGotoW.java
```

Result:

```
Passed: compiler/jeandle/bytecodeTranslate/TestGotoW.java
Test results: passed: 1
```