### PR TITLE
enhance: Track Jeandle inline attempts with reasons

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -682,7 +682,7 @@ bool JeandleInlineTree::should_inline(JeandleCompilation* comp,
     return false;
   }
   reason = JeandleInlineReason::InlineHot;
-  return size <= max_inline_size;
+  return true;
 }
 
 bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -124,6 +124,91 @@ static void print_inline_tree_method(outputStream* out, ciMethod* method) {
   }
 }
 
+const char* jeandle_inline_reason_name(JeandleInlineReason reason) {
+  switch (reason) {
+    case JeandleInlineReason::InlineHot:
+      return "inline (hot)";
+    case JeandleInlineReason::ForceInlineByCompileCommand:
+      return "force inline by CompileCommand";
+    case JeandleInlineReason::ForceInlineByAnnotation:
+      return "force inline by annotation";
+    case JeandleInlineReason::ForceInlineByCiReplay:
+      return "force inline by ciReplay";
+    case JeandleInlineReason::ForceIncrementalInlineByCiReplay:
+      return "force incremental inline by ciReplay";
+    case JeandleInlineReason::ManyThrows:
+      return "many throws";
+    case JeandleInlineReason::Accessor:
+      return "accessor";
+    case JeandleInlineReason::FailedInitialChecks:
+      return "failed initial checks";
+    case JeandleInlineReason::NativeMethod:
+      return "native method";
+    case JeandleInlineReason::AbstractMethod:
+      return "abstract method";
+    case JeandleInlineReason::NotCompilableUnbalancedMonitors:
+      return "not compilable (unbalanced monitors)";
+    case JeandleInlineReason::NotCompilableFlowAnalysisFailed:
+      return "not compilable (flow analysis failed)";
+    case JeandleInlineReason::CannotBeParsed:
+      return "cannot be parsed";
+    case JeandleInlineReason::MethodHolderNotInitialized:
+      return "method holder not initialized";
+    case JeandleInlineReason::DontInlineByAnnotation:
+      return "disallowed by DontInline annotation";
+    case JeandleInlineReason::MethodChangesCurrentThread:
+      return "method changes current thread";
+    case JeandleInlineReason::UnloadedSignatureClasses:
+      return "unloaded signature classes";
+    case JeandleInlineReason::DisallowedByCompileCommand:
+      return "disallowed by CompileCommand";
+    case JeandleInlineReason::DisallowedByCiReplay:
+      return "disallowed by ciReplay";
+    case JeandleInlineReason::AlreadyCompiledIntoMediumMethod:
+      return "already compiled into a medium method";
+    case JeandleInlineReason::AlreadyCompiledIntoBigMethod:
+      return "already compiled into a big method";
+    case JeandleInlineReason::HotMethodTooBig:
+      return "hot method too big";
+    case JeandleInlineReason::TooBig:
+      return "too big";
+    case JeandleInlineReason::ExceptionMethod:
+      return "exception method";
+    case JeandleInlineReason::NeverExecuted:
+      return "never executed";
+    case JeandleInlineReason::LowCallSiteFrequency:
+      return "low call site frequency";
+    case JeandleInlineReason::SizeGreaterThanDesiredMethodLimit:
+      return "size > DesiredMethodLimit";
+    case JeandleInlineReason::NodeCountInliningCutoff:
+      return "node count inlining cutoff";
+    case JeandleInlineReason::CallSiteNotReached:
+      return "call site not reached";
+    case JeandleInlineReason::NotAnAccessor:
+      return "not an accessor";
+    case JeandleInlineReason::MaxForceInlineLevel:
+      return "MaxForceInlineLevel";
+    case JeandleInlineReason::InliningTooDeep:
+      return "inlining too deep";
+    case JeandleInlineReason::RecursiveInliningTooDeep:
+      return "recursive inlining too deep";
+    case JeandleInlineReason::TooColdToInline:
+      return "too cold to inline";
+    case JeandleInlineReason::LLVMRootCalleeUnsupported:
+      return "LLVM root callee unsupported";
+    case JeandleInlineReason::LLVMGetInlineCalleeIRFailed:
+      return "LLVM get inline callee IR failed";
+    case JeandleInlineReason::LLVMMissingInlineCalleeDefinition:
+      return "LLVM missing inline callee definition";
+    case JeandleInlineReason::LLVMNotInlineViable:
+      return "LLVM not inline viable";
+    case JeandleInlineReason::LLVMInlineFailed:
+      return "LLVM inline failed";
+    default:
+      return "unknown";
+  }
+}
+
 // Returns the const section alignment for the current Jeandle compilation.
 // Only returns a valid value when running inside a Jeandle compilation thread;
 // returns -1 otherwise (e.g., non-compiler threads, or C1/C2 compiler threads
