### PR TITLE
fix: use InvokeInst for shared_unlock slow path to enable exception handling

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -3623,8 +3623,9 @@ void JeandleAbstractInterpreter::shared_unlock(LockValue lock) {
   _ir_builder.SetInsertPoint(monitorexit_slow_path);
   llvm::FunctionCallee monitorexit_callee = JeandleRuntimeRoutine::SharedRuntime_complete_monitor_unlocking_C_callee(_module);
   llvm::CallInst* current_thread = call_java_op("jeandle.current_thread", {});
-  llvm::CallInst* call_monitorexit = _ir_builder.CreateCall(monitorexit_callee, {lock.object().value(), lock.lock(), current_thread});
-  call_monitorexit->setCallingConv(llvm::CallingConv::C);
+  // Use create_call_ex (InvokeInst) so that IllegalMonitorStateException from
+  // complete_monitor_unlocking_C can be caught by Java exception handlers.
+  create_call_ex(monitorexit_callee, {lock.object().value(), lock.lock(), current_thread}, llvm::CallingConv::C);
   _ir_builder.CreateBr(monitor_exited);
 
   _ir_builder.SetInsertPoint(monitor_exited);

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -3121,7 +3121,7 @@ void JeandleAbstractInterpreter::dispatch_exception_to_handler(llvm::Value* exce
     if (handler->is_rethrow()) {
       // unlock before the exception is rethrown out of the synchronized method
       if (_method && _method->is_synchronized()) {
-        shared_unlock(_sync_lock, false /* needs_exception_handling */);
+        shared_unlock(_sync_lock);
       }
       throw_exception(exception_oop, landingpad);
       return;
@@ -3601,7 +3601,7 @@ void JeandleAbstractInterpreter::shared_lock(LockValue lock) {
   _block->set_tail_llvm_block(monitor_entered);
 }
 
-void JeandleAbstractInterpreter::shared_unlock(LockValue lock, bool needs_exception_handling) {
+void JeandleAbstractInterpreter::shared_unlock(LockValue lock) {
   assert(!lock.is_null(), "sanity");
 
   int cur_bci = _bytecodes.cur_bci();
@@ -3623,16 +3623,13 @@ void JeandleAbstractInterpreter::shared_unlock(LockValue lock, bool needs_except
   _ir_builder.SetInsertPoint(monitorexit_slow_path);
   llvm::FunctionCallee monitorexit_callee = JeandleRuntimeRoutine::SharedRuntime_complete_monitor_unlocking_C_callee(_module);
   llvm::CallInst* current_thread = call_java_op("jeandle.current_thread", {});
-  if (needs_exception_handling) {
-    // Use InvokeInst so that IllegalMonitorStateException from
-    // complete_monitor_unlocking_C can be caught by Java exception handlers.
-    create_call_ex(monitorexit_callee, {lock.object().value(), lock.lock(), current_thread}, llvm::CallingConv::C);
-  } else {
-    // Use CallInst when exception handling is not needed (e.g., rethrow or
-    // return_current paths) to avoid recursive dispatch_exception_for_invoke.
-    llvm::CallInst* call_monitorexit = _ir_builder.CreateCall(monitorexit_callee, {lock.object().value(), lock.lock(), current_thread});
-    call_monitorexit->setCallingConv(llvm::CallingConv::C);
-  }
+  // complete_monitor_unlocking_C is declared as JRT_LEAF and uses ExceptionMark
+  // internally, so it cannot produce Java-visible exceptional control flow.
+  // Using CallInst (instead of InvokeInst) is safe here and avoids recursive
+  // dispatch_exception_for_invoke when shared_unlock is called from rethrow
+  // or return_current paths.
+  llvm::CallInst* call_monitorexit = _ir_builder.CreateCall(monitorexit_callee, {lock.object().value(), lock.lock(), current_thread});
+  call_monitorexit->setCallingConv(llvm::CallingConv::C);
   _ir_builder.CreateBr(monitor_exited);
 
   _ir_builder.SetInsertPoint(monitor_exited);
@@ -3654,7 +3651,7 @@ void JeandleAbstractInterpreter::monitorexit() {
   LockValue lock = _jvm->pop_lock();
   assert(basic_lock_slot_at(_jvm->locks_size()) == lock.lock(), "unbalanced monitors");
 
-  shared_unlock(lock, true /* needs_exception_handling */);
+  shared_unlock(lock);
 }
 
 void JeandleAbstractInterpreter::null_check(llvm::Value* obj) {
@@ -3766,7 +3763,7 @@ void JeandleAbstractInterpreter::return_current(llvm::Value* value) {
   if (_method && _method->is_synchronized()) {
     LockValue lock = _jvm->pop_lock();
     assert(lock.equals(_sync_lock), "sanity");
-    shared_unlock(lock, false /* needs_exception_handling */);
+    shared_unlock(lock);
   }
 
   if (value == nullptr) {

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -3121,7 +3121,7 @@ void JeandleAbstractInterpreter::dispatch_exception_to_handler(llvm::Value* exce
     if (handler->is_rethrow()) {
       // unlock before the exception is rethrown out of the synchronized method
       if (_method && _method->is_synchronized()) {
-        shared_unlock(_sync_lock);
+        shared_unlock(_sync_lock, false /* needs_exception_handling */);
       }
       throw_exception(exception_oop, landingpad);
       return;
@@ -3601,7 +3601,7 @@ void JeandleAbstractInterpreter::shared_lock(LockValue lock) {
   _block->set_tail_llvm_block(monitor_entered);
 }
 
-void JeandleAbstractInterpreter::shared_unlock(LockValue lock) {
+void JeandleAbstractInterpreter::shared_unlock(LockValue lock, bool needs_exception_handling) {
   assert(!lock.is_null(), "sanity");
 
   int cur_bci = _bytecodes.cur_bci();
@@ -3623,9 +3623,16 @@ void JeandleAbstractInterpreter::shared_unlock(LockValue lock) {
   _ir_builder.SetInsertPoint(monitorexit_slow_path);
   llvm::FunctionCallee monitorexit_callee = JeandleRuntimeRoutine::SharedRuntime_complete_monitor_unlocking_C_callee(_module);
   llvm::CallInst* current_thread = call_java_op("jeandle.current_thread", {});
-  // Use create_call_ex (InvokeInst) so that IllegalMonitorStateException from
-  // complete_monitor_unlocking_C can be caught by Java exception handlers.
-  create_call_ex(monitorexit_callee, {lock.object().value(), lock.lock(), current_thread}, llvm::CallingConv::C);
+  if (needs_exception_handling) {
+    // Use InvokeInst so that IllegalMonitorStateException from
+    // complete_monitor_unlocking_C can be caught by Java exception handlers.
+    create_call_ex(monitorexit_callee, {lock.object().value(), lock.lock(), current_thread}, llvm::CallingConv::C);
+  } else {
+    // Use CallInst when exception handling is not needed (e.g., rethrow or
+    // return_current paths) to avoid recursive dispatch_exception_for_invoke.
+    llvm::CallInst* call_monitorexit = _ir_builder.CreateCall(monitorexit_callee, {lock.object().value(), lock.lock(), current_thread});
+    call_monitorexit->setCallingConv(llvm::CallingConv::C);
+  }
   _ir_builder.CreateBr(monitor_exited);
 
   _ir_builder.SetInsertPoint(monitor_exited);
@@ -3647,7 +3654,7 @@ void JeandleAbstractInterpreter::monitorexit() {
   LockValue lock = _jvm->pop_lock();
   assert(basic_lock_slot_at(_jvm->locks_size()) == lock.lock(), "unbalanced monitors");
 
-  shared_unlock(lock);
+  shared_unlock(lock, true /* needs_exception_handling */);
 }
 
 void JeandleAbstractInterpreter::null_check(llvm::Value* obj) {
@@ -3759,7 +3766,7 @@ void JeandleAbstractInterpreter::return_current(llvm::Value* value) {
   if (_method && _method->is_synchronized()) {
     LockValue lock = _jvm->pop_lock();
     assert(lock.equals(_sync_lock), "sanity");
-    shared_unlock(lock);
+    shared_unlock(lock, false /* needs_exception_handling */);
   }
 
   if (value == nullptr) {

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -481,7 +481,7 @@ class JeandleAbstractInterpreter : public StackObj {
   void do_new();
 
   void shared_lock(LockValue lock);
-  void shared_unlock(LockValue lock, bool needs_exception_handling = false);
+  void shared_unlock(LockValue lock);
   void monitorenter();
   void monitorexit();
 

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -481,7 +481,7 @@ class JeandleAbstractInterpreter : public StackObj {
   void do_new();
 
   void shared_lock(LockValue lock);
-  void shared_unlock(LockValue lock);
+  void shared_unlock(LockValue lock, bool needs_exception_handling = false);
   void monitorenter();
   void monitorexit();
 


### PR DESCRIPTION
### Problem
The slow-path unlock call in `shared_unlock` used `CallInst` instead of `InvokeInst`, so `IllegalMonitorStateException` from `complete_monitor_unlocking_C` could not be caught by Java exception handlers.

### Fix
Replace `_ir_builder.CreateCall` with `create_call_ex()` in the `shared_unlock` slow path. This generates an `InvokeInst` with a proper unwind destination (landing pad), allowing exceptions to be dispatched to Java exception handlers via `dispatch_exception_for_invoke`.

### Details
- `create_call_ex` internally calls `dispatch_exception_for_invoke()` to create both `normal_dest` and `unwind_dest` blocks
- The `unwind_dest` block contains a `LandingPadInst` that reads the pending exception and dispatches it to the correct Java catch handler based on the current BCI's exception handler table
- The `normal_dest` block continues execution flow to `monitor_exited` as before
- Calling convention (`llvm::CallingConv::C`) is set by `create_call_ex` internally
