### PR TITLE
fix: add missing bounds checks on derived pointer iterator in oop map parsing

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -646,11 +646,14 @@ JeandleStackMap* JeandleCompiledCode::parse_stackmap(StackMapParser& stackmaps,
     // should_reexecute flag goes first (explicitly set by intrinsic lowering to match C2 behavior).
     // Pushed as i64 on the frontend side so it can't be mistaken for a duplicated-bci marker
     // (see JeandleAbstractInterpreter::deopt_args), so read it with the wide-constant accessor.
+    assert(location != record->location_end(), "must be in range");
     bool forced_reexecute = (StackMapUtil::getConstantUlong(stackmaps, *(location++)) != 0);
     num_deopts--;
 
     // bci goes next in deopt operands
+    assert(location != record->location_end(), "must be in range");
     bci = (location++)->getSmallConstant();
+    assert(location != record->location_end(), "must be in range");
     guarantee(bci == (int)((location++)->getSmallConstant()), "duplicated bci must match");
     num_deopts -= 2;
 


### PR DESCRIPTION
## Description

This PR completes the fix for #480 — *Missing bounds check on derived pointer iterator in oop map parsing*.

### Background

Issue #480 reported that in `JeandleCompiledCode::parse_stackmap`, after `location++`, there is no check against `record->location_end()`. If the stackmap has an odd number of entries, this dereferences the end iterator.

### What was already done

Most of the `location++` operations in `parse_stackmap` (and `parse_stackmap_prologue`) **already had** `assert(location != record->location_end(), "must be in range")` guards added — specifically in:

- `parse_stackmap_prologue` (all 3 increments)
- The deopt value parsing `while` loop (all cases: Local/Stack, Monitor, OrigPcSlot, MethodType, NarrowOopMarker)
- The oop map GC pair loop (with `assert` before the derived pointer dereference)

### What this PR adds

Three `location++` operations in the **deopt header parsing section** of `parse_stackmap` were still missing bounds checks:

1. `forced_reexecute` read (line 649)
2. First `bci` read (line 653)
3. Duplicated `bci` validation (line 654)

This PR adds the same `assert(location != record->location_end(), "must be in range")` guard before each of these three operations, consistent with the existing pattern throughout the rest of the function.

### Changes

Only 3 lines added to `src/hotspot/share/jeandle/jeandleCompiledCode.cpp`:

```diff
+    assert(location != record->location_end(), "must be in range");
     bool forced_reexecute = (StackMapUtil::getConstantUlong(stackmaps, *(location++)) != 0);
     num_deopts--;
 
     // bci goes next in deopt operands
+    assert(location != record->location_end(), "must be in range");
     bci = (location++)->getSmallConstant();
+    assert(location != record->location_end(), "must be in range");
     guarantee(bci == (int)((location++)->getSmallConstant()), "duplicated bci must match");
```

Closes #480