@@ -368,18 +453,12 @@ JeandleInlineTree::JeandleInlineTree(JeandleInlineTree* caller_tree,
                                      _inline_depth(caller_tree == nullptr ? 0 : caller_tree->inline_depth() + 1),
                                      _max_inline_level(max_inline_level),
                                      _count_inline_bcs(method == nullptr ? 0 : method->code_size_for_inlining()),
+                                     _reason(JeandleInlineReason::InlineHot),
                                      _subtrees(arena, 2, 0, nullptr) {
 }
 
 static methodHandle jeandle_method_handle(ciMethod* method) {
   return methodHandle(Thread::current(), method->get_Method());
-}
-
-static bool jeandle_force_inline(ciMethod* method) {
-  // C2 also consults ciReplay in InlineTree::should_inline. Jeandle does that
-  // at the call site because replay decisions need caller bci and inline depth.
-  return method->force_inline() ||
-         CompilerOracle::should_inline(jeandle_method_handle(method));
 }
 
 static bool jeandle_is_unboxing_method(ciMethod* callee) {
@@ -487,20 +566,25 @@ static bool jeandle_is_valid_invoke_bci(ciMethod* caller, int bci) {
 bool JeandleInlineTree::pass_initial_checks(JeandleCompilation* comp,
                                             ciMethod* caller,
                                             int caller_bci,
-                                            ciMethod* callee) {
+                                            ciMethod* callee,
+                                            JeandleInlineReason& reason) {
   if (callee == nullptr || caller == nullptr) {
+    reason = JeandleInlineReason::FailedInitialChecks;
     return false;
   }
   if (!jeandle_is_valid_invoke_bci(caller, caller_bci)) {
+    reason = JeandleInlineReason::FailedInitialChecks;
     return false;
   }
 
   ciInstanceKlass* callee_holder = callee->holder();
   if (!callee_holder->is_loaded()) {
+    reason = JeandleInlineReason::FailedInitialChecks;
     return false;
   }
   if (!callee_holder->is_initialized() &&
       comp->compiled_code()->needs_clinit_barrier(callee_holder, caller)) {
+    reason = JeandleInlineReason::MethodHolderNotInitialized;
     return false;
   }
 
@@ -514,9 +598,11 @@ bool JeandleInlineTree::pass_initial_checks(JeandleCompilation* comp,
     if (call_bc != Bytecodes::_invokedynamic) {
       int index = iter.get_index_u2_cpcache();
       if (!caller->is_klass_loaded(index, call_bc, true)) {
+        reason = JeandleInlineReason::FailedInitialChecks;
         return false;
       }
       if (!caller->check_call(index, call_bc == Bytecodes::_invokestatic)) {
+        reason = JeandleInlineReason::FailedInitialChecks;
         return false;
       }
     }
@@ -524,13 +610,13 @@ bool JeandleInlineTree::pass_initial_checks(JeandleCompilation* comp,
   return true;
 }
 
-const char* JeandleInlineTree::check_can_parse(ciMethod* callee) const {
-  if (callee->is_native())                    return "native method";
-  if (callee->is_abstract())                  return "abstract method";
-  if (!callee->has_balanced_monitors())       return "not compilable (unbalanced monitors)";
-  if (callee->get_flow_analysis()->failing()) return "not compilable (flow analysis failed)";
-  if (!callee->can_be_parsed())               return "cannot be parsed";
-  return nullptr;
+JeandleInlineReason JeandleInlineTree::check_can_parse(ciMethod* callee) const {
+  if (callee->is_native())                    return JeandleInlineReason::NativeMethod;
+  if (callee->is_abstract())                  return JeandleInlineReason::AbstractMethod;
+  if (!callee->has_balanced_monitors())       return JeandleInlineReason::NotCompilableUnbalancedMonitors;
+  if (callee->get_flow_analysis()->failing()) return JeandleInlineReason::NotCompilableFlowAnalysisFailed;
+  if (!callee->can_be_parsed())               return JeandleInlineReason::CannotBeParsed;
+  return JeandleInlineReason::InlineHot;
 }
 
 bool JeandleInlineTree::should_inline(JeandleCompilation* comp,
@@ -538,9 +624,16 @@ bool JeandleInlineTree::should_inline(JeandleCompilation* comp,
                                       ciMethod* caller,
                                       int caller_bci,
                                       bool& forced_inline,
-                                      ciCallProfile& profile) {
-  if (jeandle_force_inline(callee)) {
+                                      ciCallProfile& profile,
+                                      JeandleInlineReason& reason) {
+  if (CompilerOracle::should_inline(jeandle_method_handle(callee))) {
     forced_inline = true;
+    reason = JeandleInlineReason::ForceInlineByCompileCommand;
+    return true;
+  }
+  if (callee->force_inline()) {
+    forced_inline = true;
+    reason = JeandleInlineReason::ForceInlineByAnnotation;
     return true;
   }
 
@@ -555,12 +648,15 @@ bool JeandleInlineTree::should_inline(JeandleCompilation* comp,
     // no late inline queue yet, so replay-forced inlines are performed
     // immediately even when should_delay is true.
     forced_inline = true;
+    reason = should_delay ? JeandleInlineReason::ForceIncrementalInlineByCiReplay :
+                            JeandleInlineReason::ForceInlineByCiReplay;
     return true;
   }
 
   int size = callee->code_size_for_inlining();
   if (callee->interpreter_throwout_count() > InlineThrowCount &&
       size < InlineThrowMaxSize) {
+    reason = JeandleInlineReason::ManyThrows;
     return true;
   }
 
@@ -576,9 +672,16 @@ bool JeandleInlineTree::should_inline(JeandleCompilation* comp,
     max_inline_size = FreqInlineSize;
   } else if (callee->has_compiled_code() &&
              callee->inline_instructions_size() > InlineSmallCode / 4) {
+    reason = JeandleInlineReason::AlreadyCompiledIntoMediumMethod;
     return false;
   }
 
+  if (size > max_inline_size) {
+    reason = max_inline_size == FreqInlineSize ? JeandleInlineReason::HotMethodTooBig :
+                                                 JeandleInlineReason::TooBig;
+    return false;
+  }
+  reason = JeandleInlineReason::InlineHot;
   return size <= max_inline_size;
 }
 
@@ -586,25 +689,32 @@ bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,
                                           ciMethod* callee,
                                           ciMethod* caller,
                                           int caller_bci,
-                                          ciCallProfile& profile) {
+                                          ciCallProfile& profile,
+                                          JeandleInlineReason& reason) {
   if (callee->is_abstract()) {
+    reason = JeandleInlineReason::AbstractMethod;
     return true;
   }
   if (!callee->holder()->is_initialized() &&
       comp->compiled_code()->needs_clinit_barrier(callee->holder(), caller)) {
+    reason = JeandleInlineReason::MethodHolderNotInitialized;
     return true;
   }
   if (callee->is_native()) {
+    reason = JeandleInlineReason::NativeMethod;
     return true;
   }
   if (callee->dont_inline()) {
+    reason = JeandleInlineReason::DontInlineByAnnotation;
     return true;
   }
   if (callee->changes_current_thread() &&
       !comp->method()->changes_current_thread()) {
+    reason = JeandleInlineReason::MethodChangesCurrentThread;
     return true;
   }
   if (callee->has_unloaded_classes_in_signature()) {
+    reason = JeandleInlineReason::UnloadedSignatureClasses;
     return true;
   }
 
@@ -613,9 +723,11 @@ bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,
   // inline command wins over explicit no-inline, then annotation force-inline
   // can override only heuristic objections below.
   if (CompilerOracle::should_inline(jeandle_method_handle(callee))) {
+    reason = JeandleInlineReason::ForceInlineByCompileCommand;
     return false;
   }
   if (CompilerOracle::should_not_inline(jeandle_method_handle(callee))) {
+    reason = JeandleInlineReason::DisallowedByCompileCommand;
     return true;
   }
 
@@ -628,19 +740,24 @@ bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,
                               should_delay)) {
     // TODO: Jeandle currently ignores replay late-inline timing and treats this
     // as an immediate replay-forced inline.
+    reason = should_delay ? JeandleInlineReason::ForceIncrementalInlineByCiReplay :
+                            JeandleInlineReason::ForceInlineByCiReplay;
     return false;
   }
   if (ciReplay::should_not_inline(comp->replay_inline_data(),
                                   callee,
                                   caller_bci,
                                   replay_inline_depth)) {
+    reason = JeandleInlineReason::DisallowedByCiReplay;
     return true;
   }
   if (ciReplay::should_not_inline(callee)) {
+    reason = JeandleInlineReason::DisallowedByCiReplay;
     return true;
   }
 
   if (callee->force_inline()) {
+    reason = JeandleInlineReason::ForceInlineByAnnotation;
     return false;
   }
   if (jeandle_is_unboxing_method(callee)) {
@@ -648,6 +765,7 @@ bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,
   }
   if (callee->has_compiled_code() &&
       callee->inline_instructions_size() > InlineSmallCode) {
+    reason = JeandleInlineReason::AlreadyCompiledIntoBigMethod;
     return true;
   }
 
@@ -658,6 +776,7 @@ bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,
       top = top->caller_tree();
     }
     if (!top->method()->holder()->is_subclass_of(ciEnv::current()->Throwable_klass())) {
+      reason = JeandleInlineReason::ExceptionMethod;
       return true;
     }
   }
@@ -669,6 +788,7 @@ bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,
   if (UseInterpreter) {
     if (!callee->has_compiled_code() &&
         !callee->was_executed_more_than(0)) {
+      reason = JeandleInlineReason::NeverExecuted;
       return true;
     }
     if (jeandle_is_init_with_ea(callee, caller, comp->method())) {
@@ -682,6 +802,7 @@ bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,
       int cp_min_inv = MAX2(1, CompilationPolicy::min_invocations());
       double min_freq = MAX2(MinInlineFrequencyRatio, 1.0 / cp_min_inv);
       if (freq < min_freq) {
+        reason = JeandleInlineReason::LowCallSiteFrequency;
         return true;
       }
     }
@@ -718,20 +839,23 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
                                       ciMethod* callee,
                                       ciMethod* caller,
                                       int caller_bci,
-                                      ciCallProfile& profile) {
+                                      ciCallProfile& profile,
+                                      JeandleInlineReason& reason) {
   bool forced_inline = false;
   if (jeandle_exceeds_desired_method_limit(callee, (int)count_inline_bcs())) {
+    reason = JeandleInlineReason::SizeGreaterThanDesiredMethodLimit;
     return false;
   }
 
-  if (!should_inline(comp, callee, caller, caller_bci, forced_inline, profile)) {
+  if (!should_inline(comp, callee, caller, caller_bci, forced_inline, profile, reason)) {
     return false;
   }
-  if (should_not_inline(comp, callee, caller, caller_bci, profile)) {
+  if (should_not_inline(comp, callee, caller, caller_bci, profile, reason)) {
     return false;
   }
 
   if (InlineAccessors && callee->is_accessor()) {
+    reason = JeandleInlineReason::Accessor;
     return true;
   }
 
@@ -741,11 +865,13 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
     // so non-forced inline candidates are rejected instead of delayed.
     if (comp->over_inlining_cutoff() &&
         (!callee->force_inline() || !IncrementalInline)) {
+      reason = JeandleInlineReason::NodeCountInliningCutoff;
       return false;
     }
     if (!forced_inline &&
         !(!UseInterpreter && jeandle_is_init_with_ea(callee, caller, comp->method())) &&
         is_not_reached(callee, caller, caller_bci, profile)) {
+      reason = JeandleInlineReason::CallSiteNotReached;
       return false;
     }
   }
@@ -753,14 +879,17 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
   // If global inlining is disabled, only the InlineAccessors fast path above
   // may pass. LLVM normally enforces the same mode before invoking this policy.
   if (!Inline) {
+    reason = JeandleInlineReason::NotAnAccessor;
     return false;
   }
 
   if (inline_depth() > MaxForceInlineLevel) {
+    reason = JeandleInlineReason::MaxForceInlineLevel;
     return false;
   }
   if (inline_depth() > max_inline_level()) {
     if (!callee->force_inline() || !IncrementalInline) {
+      reason = JeandleInlineReason::InliningTooDeep;
       return false;
     }
     // TODO: C2 delays this inline when not already in incremental inlining.
@@ -774,6 +903,7 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
     }
   }
   if (recursive_inline_level > MaxRecursiveInlineLevel) {
+    reason = JeandleInlineReason::RecursiveInliningTooDeep;
     return false;
   }
   // TODO: C2 gives compiled lambda forms special recursion handling based on
@@ -782,6 +912,7 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
 
   int size = callee->code_size_for_inlining();
   if (jeandle_exceeds_desired_method_limit(callee, (int)count_inline_bcs() + size)) {
+    reason = JeandleInlineReason::SizeGreaterThanDesiredMethodLimit;
     return false;
   }
 
@@ -790,25 +921,29 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
 
 bool JeandleInlineTree::ok_to_inline(JeandleCompilation* comp,
                                      ciMethod* callee,
-                                     int caller_bci) {
+                                     int caller_bci,
+                                     JeandleInlineReason& reason) {
   ciMethod* caller = method();
   assert(caller != nullptr, "caller method must exist");
+  reason = JeandleInlineReason::InlineHot;
 
   // Jeandle gets here only after LLVM has selected a monomorphic Java call
   // site. CHA/PGO monomorphization is represented in IR before this policy;
   // this method mirrors C2's post-target-selection inline checks.
-  if (!pass_initial_checks(comp, caller, caller_bci, callee)) {
+  if (!pass_initial_checks(comp, caller, caller_bci, callee, reason)) {
     return false;
   }
 
   // Keep parseability separate from heuristic policy, matching C2's
   // InlineTree::ok_to_inline structure.
-  if (check_can_parse(callee) != nullptr) {
+  JeandleInlineReason parse_reason = check_can_parse(callee);
+  if (parse_reason != JeandleInlineReason::InlineHot) {
+    reason = parse_reason;
     return false;
   }
 
   ciCallProfile profile = caller->call_profile_at_bci(caller_bci);
-  return try_to_inline(comp, callee, caller, caller_bci, profile);
+  return try_to_inline(comp, callee, caller, caller_bci, profile, reason);
 }
 
 JeandleInlineTree* JeandleInlineTree::callee_at(int caller_bci, ciMethod* callee) const {
@@ -858,29 +993,6 @@ int JeandleInlineTree::count() const {
     result += _subtrees.at(i)->count();
   }
   return result;
-}
-
-void JeandleInlineTree::print(outputStream* out) const {
-  assert(method() != nullptr, "inline tree node must have a method");
-  print_inline_tree_method(out, method());
-  out->cr();
-  for (int i = 0; i < _subtrees.length(); i++) {
-    _subtrees.at(i)->print_impl(out, "", i == _subtrees.length() - 1);
-  }
-}
-
-void JeandleInlineTree::print_impl(outputStream* out,
-                                   const std::string& prefix,
-                                   bool is_last) const {
-  assert(method() != nullptr, "inline tree node must have a method");
-  out->print("%s%s@%d ", prefix.c_str(), is_last ? "`- " : "|- ", caller_bci());
-  print_inline_tree_method(out, method());
-  out->cr();
-
-  std::string child_prefix = prefix + (is_last ? "   " : "|  ");
-  for (int i = 0; i < _subtrees.length(); i++) {
-    _subtrees.at(i)->print_impl(out, child_prefix, i == _subtrees.length() - 1);
-  }
 }
 
 void JeandleInlineTree::dump_replay_data(outputStream* out, int depth_adjust) const {
@@ -961,9 +1073,125 @@ void JeandleCompilation::commit_inline_tree_for_callee(int caller_scope_id,
 
   caller_tree->commit_inline_tree_for_callee(callee_tree);
   // Keep this array in lockstep with LLVM's InlineScopes vector. LLVM assigns
-  // the new scope id after RecordInlineSuccess using the same successful-inline
-  // order, so appending here produces the id that cloned child call sites use.
+  // the new scope id after a successful RecordInlineResult using the same
+  // successful-inline order, so appending here produces the id that cloned child
+  // call sites use.
   _inline_trees.append(callee_tree);
+}
+
+void JeandleCompilation::record_inline_failure(int caller_scope_id,
+                                               int caller_bci,
+                                               ciMethod* callee,
+                                               JeandleInlineReason reason) {
+  for (int i = 0; i < _inline_failures.length(); i++) {
+    JeandleInlineFailure* failure = _inline_failures.at(i);
+    if (failure->caller_scope_id() == caller_scope_id &&
+        failure->caller_bci() == caller_bci &&
+        failure->callee() == callee &&
+        failure->reason() == reason) {
+      return;
+    }
+  }
+  _inline_failures.append(new (_arena) JeandleInlineFailure(caller_scope_id,
+                                                            caller_bci,
+                                                            callee,
+                                                            reason));
+}
+
+static void insert_inline_tree_by_bci(GrowableArray<JeandleInlineTree*>* trees,
+                                      JeandleInlineTree* tree) {
+  int insert_at = trees->length();
+  while (insert_at > 0 && tree->caller_bci() < trees->at(insert_at - 1)->caller_bci()) {
+    insert_at--;
+  }
+  trees->insert_before(insert_at, tree);
+}
+
+static void insert_inline_failure_by_bci(GrowableArray<JeandleInlineFailure*>* failures,
+                                         JeandleInlineFailure* failure) {
+  int insert_at = failures->length();
+  while (insert_at > 0 && failure->caller_bci() < failures->at(insert_at - 1)->caller_bci()) {
+    insert_at--;
+  }
+  failures->insert_before(insert_at, failure);
+}
+
+int JeandleCompilation::inline_scope_id_for_tree(const JeandleInlineTree* tree) const {
+  if (tree == _inline_tree_root) {
+    return -1;
+  }
+  for (int i = 0; i < _inline_trees.length(); i++) {
+    if (_inline_trees.at(i) == tree) {
+      return i;
+    }
+  }
+  ShouldNotReachHere();
+  return -1;
+}
+
+void JeandleCompilation::print_inline_tree_impl(outputStream* out,
+                                                const JeandleInlineTree* tree,
+                                                int scope_id,
+                                                const std::string& prefix) const {
+  // Diagnostics merge successful children and failed attempts for this scope.
+  // Keep the semantic tree untouched, and sort the merged view by caller bci so
+  // the output follows bytecode order instead of callback order.
+  GrowableArray<JeandleInlineTree*> subtrees;
+  for (int i = 0; i < tree->subtrees().length(); i++) {
+    insert_inline_tree_by_bci(&subtrees, tree->subtrees().at(i));
+  }
+
+  GrowableArray<JeandleInlineFailure*> failures;
+  for (int i = 0; i < _inline_failures.length(); i++) {
+    JeandleInlineFailure* failure = _inline_failures.at(i);
+    if (failure->caller_scope_id() == scope_id) {
+      insert_inline_failure_by_bci(&failures, failure);
+    }
+  }
+
+  int subtree_index = 0;
+  int failure_index = 0;
+  int total = subtrees.length() + failures.length();
+  for (int i = 0; i < total; i++) {
+    bool use_failure;
+    if (subtree_index >= subtrees.length()) {
+      use_failure = true;
+    } else if (failure_index >= failures.length()) {
+      use_failure = false;
+    } else {
+      use_failure = failures.at(failure_index)->caller_bci() <
+                    subtrees.at(subtree_index)->caller_bci();
+    }
+
+    bool is_last = i == total - 1;
+    const char* branch = is_last ? "`- " : "|- ";
+    std::string child_prefix = prefix + (is_last ? "   " : "|  ");
+    if (use_failure) {
+      JeandleInlineFailure* failure = failures.at(failure_index++);
+      // Prefix failed attempts with "X" so large trees can be scanned from the
+      // left edge: "@bci" means inlined, while "X@bci" means not inlined.
+      out->print("%s%sX@%d ", prefix.c_str(), branch, failure->caller_bci());
+      print_inline_tree_method(out, failure->callee());
+      out->print("  [failed: %s]", jeandle_inline_reason_name(failure->reason()));
+      out->cr();
+    } else {
+      JeandleInlineTree* subtree = subtrees.at(subtree_index++);
+      out->print("%s%s@%d ", prefix.c_str(), branch, subtree->caller_bci());
+      print_inline_tree_method(out, subtree->method());
+      out->print("  [%s]", jeandle_inline_reason_name(subtree->reason()));
+      out->cr();
+      print_inline_tree_impl(out, subtree, inline_scope_id_for_tree(subtree), child_prefix);
+    }
+  }
+}
+
+void JeandleCompilation::print_inline_tree(outputStream* out) const {
+  assert(_inline_tree_root != nullptr, "root inline tree must exist");
+  assert(_inline_tree_root->method() != nullptr, "root inline tree node must have a method");
+  ResourceMark rm;
+  print_inline_tree_method(out, _inline_tree_root->method());
+  out->cr();
+  print_inline_tree_impl(out, _inline_tree_root, -1, "");
 }
 
 void JeandleCompilation::dump_inline_data(outputStream* out) {
@@ -1056,7 +1284,7 @@ void JeandleCompilation::install_code() {
   if (JeandlePrintInlineTree && _inline_tree_root != nullptr) {
     stringStream inline_tree;
     inline_tree.print_cr("Jeandle inline tree:");
-    _inline_tree_root->print(&inline_tree);
+    print_inline_tree(&inline_tree);
 
     ttyLocker ttyl;
     tty->print("%s", inline_tree.as_string());

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -369,9 +369,6 @@ JeandleInlineTree::JeandleInlineTree(JeandleInlineTree* caller_tree,
                                      _max_inline_level(max_inline_level),
                                      _count_inline_bcs(method == nullptr ? 0 : method->code_size_for_inlining()),
                                      _subtrees(arena, 2, 0, nullptr) {
-  for (JeandleInlineTree* caller = caller_tree; caller != nullptr; caller = caller->caller_tree()) {
-    caller->_count_inline_bcs += _count_inline_bcs;
-  }
 }
 
 static methodHandle jeandle_method_handle(ciMethod* method) {
@@ -824,13 +821,10 @@ JeandleInlineTree* JeandleInlineTree::callee_at(int caller_bci, ciMethod* callee
   return nullptr;
 }
 
-JeandleInlineTree* JeandleInlineTree::build_inline_tree_for_callee(ciMethod* callee,
-                                                                   int caller_bci,
-                                                                   Arena* arena) {
-  JeandleInlineTree* old_tree = callee_at(caller_bci, callee);
-  if (old_tree != nullptr) {
-    return old_tree;
-  }
+JeandleInlineTree* JeandleInlineTree::allocate_inline_tree_for_callee(ciMethod* callee,
+                                                                      int caller_bci,
+                                                                      Arena* arena) {
+  // Allocate before LLVM mutates IR, but do not append the node until the inline succeeds.
   int max_inline_level_adjust = 0;
   if (method() != nullptr) {
     if (method()->is_compiled_lambda_form()) {
@@ -840,12 +834,22 @@ JeandleInlineTree* JeandleInlineTree::build_inline_tree_for_callee(ciMethod* cal
       max_inline_level_adjust += 1; // Do not count method handle calls from java.lang.invoke implementation.
     }
   }
-  JeandleInlineTree* callee_tree =
-      new (arena) JeandleInlineTree(this, callee, caller_bci,
-                                    max_inline_level() + max_inline_level_adjust,
-                                    arena);
+  return new (arena) JeandleInlineTree(this, callee, caller_bci,
+                                       max_inline_level() + max_inline_level_adjust,
+                                       arena);
+}
+
+void JeandleInlineTree::commit_inline_tree_for_callee(JeandleInlineTree* callee_tree) {
+  assert(callee_tree != nullptr, "callee inline tree must exist");
+  assert(callee_tree->caller_tree() == this, "callee inline tree must belong to this caller");
+  assert(callee_at(callee_tree->caller_bci(), callee_tree->method()) == nullptr,
+         "callee inline tree must not be committed twice");
+  // From this point on, the tree reflects a successful LLVM inline and can
+  // contribute to replay data, inline scope lookup, and bytecode-size limits.
   _subtrees.append(callee_tree);
-  return callee_tree;
+  for (JeandleInlineTree* caller = this; caller != nullptr; caller = caller->caller_tree()) {
+    caller->_count_inline_bcs += callee_tree->count_inline_bcs();
+  }
 }
 
 int JeandleInlineTree::count() const {
@@ -907,18 +911,59 @@ JeandleInlineTree* JeandleCompilation::inline_tree_for_scope(int scope_id) const
   return _inline_trees.at(scope_id);
 }
 
-JeandleInlineTree* JeandleCompilation::build_inline_tree_for_callee(int caller_scope_id,
-                                                                    int caller_bci,
-                                                                    ciMethod* callee) {
+JeandleInlineTree* JeandleCompilation::prepare_inline_tree_for_callee(int caller_scope_id,
+                                                                      int caller_bci,
+                                                                      ciMethod* callee) {
   JeandleInlineTree* caller_tree = inline_tree_for_scope(caller_scope_id);
   assert(caller_tree != nullptr, "caller inline tree must exist");
-  JeandleInlineTree* callee_tree =
-      caller_tree->build_inline_tree_for_callee(callee, caller_bci, _arena);
+
+  JeandleInlineTree* committed_tree = caller_tree->callee_at(caller_bci, callee);
+  if (committed_tree != nullptr) {
+    return committed_tree;
+  }
+  for (int i = 0; i < _pending_inline_trees.length(); i++) {
+    JeandlePendingInlineTree* pending = _pending_inline_trees.at(i);
+    if (pending->matches(caller_scope_id, caller_bci, callee)) {
+      return pending->_callee_tree;
+    }
+  }
+
+  JeandleInlineTree* callee_tree = caller_tree->allocate_inline_tree_for_callee(callee, caller_bci, _arena);
+  _pending_inline_trees.append(new (_arena) JeandlePendingInlineTree(caller_scope_id,
+                                                                     caller_bci,
+                                                                     callee,
+                                                                     callee_tree));
+  return callee_tree;
+}
+
+void JeandleCompilation::commit_inline_tree_for_callee(int caller_scope_id,
+                                                       int caller_bci,
+                                                       ciMethod* callee) {
+  JeandleInlineTree* caller_tree = inline_tree_for_scope(caller_scope_id);
+  assert(caller_tree != nullptr, "caller inline tree must exist");
+
+  JeandleInlineTree* committed_tree = caller_tree->callee_at(caller_bci, callee);
+  if (committed_tree != nullptr) {
+    _inline_trees.append(committed_tree);
+    return;
+  }
+
+  JeandleInlineTree* callee_tree = nullptr;
+  for (int i = 0; i < _pending_inline_trees.length(); i++) {
+    JeandlePendingInlineTree* pending = _pending_inline_trees.at(i);
+    if (pending->matches(caller_scope_id, caller_bci, callee)) {
+      callee_tree = pending->_callee_tree;
+      _pending_inline_trees.remove_at(i);
+      break;
+    }
+  }
+  assert(callee_tree != nullptr, "callee inline tree must have been prepared before a successful inline");
+
+  caller_tree->commit_inline_tree_for_callee(callee_tree);
   // Keep this array in lockstep with LLVM's InlineScopes vector. LLVM assigns
   // the new scope id after RecordInlineSuccess using the same successful-inline
   // order, so appending here produces the id that cloned child call sites use.
   _inline_trees.append(callee_tree);
-  return callee_tree;
 }
 
 void JeandleCompilation::dump_inline_data(outputStream* out) {

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -44,8 +44,78 @@ class ciCallProfile;
 class ciObject;
 class DirectiveSet;
 class JeandleCompilation;
+class JeandleInlineFailure;
 class JeandleInlineTree;
 class outputStream;
+
+enum class JeandleInlineReason {
+  InlineHot,
+  ForceInlineByCompileCommand,
+  ForceInlineByAnnotation,
+  ForceInlineByCiReplay,
+  ForceIncrementalInlineByCiReplay,
+  ManyThrows,
+  Accessor,
+  FailedInitialChecks,
+  NativeMethod,
+  AbstractMethod,
+  NotCompilableUnbalancedMonitors,
+  NotCompilableFlowAnalysisFailed,
+  CannotBeParsed,
+  MethodHolderNotInitialized,
+  DontInlineByAnnotation,
+  MethodChangesCurrentThread,
+  UnloadedSignatureClasses,
+  DisallowedByCompileCommand,
+  DisallowedByCiReplay,
+  AlreadyCompiledIntoMediumMethod,
+  AlreadyCompiledIntoBigMethod,
+  HotMethodTooBig,
+  TooBig,
+  ExceptionMethod,
+  NeverExecuted,
+  LowCallSiteFrequency,
+  SizeGreaterThanDesiredMethodLimit,
+  NodeCountInliningCutoff,
+  CallSiteNotReached,
+  NotAnAccessor,
+  MaxForceInlineLevel,
+  InliningTooDeep,
+  RecursiveInliningTooDeep,
+  TooColdToInline,
+  LLVMRootCalleeUnsupported,
+  LLVMGetInlineCalleeIRFailed,
+  LLVMMissingInlineCalleeDefinition,
+  LLVMNotInlineViable,
+  LLVMInlineFailed
+};
+
+const char* jeandle_inline_reason_name(JeandleInlineReason reason);
+
+// Successful inlines form the semantic inline tree used by scope lookup,
+// replay, and deopt metadata. Failed attempts are tracked separately so
+// diagnostics can show them without making failed callees visible as scopes.
+class JeandleInlineFailure : public AnyObj {
+  int _caller_scope_id;
+  int _caller_bci;
+  ciMethod* _callee;
+  JeandleInlineReason _reason;
+
+ public:
+  JeandleInlineFailure(int caller_scope_id,
+                       int caller_bci,
+                       ciMethod* callee,
+                       JeandleInlineReason reason) :
+                       _caller_scope_id(caller_scope_id),
+                       _caller_bci(caller_bci),
+                       _callee(callee),
+                       _reason(reason) {}
+
+  int caller_scope_id() const { return _caller_scope_id; }
+  int caller_bci() const { return _caller_bci; }
+  ciMethod* callee() const { return _callee; }
+  JeandleInlineReason reason() const { return _reason; }
+};
 
 class JeandlePendingInlineTree : public AnyObj {
  public:
@@ -77,36 +147,38 @@ class JeandleInlineTree : public AnyObj {
   int _inline_depth;
   int _max_inline_level;
   uint _count_inline_bcs;
+  JeandleInlineReason _reason;
   GrowableArray<JeandleInlineTree*> _subtrees;
 
   bool pass_initial_checks(JeandleCompilation* comp,
                            ciMethod* caller,
                            int caller_bci,
-                           ciMethod* callee);
-  const char* check_can_parse(ciMethod* callee) const;
+                           ciMethod* callee,
+                           JeandleInlineReason& reason);
+  JeandleInlineReason check_can_parse(ciMethod* callee) const;
   bool should_inline(JeandleCompilation* comp,
                      ciMethod* callee,
                      ciMethod* caller,
                      int caller_bci,
                      bool& forced_inline,
-                     ciCallProfile& profile);
+                     ciCallProfile& profile,
+                     JeandleInlineReason& reason);
   bool should_not_inline(JeandleCompilation* comp,
                          ciMethod* callee,
                          ciMethod* caller,
                          int caller_bci,
-                         ciCallProfile& profile);
+                         ciCallProfile& profile,
+                         JeandleInlineReason& reason);
   bool is_not_reached(ciMethod* callee,
                       ciMethod* caller,
                       int caller_bci,
                       ciCallProfile& profile);
-  void print_impl(outputStream* out,
-                  const std::string& prefix,
-                  bool is_last) const;
   bool try_to_inline(JeandleCompilation* comp,
                      ciMethod* callee,
                      ciMethod* caller,
                      int caller_bci,
-                     ciCallProfile& profile);
+                     ciCallProfile& profile,
+                     JeandleInlineReason& reason);
 
  public:
   JeandleInlineTree(JeandleInlineTree* caller_tree,
@@ -121,23 +193,25 @@ class JeandleInlineTree : public AnyObj {
   int inline_depth() const { return _inline_depth; }
   int max_inline_level() const { return _max_inline_level; }
   uint count_inline_bcs() const { return _count_inline_bcs; }
+  JeandleInlineReason reason() const { return _reason; }
+  void set_reason(JeandleInlineReason reason) { _reason = reason; }
   const GrowableArray<JeandleInlineTree*>& subtrees() const { return _subtrees; }
 
   bool ok_to_inline(JeandleCompilation* comp,
                     ciMethod* callee,
-                    int caller_bci);
+                    int caller_bci,
+                    JeandleInlineReason& reason);
   JeandleInlineTree* callee_at(int caller_bci, ciMethod* callee) const;
   // Inline tree allocation is separated from commit so allocation happens before
   // LLVM mutates IR. If the tree were allocated only after a successful LLVM
   // inline, an allocation failure could leave LLVM IR inlined while JVM inline
-  // metadata is missing. Commit is still delayed until RecordInlineSuccess so
-  // failed LLVM inline attempts are not recorded.
+  // metadata is missing. Commit is still delayed until RecordInlineResult
+  // reports InlineSuccess, so failed LLVM inline attempts are not recorded.
   JeandleInlineTree* allocate_inline_tree_for_callee(ciMethod* callee,
                                                      int caller_bci,
                                                      Arena* arena);
   void commit_inline_tree_for_callee(JeandleInlineTree* callee_tree);
   int count() const;
-  void print(outputStream* out) const;
   void dump_replay_data(outputStream* out, int depth_adjust = 0) const;
 };
 
@@ -201,6 +275,11 @@ class JeandleCompilation : public StackObj {
   void commit_inline_tree_for_callee(int caller_scope_id,
                                      int caller_bci,
                                      ciMethod* callee);
+  void record_inline_failure(int caller_scope_id,
+                             int caller_bci,
+                             ciMethod* callee,
+                             JeandleInlineReason reason);
+  void print_inline_tree(outputStream* out) const;
 
   JeandleCompiledCode* compiled_code() { return &_code; }
 
@@ -236,6 +315,7 @@ class JeandleCompilation : public StackObj {
   // assigned in successful inline order and index this array.
   GrowableArray<JeandleInlineTree*> _inline_trees;
   GrowableArray<JeandlePendingInlineTree*> _pending_inline_trees;
+  GrowableArray<JeandleInlineFailure*> _inline_failures;
   JeandleInlineTree* _inline_tree_root;
 
   // Record oop constants as module-level globals. This is shared by all
@@ -260,6 +340,11 @@ class JeandleCompilation : public StackObj {
   void compile_java_method();
   void compile_module();
   void install_code();
+  int inline_scope_id_for_tree(const JeandleInlineTree* tree) const;
+  void print_inline_tree_impl(outputStream* out,
+                              const JeandleInlineTree* tree,
+                              int scope_id,
+                              const std::string& prefix) const;
 
   void dump_obj();
   void dump_ir(bool optimized);

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -44,7 +44,31 @@ class ciCallProfile;
 class ciObject;
 class DirectiveSet;
 class JeandleCompilation;
+class JeandleInlineTree;
 class outputStream;
+
+class JeandlePendingInlineTree : public AnyObj {
+ public:
+  int _caller_scope_id;
+  int _caller_bci;
+  ciMethod* _callee;
+  JeandleInlineTree* _callee_tree;
+
+  JeandlePendingInlineTree(int caller_scope_id,
+                           int caller_bci,
+                           ciMethod* callee,
+                           JeandleInlineTree* callee_tree) :
+                           _caller_scope_id(caller_scope_id),
+                           _caller_bci(caller_bci),
+                           _callee(callee),
+                           _callee_tree(callee_tree) {}
+
+  bool matches(int caller_scope_id, int caller_bci, ciMethod* callee) const {
+    return _caller_scope_id == caller_scope_id &&
+           _caller_bci == caller_bci &&
+           _callee == callee;
+  }
+};
 
 class JeandleInlineTree : public AnyObj {
   JeandleInlineTree* _caller_tree;
@@ -103,9 +127,15 @@ class JeandleInlineTree : public AnyObj {
                     ciMethod* callee,
                     int caller_bci);
   JeandleInlineTree* callee_at(int caller_bci, ciMethod* callee) const;
-  JeandleInlineTree* build_inline_tree_for_callee(ciMethod* callee,
-                                                  int caller_bci,
-                                                  Arena* arena);
+  // Inline tree allocation is separated from commit so allocation happens before
+  // LLVM mutates IR. If the tree were allocated only after a successful LLVM
+  // inline, an allocation failure could leave LLVM IR inlined while JVM inline
+  // metadata is missing. Commit is still delayed until RecordInlineSuccess so
+  // failed LLVM inline attempts are not recorded.
+  JeandleInlineTree* allocate_inline_tree_for_callee(ciMethod* callee,
+                                                     int caller_bci,
+                                                     Arena* arena);
+  void commit_inline_tree_for_callee(JeandleInlineTree* callee_tree);
   int count() const;
   void print(outputStream* out) const;
   void dump_replay_data(outputStream* out, int depth_adjust = 0) const;
@@ -165,9 +195,12 @@ class JeandleCompilation : public StackObj {
 
   JeandleInlineTree* inline_tree_root() const { return _inline_tree_root; }
   JeandleInlineTree* inline_tree_for_scope(int scope_id) const;
-  JeandleInlineTree* build_inline_tree_for_callee(int caller_scope_id,
-                                                  int caller_bci,
-                                                  ciMethod* callee);
+  JeandleInlineTree* prepare_inline_tree_for_callee(int caller_scope_id,
+                                                    int caller_bci,
+                                                    ciMethod* callee);
+  void commit_inline_tree_for_callee(int caller_scope_id,
+                                     int caller_bci,
+                                     ciMethod* callee);
 
   JeandleCompiledCode* compiled_code() { return &_code; }
 
@@ -202,6 +235,7 @@ class JeandleCompilation : public StackObj {
   // LLVM uses -1 for the root Java method scope. Non-negative scope ids are
   // assigned in successful inline order and index this array.
   GrowableArray<JeandleInlineTree*> _inline_trees;
+  GrowableArray<JeandlePendingInlineTree*> _pending_inline_trees;
   JeandleInlineTree* _inline_tree_root;
 
   // Record oop constants as module-level globals. This is shared by all

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -235,6 +235,25 @@ ciMethod* jeandle_callback_method(uintptr_t method) {
   return (ciMethod*)method;
 }
 
+JeandleInlineReason jeandle_inline_reason_from_llvm(int reason) {
+  switch (static_cast<llvm::jeandle::JeandleInlineReason>(reason)) {
+    case llvm::jeandle::JeandleInlineReason::RootCalleeUnsupported:
+      return JeandleInlineReason::LLVMRootCalleeUnsupported;
+    case llvm::jeandle::JeandleInlineReason::GetInlineCalleeIRFailed:
+      return JeandleInlineReason::LLVMGetInlineCalleeIRFailed;
+    case llvm::jeandle::JeandleInlineReason::MissingInlineCalleeDefinition:
+      return JeandleInlineReason::LLVMMissingInlineCalleeDefinition;
+    case llvm::jeandle::JeandleInlineReason::NotInlineViable:
+      return JeandleInlineReason::LLVMNotInlineViable;
+    case llvm::jeandle::JeandleInlineReason::LLVMInlineFailed:
+      return JeandleInlineReason::LLVMInlineFailed;
+    case llvm::jeandle::JeandleInlineReason::InlineSuccess:
+      ShouldNotReachHere();
+  }
+  ShouldNotReachHere();
+  return JeandleInlineReason::LLVMInlineFailed;
+}
+
 bool jeandle_is_ok_to_inline(int scope_id, int bci, uintptr_t callee_method) {
   JeandleCompilation* comp = JeandleCompilation::current();
   assert(comp != nullptr, "Must be called in compile thread");
@@ -244,24 +263,35 @@ bool jeandle_is_ok_to_inline(int scope_id, int bci, uintptr_t callee_method) {
   if (caller_tree->callee_at(bci, callee) != nullptr) {
     return true;
   }
-  if (!caller_tree->ok_to_inline(comp, callee, bci)) {
+  JeandleInlineReason reason = JeandleInlineReason::InlineHot;
+  if (!caller_tree->ok_to_inline(comp, callee, bci, reason)) {
+    comp->record_inline_failure(scope_id, bci, callee, reason);
     return false;
   }
 
   JeandleInlineTree* callee_tree = comp->prepare_inline_tree_for_callee(scope_id, bci, callee);
   assert(callee_tree != nullptr, "callee inline tree must be prepared before LLVM inline");
+  callee_tree->set_reason(reason);
   return true;
 }
 
-bool jeandle_record_inline_success(int scope_id, int bci, uintptr_t callee_method) {
+bool jeandle_record_inline_result(int scope_id, int bci, uintptr_t callee_method, int result) {
   JeandleCompilation* comp = JeandleCompilation::current();
   assert(comp != nullptr, "Must be called in compile thread");
   ciMethod* callee = jeandle_callback_method(callee_method);
 
-  // LLVM calls this callback only after the inline transformation succeeds.
-  // IsOkToInline has already prepared this tree, so this operation should only
-  // commit metadata in the same successful-inline order as LLVM's InlineScopes.
-  comp->commit_inline_tree_for_callee(scope_id, bci, callee);
+  llvm::jeandle::JeandleInlineReason llvm_reason =
+      static_cast<llvm::jeandle::JeandleInlineReason>(result);
+  if (llvm_reason == llvm::jeandle::JeandleInlineReason::InlineSuccess) {
+    // IsOkToInline has already prepared this tree, so a successful result only
+    // commits metadata in the same successful-inline order as LLVM's InlineScopes.
+    comp->commit_inline_tree_for_callee(scope_id, bci, callee);
+  } else {
+    comp->record_inline_failure(scope_id,
+                                bci,
+                                callee,
+                                jeandle_inline_reason_from_llvm(result));
+  }
   return true;
 }
 
@@ -326,7 +356,7 @@ void register_jeandle_vm_callbacks() {
   callbacks.GetInlineCalleeIR = &jeandle_get_inline_callee_ir;
   callbacks.GetNewStatepointID = &jeandle_get_new_statepoint_id;
   callbacks.IsOkToInline = &jeandle_is_ok_to_inline;
-  callbacks.RecordInlineSuccess = &jeandle_record_inline_success;
+  callbacks.RecordInlineResult = &jeandle_record_inline_result;
   callbacks.RecordInliningComplete = &jeandle_record_inlining_complete;
   llvm::jeandle::registerVMCallbacks(callbacks);
 

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -244,7 +244,13 @@ bool jeandle_is_ok_to_inline(int scope_id, int bci, uintptr_t callee_method) {
   if (caller_tree->callee_at(bci, callee) != nullptr) {
     return true;
   }
-  return caller_tree->ok_to_inline(comp, callee, bci);
+  if (!caller_tree->ok_to_inline(comp, callee, bci)) {
+    return false;
+  }
+
+  JeandleInlineTree* callee_tree = comp->prepare_inline_tree_for_callee(scope_id, bci, callee);
+  assert(callee_tree != nullptr, "callee inline tree must be prepared before LLVM inline");
+  return true;
 }
 
 bool jeandle_record_inline_success(int scope_id, int bci, uintptr_t callee_method) {
@@ -253,14 +259,9 @@ bool jeandle_record_inline_success(int scope_id, int bci, uintptr_t callee_metho
   ciMethod* callee = jeandle_callback_method(callee_method);
 
   // LLVM calls this callback only after the inline transformation succeeds.
-  // Keep Jeandle's inline tree in sync at that point so later policy checks
-  // account for the bytecodes that were actually inlined.
-  JeandleInlineTree* callee_tree = comp->build_inline_tree_for_callee(scope_id, bci, callee);
-  // TODO: Allocate the callee inline tree before asking LLVM to inline. Today
-  // this callback is reached after LLVM has already changed IR, so failing to
-  // build the tree here would leave frontend inline metadata out of sync with
-  // backend IR.
-  guarantee(callee_tree != nullptr, "callee inline tree must be recorded after a successful inline");
+  // IsOkToInline has already prepared this tree, so this operation should only
+  // commit metadata in the same successful-inline order as LLVM's InlineScopes.
+  comp->commit_inline_tree_for_callee(scope_id, bci, callee);
   return true;
 }
 

--- a/test/hotspot/jtreg/compiler/jeandle/TestInline.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestInline.java
@@ -150,11 +150,15 @@ public class TestInline {
     private static int countMethod(List<String> tree, String method) {
         int count = 0;
         for (int i = 1; i < tree.size(); i++) {
-            if (containsMethodName(tree.get(i), method)) {
+            if (isSuccessfulInline(tree.get(i)) && containsMethodName(tree.get(i), method)) {
                 count++;
             }
         }
         return count;
+    }
+
+    private static boolean isSuccessfulInline(String line) {
+        return !line.contains("[failed:");
     }
 
     private static boolean containsMethodName(String line, String method) {
@@ -164,7 +168,7 @@ public class TestInline {
             return false;
         }
         int end = idx + marker.length();
-        return end == line.length() || line.charAt(end) == '(';
+        return end == line.length() || line.charAt(end) == '(' || Character.isWhitespace(line.charAt(end));
     }
 
     private static String formatTree(List<String> tree) {


### PR DESCRIPTION
## Related issue(s):

issue #428

## What this PR does / why we need it:

Track Jeandle inline attempts with explicit success and failure reasons.

- Preallocate inline tree nodes before LLVM mutates IR, and commit them only after inline success.
- Handle LLVM RecordInlineResult so failed inline attempts are recorded for diagnostics.
- Print inline trees with reason annotations and mark failed call sites as `X@bci`.
- Update TestInline to distinguish successful inline nodes from failed attempts.

Example inline tree:
```
Jeandle inline tree:
java/lang/invoke/InvokerBytecodeGenerator::addMethod
|- @1 java/lang/invoke/InvokerBytecodeGenerator::methodPrologue  [inline (hot)]
|  `- @4 java/lang/invoke/MethodType::toMethodDescriptorString  [inline (hot)]
|     `- X@17 sun/invoke/util/BytecodeDescriptor::unparseMethod  [failed: too big]
|- @194 java/lang/invoke/InvokerBytecodeGenerator::emitStoreResult  [inline (hot)]
|  `- @23 java/lang/invoke/InvokerBytecodeGenerator::emitStoreInsn  [inline (hot)]
|     `- X@2 java/lang/invoke/InvokerBytecodeGenerator::storeInsnOpcode  [failed: too big]
`- @721 java/lang/invoke/InvokerBytecodeGenerator::methodEpilogue  [inline (hot)]
```