### PR TITLE
feat: support vectorizedMismatch intrinsic

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleIntrinsicLowering_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleIntrinsicLowering_aarch64.cpp
@@ -52,7 +52,7 @@ bool JeandleIntrinsicLowering::cpu_supports_spin_wait() {
   return VM_Version::spin_wait_desc().inst() == SpinWait::YIELD;
 }
 
-bool JeandleIntrinsicLowering::cpu_supports_string_simd() {
+bool JeandleIntrinsicLowering::supports_vectorized_mismatch_medium_path() {
   // NEON (128-bit Advanced SIMD) is ARMv8-A baseline, always available.
   return true;
 }

--- a/src/hotspot/cpu/aarch64/jeandleIntrinsicLowering_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleIntrinsicLowering_aarch64.cpp
@@ -52,6 +52,11 @@ bool JeandleIntrinsicLowering::cpu_supports_spin_wait() {
   return VM_Version::spin_wait_desc().inst() == SpinWait::YIELD;
 }
 
+bool JeandleIntrinsicLowering::cpu_supports_string_simd() {
+  // NEON (128-bit Advanced SIMD) is ARMv8-A baseline, always available.
+  return true;
+}
+
 // =============================================================================
 // Arch-specific intrinsic lowering (AArch64)
 // =============================================================================

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6463,6 +6463,291 @@ class StubGenerator: public StubCodeGenerator {
     return entry;
   }
 
+  // Arguments:
+  //   c_rarg0 - first array/raw memory address
+  //   c_rarg1 - second array/raw memory address
+  //   c_rarg2 - element length
+  //   c_rarg3 - log2(element size in bytes)
+  //
+  // Result:
+  //   r0 >= 0 - first mismatching element index
+  //   r0 == -1 - all requested elements match
+  address generate_vectorizedMismatch() {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", "vectorizedMismatch");
+    address entry = __ pc();
+
+    const Register obja = c_rarg0;
+    const Register objb = c_rarg1;
+    const Register length = c_rarg2;
+    const Register scale = c_rarg3;
+    const Register result = r0;
+    const Register byte_index = r4;
+    const Register byte_length = r5;
+    const Register tmp1 = r6;
+    const Register tmp2 = r7;
+    const Register tmp3 = r8;
+    const Register tmp4 = r9;
+    const Register a_ptr = r10;
+    const Register b_ptr = r11;
+    const Register a_load_ptr = r12;
+    const Register b_load_ptr = r13;
+
+    Label LOOP256, CHECK64, LOOP64;
+    Label LOOP16, TAIL16, TAIL8, TAIL4, TAIL1, BYTES_LOOP;
+    Label DIFF256, DIFF64, DIFF_LOW, DIFF_HIGH, DIFF4, DIFF_BYTE;
+    Label SAME_TILL_END, DONE;
+
+    __ mov(byte_index, zr);
+    __ mov(a_ptr, obja);
+    __ mov(b_ptr, objb);
+    // length is a Java int, but the byte length can exceed 32 bits for large
+    // int/long arrays. Zero-extend before scaling so the shift cannot wrap.
+    __ movw(byte_length, length);
+    __ lslv(byte_length, byte_length, scale);
+    __ mov(tmp3, 256);
+
+    // Use the four-way unrolled loop while at least 256 bytes remain. Shorter
+    // ranges start with the 64-byte loop or the scalar tail.
+    __ cmp(byte_length, tmp3);
+    __ br(__ GE, LOOP256);
+
+    __ bind(CHECK64);
+    __ cmp(byte_length, (u1)64);
+    __ br(__ LT, TAIL16);
+    __ b(LOOP64);
+
+    // Match C2's vector-tier approach by checking four vector blocks together.
+    // The per-block differences stay live, so a mismatch can still fall back to
+    // the original 64-byte locator without changing the result semantics.
+    __ bind(LOOP256);
+      __ mov(a_load_ptr, a_ptr);
+      __ mov(b_load_ptr, b_ptr);
+
+      // Bytes [0, 64).
+      __ ld1(v0, v1, v2, v3, __ T16B, Address(a_ptr));
+      __ ld1(v4, v5, v6, v7, __ T16B, Address(b_ptr));
+      __ eor(v0, __ T16B, v0, v4);
+      __ eor(v1, __ T16B, v1, v5);
+      __ eor(v2, __ T16B, v2, v6);
+      __ eor(v3, __ T16B, v3, v7);
+      __ orr(v0, __ T16B, v0, v1);
+      __ orr(v2, __ T16B, v2, v3);
+      __ orr(v16, __ T16B, v0, v2);
+
+      // Bytes [64, 128).
+      __ add(a_load_ptr, a_load_ptr, (u1)64);
+      __ add(b_load_ptr, b_load_ptr, (u1)64);
+      __ ld1(v0, v1, v2, v3, __ T16B, Address(a_load_ptr));
+      __ ld1(v4, v5, v6, v7, __ T16B, Address(b_load_ptr));
+      __ eor(v0, __ T16B, v0, v4);
+      __ eor(v1, __ T16B, v1, v5);
+      __ eor(v2, __ T16B, v2, v6);
+      __ eor(v3, __ T16B, v3, v7);
+      __ orr(v0, __ T16B, v0, v1);
+      __ orr(v2, __ T16B, v2, v3);
+      __ orr(v17, __ T16B, v0, v2);
+
+      // Bytes [128, 192).
+      __ add(a_load_ptr, a_load_ptr, (u1)64);
+      __ add(b_load_ptr, b_load_ptr, (u1)64);
+      __ ld1(v0, v1, v2, v3, __ T16B, Address(a_load_ptr));
+      __ ld1(v4, v5, v6, v7, __ T16B, Address(b_load_ptr));
+      __ eor(v0, __ T16B, v0, v4);
+      __ eor(v1, __ T16B, v1, v5);
+      __ eor(v2, __ T16B, v2, v6);
+      __ eor(v3, __ T16B, v3, v7);
+      __ orr(v0, __ T16B, v0, v1);
+      __ orr(v2, __ T16B, v2, v3);
+      __ orr(v18, __ T16B, v0, v2);
+
+      // Bytes [192, 256).
+      __ add(a_load_ptr, a_load_ptr, (u1)64);
+      __ add(b_load_ptr, b_load_ptr, (u1)64);
+      __ ld1(v0, v1, v2, v3, __ T16B, Address(a_load_ptr));
+      __ ld1(v4, v5, v6, v7, __ T16B, Address(b_load_ptr));
+      __ eor(v0, __ T16B, v0, v4);
+      __ eor(v1, __ T16B, v1, v5);
+      __ eor(v2, __ T16B, v2, v6);
+      __ eor(v3, __ T16B, v3, v7);
+      __ orr(v0, __ T16B, v0, v1);
+      __ orr(v2, __ T16B, v2, v3);
+      __ orr(v19, __ T16B, v0, v2);
+
+      // Reduce the four block differences to one branch condition, while
+      // retaining v16-v19 so DIFF256 can identify the first differing block.
+      __ orr(v1, __ T16B, v16, v17);
+      __ orr(v2, __ T16B, v18, v19);
+      __ orr(v1, __ T16B, v1, v2);
+      __ umov(tmp1, v1, __ D, 0);
+      __ umov(tmp2, v1, __ D, 1);
+      __ orr(tmp1, tmp1, tmp2);
+      __ cbnz(tmp1, DIFF256);
+
+      // All 256 bytes matched. Advance every cursor to the next block.
+      __ add(a_ptr, a_ptr, tmp3);
+      __ add(b_ptr, b_ptr, tmp3);
+      __ add(byte_index, byte_index, tmp3);
+      __ sub(byte_length, byte_length, tmp3);
+      __ cmp(byte_length, tmp3);
+      __ br(__ GE, LOOP256);
+      __ b(CHECK64);
+
+    // Compare one 64-byte block with four NEON registers.
+    __ bind(LOOP64);
+      __ ld1(v0, v1, v2, v3, __ T16B, Address(a_ptr));
+      __ ld1(v4, v5, v6, v7, __ T16B, Address(b_ptr));
+      __ eor(v0, __ T16B, v0, v4);
+      __ eor(v1, __ T16B, v1, v5);
+      __ eor(v2, __ T16B, v2, v6);
+      __ eor(v3, __ T16B, v3, v7);
+      __ orr(v0, __ T16B, v0, v1);
+      __ orr(v2, __ T16B, v2, v3);
+      __ orr(v0, __ T16B, v0, v2);
+      __ umov(tmp1, v0, __ D, 0);
+      __ umov(tmp2, v0, __ D, 1);
+      __ orr(tmp1, tmp1, tmp2);
+      __ cbnz(tmp1, DIFF64);
+      __ add(a_ptr, a_ptr, (u1)64);
+      __ add(b_ptr, b_ptr, (u1)64);
+      __ add(byte_index, byte_index, (u1)64);
+      __ sub(byte_length, byte_length, (u1)64);
+      __ cmp(byte_length, (u1)64);
+      __ br(__ GE, LOOP64);
+      __ b(TAIL16);
+
+    // Locate the first differing 64-byte sub-block in the unrolled chunk.
+    // DIFF64 then refines that block to the exact byte.
+    __ bind(DIFF256);
+      __ umov(tmp1, v16, __ D, 0);
+      __ umov(tmp2, v16, __ D, 1);
+      __ orr(tmp1, tmp1, tmp2);
+      __ cbnz(tmp1, DIFF64);
+      __ add(a_ptr, a_ptr, (u1)64);
+      __ add(b_ptr, b_ptr, (u1)64);
+      __ add(byte_index, byte_index, (u1)64);
+
+      __ umov(tmp1, v17, __ D, 0);
+      __ umov(tmp2, v17, __ D, 1);
+      __ orr(tmp1, tmp1, tmp2);
+      __ cbnz(tmp1, DIFF64);
+      __ add(a_ptr, a_ptr, (u1)64);
+      __ add(b_ptr, b_ptr, (u1)64);
+      __ add(byte_index, byte_index, (u1)64);
+
+      __ umov(tmp1, v18, __ D, 0);
+      __ umov(tmp2, v18, __ D, 1);
+      __ orr(tmp1, tmp1, tmp2);
+      __ cbnz(tmp1, DIFF64);
+      // The aggregate check guarantees the remaining fourth block differs.
+      __ add(a_ptr, a_ptr, (u1)64);
+      __ add(b_ptr, b_ptr, (u1)64);
+      __ add(byte_index, byte_index, (u1)64);
+      __ b(DIFF64);
+
+    // Scalar tail: consume complete 16-byte chunks with paired 64-bit loads.
+    __ bind(TAIL16);
+      __ cmp(byte_length, (u1)16);
+      __ br(__ LT, TAIL8);
+
+    __ bind(LOOP16);
+      __ ldp(tmp1, tmp2, Address(a_ptr));
+      __ ldp(tmp3, tmp4, Address(b_ptr));
+      __ eor(tmp1, tmp1, tmp3);
+      __ eor(tmp2, tmp2, tmp4);
+      __ cbnz(tmp1, DIFF_LOW);
+      __ cbnz(tmp2, DIFF_HIGH);
+      __ add(a_ptr, a_ptr, (u1)16);
+      __ add(b_ptr, b_ptr, (u1)16);
+      __ add(byte_index, byte_index, (u1)16);
+      __ sub(byte_length, byte_length, (u1)16);
+      __ cmp(byte_length, (u1)16);
+      __ br(__ GE, LOOP16);
+
+    // Consume an optional 8-byte chunk.
+    __ bind(TAIL8);
+      __ cmp(byte_length, (u1)8);
+      __ br(__ LT, TAIL4);
+      __ ldr(tmp1, Address(a_ptr));
+      __ ldr(tmp2, Address(b_ptr));
+      __ eor(tmp1, tmp1, tmp2);
+      __ cbnz(tmp1, DIFF_LOW);
+      __ add(a_ptr, a_ptr, (u1)8);
+      __ add(b_ptr, b_ptr, (u1)8);
+      __ add(byte_index, byte_index, (u1)8);
+      __ sub(byte_length, byte_length, (u1)8);
+
+    // Consume an optional 4-byte chunk.
+    __ bind(TAIL4);
+      __ cmp(byte_length, (u1)4);
+      __ br(__ LT, TAIL1);
+      __ ldrw(tmp1, Address(a_ptr));
+      __ ldrw(tmp2, Address(b_ptr));
+      __ eorw(tmp1, tmp1, tmp2);
+      __ cbnzw(tmp1, DIFF4);
+      __ add(a_ptr, a_ptr, (u1)4);
+      __ add(b_ptr, b_ptr, (u1)4);
+      __ add(byte_index, byte_index, (u1)4);
+      __ sub(byte_length, byte_length, (u1)4);
+
+    // Compare the remaining one to three bytes individually.
+    __ bind(TAIL1);
+      __ cbz(byte_length, SAME_TILL_END);
+
+    __ bind(BYTES_LOOP);
+      __ ldrb(tmp1, Address(a_ptr));
+      __ ldrb(tmp2, Address(b_ptr));
+      __ eorw(tmp1, tmp1, tmp2);
+      __ cbnzw(tmp1, DIFF_BYTE);
+      __ add(a_ptr, a_ptr, (u1)1);
+      __ add(b_ptr, b_ptr, (u1)1);
+      __ add(byte_index, byte_index, (u1)1);
+      __ subs(byte_length, byte_length, (u1)1);
+      __ br(__ NE, BYTES_LOOP);
+
+    // Every requested byte matched.
+    __ bind(SAME_TILL_END);
+      __ mov(result, -1);
+      __ ret(lr);
+
+    // A 64-byte vector block differed. Reuse the 16-byte locator to find the
+    // exact differing word and byte.
+    __ bind(DIFF64);
+      __ mov(byte_length, (u1)64);
+      __ b(LOOP16);
+
+    // The high 64-bit word of a 16-byte pair differed.
+    __ bind(DIFF_HIGH);
+      __ add(byte_index, byte_index, (u1)8);
+      __ mov(tmp1, tmp2);
+
+    // rbit + clz counts from the least-significant differing bit, which is the
+    // first differing byte at the current little-endian memory address.
+    __ bind(DIFF_LOW);
+      __ rbit(tmp1, tmp1);
+      __ clz(tmp1, tmp1);
+      __ add(result, byte_index, tmp1, __ LSR, LogBitsPerByte);
+      __ b(DONE);
+
+    // Apply the same bit-to-byte conversion to a differing 32-bit word.
+    __ bind(DIFF4);
+      __ rbit(tmp1, tmp1);
+      __ clz(tmp1, tmp1);
+      __ add(result, byte_index, tmp1, __ LSR, LogBitsPerByte);
+      __ b(DONE);
+
+    __ bind(DIFF_BYTE);
+      __ mov(result, byte_index);
+
+    // The search tracks byte offsets. Convert the result back to the element
+    // index required by ArraysSupport.vectorizedMismatch.
+    __ bind(DONE);
+      __ lsrv(result, result, scale);
+      __ ret(lr);
+
+    return entry;
+  }
+
   /**
    *  Arguments:
    *
@@ -8680,6 +8965,10 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     StubRoutines::aarch64::_spin_wait = generate_spin_wait();
+
+    if (UseVectorizedMismatchIntrinsic) {
+      StubRoutines::_vectorizedMismatch = generate_vectorizedMismatch();
+    }
 
     if (UsePoly1305Intrinsics) {
       StubRoutines::_poly1305_processBlocks = generate_poly1305_processBlocks();

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -270,7 +270,10 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseAdler32Intrinsics, true);
   }
 
-  if (UseVectorizedMismatchIntrinsic) {
+  if (UseJeandleCompiler && FLAG_IS_DEFAULT(UseVectorizedMismatchIntrinsic)) {
+    FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, true);
+  }
+  if (UseVectorizedMismatchIntrinsic && !UseJeandleCompiler) {
     warning("UseVectorizedMismatchIntrinsic specified, but not available on this CPU.");
     FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
   }

--- a/src/hotspot/cpu/riscv/jeandleIntrinsicLowering_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jeandleIntrinsicLowering_riscv.cpp
@@ -53,7 +53,7 @@ bool JeandleIntrinsicLowering::cpu_supports_spin_wait() {
   return UseZihintpause;
 }
 
-bool JeandleIntrinsicLowering::cpu_supports_string_simd() {
+bool JeandleIntrinsicLowering::supports_vectorized_mismatch_medium_path() {
   // The RVV vector extension is optional and not yet wired up here.
   return false;
 }

--- a/src/hotspot/cpu/riscv/jeandleIntrinsicLowering_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jeandleIntrinsicLowering_riscv.cpp
@@ -53,6 +53,11 @@ bool JeandleIntrinsicLowering::cpu_supports_spin_wait() {
   return UseZihintpause;
 }
 
+bool JeandleIntrinsicLowering::cpu_supports_string_simd() {
+  // The RVV vector extension is optional and not yet wired up here.
+  return false;
+}
+
 // =============================================================================
 // Arch-specific intrinsic lowering (RISC-V)
 // =============================================================================

--- a/src/hotspot/cpu/x86/jeandleIntrinsicLowering_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleIntrinsicLowering_x86.cpp
@@ -52,6 +52,10 @@ bool JeandleIntrinsicLowering::cpu_supports_spin_wait() {
   return true;
 }
 
+bool JeandleIntrinsicLowering::cpu_supports_string_simd() {
+  return false;
+}
+
 // =============================================================================
 // Arch-specific intrinsic lowering (x86)
 // =============================================================================

--- a/src/hotspot/cpu/x86/jeandleIntrinsicLowering_x86.cpp
+++ b/src/hotspot/cpu/x86/jeandleIntrinsicLowering_x86.cpp
@@ -52,7 +52,7 @@ bool JeandleIntrinsicLowering::cpu_supports_spin_wait() {
   return true;
 }
 
-bool JeandleIntrinsicLowering::cpu_supports_string_simd() {
+bool JeandleIntrinsicLowering::supports_vectorized_mismatch_medium_path() {
   return false;
 }
 

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -223,7 +223,9 @@ bool Compiler::is_intrinsic_supported(const methodHandle& method) {
   case vmIntrinsics::_updateBytesCRC32C:
   case vmIntrinsics::_updateDirectByteBufferCRC32C:
 #endif
+#if !defined(AARCH64)
   case vmIntrinsics::_vectorizedMismatch:
+#endif
   case vmIntrinsics::_compareAndSetInt:
   case vmIntrinsics::_compareAndSetReference:
   case vmIntrinsics::_getCharStringU:

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -22,6 +22,7 @@
 #include "jeandle/__llvmHeadersBegin__.hpp"
 #include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/MDBuilder.h"
 
 #include "jeandle/jeandleAbstractInterpreter.hpp"
@@ -39,6 +40,7 @@
 #include "oops/klass.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/globals.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // =============================================================================
 // Call-site IR annotation helpers (migrated from JeandleIntrinsicIRSemantics)
@@ -93,6 +95,9 @@ bool JeandleIntrinsicLowering::is_supported(vmIntrinsics::ID id) {
 
     case vmIntrinsics::_onSpinWait:
       return cpu_supports_spin_wait();
+
+    case vmIntrinsics::_vectorizedMismatch:
+      return UseVectorizedMismatchIntrinsic;
 
     default: break;
   }
@@ -370,6 +375,9 @@ bool JeandleIntrinsicLowering::lower(vmIntrinsics::ID id, const ciMethod* target
     case vmIntrinsics::_PhantomReference_refersTo0:
       return lower_java_op("jeandle.reference_refers_to",
                            {CTRL_NONE, MEM_READ | MEM_NEEDS_GC_STATE});
+
+    case vmIntrinsics::_vectorizedMismatch:
+      return lower_vectorized_mismatch();
 
     // newArray
     case vmIntrinsics::_newArray:
@@ -861,6 +869,261 @@ bool JeandleIntrinsicLowering::lower_new_array() {
 
   _interp->_jvm->apush(result);
   return true;
+}
+
+// ---- lower_vectorized_mismatch ----
+//
+// Use LLVM IR for byte ranges too small to benefit from the platform stub. The
+// larger ranges retain the platform StubRoutines implementation, including its
+// vector tiers where available.
+bool JeandleIntrinsicLowering::lower_vectorized_mismatch() {
+  if (!UseVectorizedMismatchIntrinsic ||
+      JeandleRuntimeRoutine::find_routine_entry("StubRoutines_vectorizedMismatch") == nullptr) {
+    return false;
+  }
+
+  llvm::IRBuilder<>& b = _interp->_ir_builder;
+  llvm::Type* i8 = b.getInt8Ty();
+
+  // Operand stack, top to bottom:
+  //   scale, length, bOffset, b, aOffset, a
+  // All support checks above must complete before these values are consumed.
+  llvm::Value* scale = _interp->_jvm->ipop();
+  llvm::Value* length = _interp->_jvm->ipop();
+  llvm::Value* b_offset = _interp->_jvm->lpop();
+  llvm::Value* b_obj = _interp->_jvm->apop();
+  llvm::Value* a_offset = _interp->_jvm->lpop();
+  llvm::Value* a_obj = _interp->_jvm->apop();
+
+  llvm::Value* a_addr = b.CreateGEP(i8, a_obj, a_offset, "mismatch_a_addr");
+  llvm::Value* b_addr = b.CreateGEP(i8, b_obj, b_offset, "mismatch_b_addr");
+
+  llvm::LLVMContext& ctx = *_interp->_context;
+  llvm::Type* i32 = b.getInt32Ty();
+  llvm::Type* i64 = b.getInt64Ty();
+  llvm::Function* f = _interp->_llvm_func;
+
+  static constexpr unsigned small_path_limit = 16;
+  static constexpr unsigned medium_path_limit = 64;
+
+  // Compute in i64 so a large i32 length shifted by scale cannot wrap into an
+  // inline tier. The VM guarantees scale is a valid element-size logarithm.
+  llvm::Value* scale64 = b.CreateZExt(scale, i64, "mismatch_scale64");
+  llvm::Value* byte_length = b.CreateShl(b.CreateZExt(length, i64), scale64,
+                                         "mismatch_byte_length");
+  llvm::Value* is_small = b.CreateICmpULT(
+      byte_length, llvm::ConstantInt::get(i64, small_path_limit),
+      "mismatch_inline_small");
+  llvm::Value* is_medium = b.CreateICmpULT(
+      byte_length, llvm::ConstantInt::get(i64, medium_path_limit),
+      "mismatch_inline_medium");
+
+  llvm::BasicBlock* small_bb = llvm::BasicBlock::Create(ctx, "mismatch_inline_small", f);
+  llvm::BasicBlock* dispatch_bb = llvm::BasicBlock::Create(ctx, "mismatch_dispatch_medium", f);
+  llvm::BasicBlock* medium_bb = llvm::BasicBlock::Create(ctx, "mismatch_inline_medium", f);
+  llvm::BasicBlock* stub_bb = llvm::BasicBlock::Create(ctx, "mismatch_stub", f);
+  llvm::BasicBlock* done_bb = llvm::BasicBlock::Create(ctx, "mismatch_done", f);
+  b.CreateCondBr(is_small, small_bb, dispatch_bb);
+
+  // Tier 1: inline scalar IR for ranges shorter than 16 bytes.
+  b.SetInsertPoint(small_bb);
+  llvm::Value* small_result = emit_vectorized_mismatch_small(a_addr, b_addr, byte_length, scale64);
+  llvm::BasicBlock* small_done_bb = b.GetInsertBlock();
+  b.CreateBr(done_bb);
+
+  // Tier 2 is available only when the target can lower the fixed-width vector
+  // IR efficiently. Unsupported targets skip directly to the platform stub.
+  b.SetInsertPoint(dispatch_bb);
+  if (cpu_supports_string_simd()) {
+    b.CreateCondBr(is_medium, medium_bb, stub_bb);
+  } else {
+    b.CreateBr(stub_bb);
+  }
+
+  // Tier 2: inline 128-bit vector IR for byte lengths in [16, 64).
+  b.SetInsertPoint(medium_bb);
+  llvm::Value* medium_result = emit_vectorized_mismatch_medium(a_addr, b_addr, byte_length, scale64);
+  llvm::BasicBlock* medium_done_bb = b.GetInsertBlock();
+  b.CreateBr(done_bb);
+
+  // Tier 3: use the platform stub for large ranges, or as the fallback when
+  // fixed-width vector IR is not enabled on the target.
+  b.SetInsertPoint(stub_bb);
+  static constexpr CallSiteAttributeMetadata attrs = {CTRL_NONE, MEM_READ};
+  llvm::CallBase* call = emit_callsite(
+      JeandleRuntimeRoutine::StubRoutines_vectorizedMismatch_callee(_interp->_module),
+      llvm::CallingConv::C, {a_addr, b_addr, length, scale}, attrs,
+      /*is_gc_leaf_entry=*/true);
+  llvm::BasicBlock* stub_done_bb = b.GetInsertBlock();
+  b.CreateBr(done_bb);
+
+  // All three tiers produce the same element-index result.
+  b.SetInsertPoint(done_bb);
+  llvm::PHINode* result = b.CreatePHI(i32, 3, "mismatch_result");
+  result->addIncoming(small_result, small_done_bb);
+  result->addIncoming(medium_result, medium_done_bb);
+  result->addIncoming(call, stub_done_bb);
+  _interp->_block->set_tail_llvm_block(done_bb);
+  _interp->_jvm->ipush(result);
+  return true;
+}
+
+llvm::Value* JeandleIntrinsicLowering::emit_vectorized_mismatch_small(
+    llvm::Value* a_addr, llvm::Value* b_addr, llvm::Value* byte_length, llvm::Value* scale) {
+  llvm::LLVMContext& ctx = *_interp->_context;
+  llvm::IRBuilder<>& b = _interp->_ir_builder;
+  llvm::Type* i32 = b.getInt32Ty();
+  llvm::Type* i64 = b.getInt64Ty();
+  llvm::Function* f = _interp->_llvm_func;
+
+  llvm::BasicBlock* first_check = llvm::BasicBlock::Create(ctx, "mismatch_inline_small_check", f);
+  llvm::BasicBlock* done = llvm::BasicBlock::Create(ctx, "mismatch_inline_small_done", f);
+  llvm::PHINode* result = llvm::PHINode::Create(i32, 5, "mismatch_inline_small_result", done);
+  b.CreateBr(first_check);
+
+  // Compare the largest exact chunk first. All loads use Align(1), since
+  // vectorizedMismatch also accepts direct, non-aligned Unsafe addresses.
+  static constexpr unsigned widths[] = {8, 4, 2, 1};
+  static constexpr const char* suffixes[] = {"i64", "i32", "i16", "i8"};
+  llvm::BasicBlock* check = first_check;
+  llvm::Value* pos = llvm::ConstantInt::get(i64, 0);
+  for (unsigned index = 0; index < sizeof(widths) / sizeof(widths[0]); index++) {
+    const unsigned width = widths[index];
+    const char* suffix = suffixes[index];
+    llvm::Type* chunk_ty = llvm::IntegerType::get(ctx, width * BitsPerByte);
+    llvm::BasicBlock* load = llvm::BasicBlock::Create(ctx, "mismatch_inline_small_load", f);
+    llvm::BasicBlock* hit = llvm::BasicBlock::Create(ctx, "mismatch_inline_small_hit", f);
+    llvm::BasicBlock* equal = llvm::BasicBlock::Create(ctx, "mismatch_inline_small_equal", f);
+    llvm::BasicBlock* next_check = llvm::BasicBlock::Create(ctx, "mismatch_inline_small_check", f);
+
+    // Use this width only when the unprocessed suffix is large enough.
+    b.SetInsertPoint(check);
+    llvm::Value* remaining = b.CreateSub(byte_length, pos, "mismatch_inline_small_remaining");
+    b.CreateCondBr(b.CreateICmpUGE(remaining, llvm::ConstantInt::get(i64, width)), load, next_check);
+
+    // Loads are explicitly unaligned because either base may be a raw Unsafe
+    // address rather than an aligned Java array base.
+    b.SetInsertPoint(load);
+    llvm::Value* a_ptr = b.CreateGEP(b.getInt8Ty(), a_addr, pos, "mismatch_inline_small_a_addr");
+    llvm::Value* b_ptr = b.CreateGEP(b.getInt8Ty(), b_addr, pos, "mismatch_inline_small_b_addr");
+    llvm::Value* a_chunk = b.CreateAlignedLoad(
+        chunk_ty, a_ptr, llvm::Align(1), llvm::Twine("mismatch_inline_small_a_") + suffix);
+    llvm::Value* b_chunk = b.CreateAlignedLoad(
+        chunk_ty, b_ptr, llvm::Align(1), llvm::Twine("mismatch_inline_small_b_") + suffix);
+    llvm::Value* diff = b.CreateXor(a_chunk, b_chunk, "mismatch_inline_small_diff");
+    b.CreateCondBr(b.CreateICmpNE(diff, llvm::ConstantInt::get(chunk_ty, 0)), hit, equal);
+
+    // cttz identifies the first differing bit in the loaded little-endian
+    // chunk. Convert it first to a byte index, then to an element index.
+    b.SetInsertPoint(hit);
+    llvm::Value* first_bit = b.CreateIntrinsic(llvm::Intrinsic::cttz, {chunk_ty},
+        {diff, b.getInt1(true)}, nullptr, "mismatch_inline_small_cttz");
+    llvm::Value* byte_in_chunk = b.CreateLShr(first_bit,
+        llvm::ConstantInt::get(chunk_ty, LogBitsPerByte), "mismatch_inline_small_byte_in_chunk");
+    llvm::Value* byte_index = b.CreateAdd(pos, b.CreateZExtOrTrunc(byte_in_chunk, i64),
+                                           "mismatch_inline_small_byte_index");
+    llvm::Value* element_index = b.CreateTrunc(
+        b.CreateLShr(byte_index, scale), i32, "mismatch_inline_small_element_index");
+    result->addIncoming(element_index, hit);
+    b.CreateBr(done);
+
+    // This chunk matched. Advance by its width and try the next smaller width.
+    b.SetInsertPoint(equal);
+    llvm::Value* next_pos = b.CreateAdd(pos, llvm::ConstantInt::get(i64, width),
+                                        "mismatch_inline_small_next_pos");
+    b.CreateBr(next_check);
+
+    b.SetInsertPoint(next_check);
+    llvm::PHINode* merged_pos = b.CreatePHI(i64, 2, "mismatch_inline_small_pos");
+    merged_pos->addIncoming(pos, check);
+    merged_pos->addIncoming(next_pos, equal);
+    pos = merged_pos;
+    check = next_check;
+  }
+
+  // No width found a difference, so the complete range matched.
+  b.SetInsertPoint(check);
+  result->addIncoming(llvm::ConstantInt::getSigned(i32, -1), check);
+  b.CreateBr(done);
+
+  b.SetInsertPoint(done);
+  return result;
+}
+
+llvm::Value* JeandleIntrinsicLowering::emit_vectorized_mismatch_medium(
+    llvm::Value* a_addr, llvm::Value* b_addr, llvm::Value* byte_length, llvm::Value* scale) {
+  llvm::LLVMContext& ctx = *_interp->_context;
+  llvm::IRBuilder<>& b = _interp->_ir_builder;
+  llvm::Type* i8 = b.getInt8Ty();
+  llvm::Type* i16 = b.getInt16Ty();
+  llvm::Type* i32 = b.getInt32Ty();
+  llvm::Type* i64 = b.getInt64Ty();
+  static constexpr unsigned vector_bytes = 16;
+  llvm::Type* vec_ty = llvm::FixedVectorType::get(i8, vector_bytes);
+  llvm::Function* f = _interp->_llvm_func;
+
+  llvm::BasicBlock* pred = b.GetInsertBlock();
+  llvm::BasicBlock* head = llvm::BasicBlock::Create(ctx, "mismatch_inline_vector_head", f);
+  llvm::BasicBlock* hit = llvm::BasicBlock::Create(ctx, "mismatch_inline_vector_hit", f);
+  llvm::BasicBlock* matched = llvm::BasicBlock::Create(ctx, "mismatch_inline_vector_matched", f);
+  llvm::BasicBlock* advance = llvm::BasicBlock::Create(ctx, "mismatch_inline_vector_advance", f);
+  llvm::BasicBlock* done = llvm::BasicBlock::Create(ctx, "mismatch_inline_vector_done", f);
+
+  // The final vector load starts at byte_length - 16. When the range is not a
+  // multiple of 16, this overlaps the preceding load and covers the tail
+  // without an out-of-bounds access or a scalar cleanup loop.
+  llvm::Value* last_start = b.CreateSub(
+      byte_length, llvm::ConstantInt::get(i64, vector_bytes),
+      "mismatch_inline_vector_last_start");
+  b.CreateBr(head);
+
+  // Compare one 16-byte window and reduce the per-byte comparison to a mask.
+  b.SetInsertPoint(head);
+  llvm::PHINode* pos = b.CreatePHI(i64, 2, "mismatch_inline_vector_pos");
+  pos->addIncoming(llvm::ConstantInt::get(i64, 0), pred);
+  llvm::Value* a_ptr = b.CreateGEP(i8, a_addr, pos, "mismatch_inline_vector_a_addr");
+  llvm::Value* b_ptr = b.CreateGEP(i8, b_addr, pos, "mismatch_inline_vector_b_addr");
+  llvm::Value* va = b.CreateAlignedLoad(vec_ty, a_ptr, llvm::Align(1),
+                                        "mismatch_inline_vector_a");
+  llvm::Value* vb = b.CreateAlignedLoad(vec_ty, b_ptr, llvm::Align(1),
+                                        "mismatch_inline_vector_b");
+  llvm::Value* byte_diff = b.CreateICmpNE(va, vb, "mismatch_inline_vector_diff");
+  llvm::Value* mask = b.CreateBitCast(byte_diff, i16, "mismatch_inline_vector_mask");
+  b.CreateCondBr(b.CreateICmpNE(mask, llvm::ConstantInt::get(i16, 0)), hit, matched);
+
+  // Each bit in the mask represents one byte. cttz therefore gives the first
+  // differing byte directly.
+  b.SetInsertPoint(hit);
+  llvm::Value* first_byte = b.CreateIntrinsic(llvm::Intrinsic::cttz, {i16},
+      {mask, b.getInt1(true)}, nullptr, "mismatch_inline_vector_cttz");
+  llvm::Value* byte_index = b.CreateAdd(pos, b.CreateZExt(first_byte, i64),
+                                        "mismatch_inline_vector_byte_index");
+  llvm::Value* element_index = b.CreateTrunc(b.CreateLShr(byte_index, scale), i32,
+                                              "mismatch_inline_vector_element_index");
+  b.CreateBr(done);
+
+  // Reaching last_start means the entire byte range has been compared.
+  b.SetInsertPoint(matched);
+  b.CreateCondBr(b.CreateICmpEQ(pos, last_start), done, advance);
+
+  // Advance normally when another full vector fits. Otherwise compare the
+  // overlapping final window at last_start.
+  b.SetInsertPoint(advance);
+  llvm::Value* sequential = b.CreateAdd(
+      pos, llvm::ConstantInt::get(i64, vector_bytes),
+      "mismatch_inline_vector_sequential");
+  llvm::Value* sequential_end = b.CreateAdd(
+      sequential, llvm::ConstantInt::get(i64, vector_bytes));
+  llvm::Value* next_pos = b.CreateSelect(b.CreateICmpULE(sequential_end, byte_length), sequential,
+                                         last_start, "mismatch_inline_vector_next");
+  pos->addIncoming(next_pos, advance);
+  b.CreateBr(head);
+
+  b.SetInsertPoint(done);
+  llvm::PHINode* result = b.CreatePHI(i32, 2, "mismatch_inline_vector_result");
+  result->addIncoming(element_index, hit);
+  result->addIncoming(llvm::ConstantInt::getSigned(i32, -1), matched);
+  return result;
 }
 
 // ---- lower_add_exact ----

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -904,7 +904,6 @@ bool JeandleIntrinsicLowering::lower_vectorized_mismatch() {
   llvm::Function* f = _interp->_llvm_func;
 
   static constexpr unsigned small_path_limit = 16;
-  static constexpr unsigned medium_path_limit = 64;
 
   // Compute in i64 so a large i32 length shifted by scale cannot wrap into an
   // inline tier. The VM guarantees scale is a valid element-size logarithm.
@@ -914,13 +913,15 @@ bool JeandleIntrinsicLowering::lower_vectorized_mismatch() {
   llvm::Value* is_small = b.CreateICmpULT(
       byte_length, llvm::ConstantInt::get(i64, small_path_limit),
       "mismatch_inline_small");
-  llvm::Value* is_medium = b.CreateICmpULT(
-      byte_length, llvm::ConstantInt::get(i64, medium_path_limit),
-      "mismatch_inline_medium");
 
+  const uint64_t medium_path_limit =
+      static_cast<uint64_t>(ArrayOperationPartialInlineSize);
+  const bool use_medium_path = supports_vectorized_mismatch_medium_path() &&
+                               medium_path_limit >= small_path_limit;
   llvm::BasicBlock* small_bb = llvm::BasicBlock::Create(ctx, "mismatch_inline_small", f);
   llvm::BasicBlock* dispatch_bb = llvm::BasicBlock::Create(ctx, "mismatch_dispatch_medium", f);
-  llvm::BasicBlock* medium_bb = llvm::BasicBlock::Create(ctx, "mismatch_inline_medium", f);
+  llvm::BasicBlock* medium_bb = use_medium_path
+      ? llvm::BasicBlock::Create(ctx, "mismatch_inline_medium", f) : nullptr;
   llvm::BasicBlock* stub_bb = llvm::BasicBlock::Create(ctx, "mismatch_stub", f);
   llvm::BasicBlock* done_bb = llvm::BasicBlock::Create(ctx, "mismatch_done", f);
   b.CreateCondBr(is_small, small_bb, dispatch_bb);
@@ -931,20 +932,26 @@ bool JeandleIntrinsicLowering::lower_vectorized_mismatch() {
   llvm::BasicBlock* small_done_bb = b.GetInsertBlock();
   b.CreateBr(done_bb);
 
+  llvm::Value* medium_result = nullptr;
+  llvm::BasicBlock* medium_done_bb = nullptr;
+
   // Tier 2 is available only when the target can lower the fixed-width vector
   // IR efficiently. Unsupported targets skip directly to the platform stub.
   b.SetInsertPoint(dispatch_bb);
-  if (cpu_supports_string_simd()) {
+  if (use_medium_path) {
+    llvm::Value* is_medium = b.CreateICmpULE(
+        byte_length, llvm::ConstantInt::get(i64, medium_path_limit),
+        "mismatch_inline_medium");
     b.CreateCondBr(is_medium, medium_bb, stub_bb);
+
+    // Tier 2: inline 128-bit vector IR up to ArrayOperationPartialInlineSize.
+    b.SetInsertPoint(medium_bb);
+    medium_result = emit_vectorized_mismatch_medium(a_addr, b_addr, byte_length, scale64);
+    medium_done_bb = b.GetInsertBlock();
+    b.CreateBr(done_bb);
   } else {
     b.CreateBr(stub_bb);
   }
-
-  // Tier 2: inline 128-bit vector IR for byte lengths in [16, 64).
-  b.SetInsertPoint(medium_bb);
-  llvm::Value* medium_result = emit_vectorized_mismatch_medium(a_addr, b_addr, byte_length, scale64);
-  llvm::BasicBlock* medium_done_bb = b.GetInsertBlock();
-  b.CreateBr(done_bb);
 
   // Tier 3: use the platform stub for large ranges, or as the fallback when
   // fixed-width vector IR is not enabled on the target.
@@ -957,11 +964,13 @@ bool JeandleIntrinsicLowering::lower_vectorized_mismatch() {
   llvm::BasicBlock* stub_done_bb = b.GetInsertBlock();
   b.CreateBr(done_bb);
 
-  // All three tiers produce the same element-index result.
+  // All enabled tiers produce the same element-index result.
   b.SetInsertPoint(done_bb);
-  llvm::PHINode* result = b.CreatePHI(i32, 3, "mismatch_result");
+  llvm::PHINode* result = b.CreatePHI(i32, use_medium_path ? 3 : 2, "mismatch_result");
   result->addIncoming(small_result, small_done_bb);
-  result->addIncoming(medium_result, medium_done_bb);
+  if (use_medium_path) {
+    result->addIncoming(medium_result, medium_done_bb);
+  }
   result->addIncoming(call, stub_done_bb);
   _interp->_block->set_tail_llvm_block(done_bb);
   _interp->_jvm->ipush(result);

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
@@ -133,6 +133,7 @@ class JeandleIntrinsicLowering : public StackObj {
   static bool cpu_supports_rounding();          // floor/ceil/rint
   static bool cpu_supports_popcount();          // bitCount_i/bitCount_l
   static bool cpu_supports_spin_wait();         // onSpinWait
+  static bool cpu_supports_string_simd();       // >=128-bit integer SIMD
 
   // ========================================================================
   // Shared emit helpers
@@ -181,6 +182,15 @@ class JeandleIntrinsicLowering : public StackObj {
   bool lower_compare_unsigned(vmIntrinsics::ID id);
   bool lower_add_exact(vmIntrinsics::ID id);
   bool lower_new_array();
+  bool lower_vectorized_mismatch();
+  llvm::Value* emit_vectorized_mismatch_small(llvm::Value* a_addr,
+                                              llvm::Value* b_addr,
+                                              llvm::Value* byte_length,
+                                              llvm::Value* scale);
+  llvm::Value* emit_vectorized_mismatch_medium(llvm::Value* a_addr,
+                                               llvm::Value* b_addr,
+                                               llvm::Value* byte_length,
+                                               llvm::Value* scale);
 
   };
 

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
@@ -133,7 +133,7 @@ class JeandleIntrinsicLowering : public StackObj {
   static bool cpu_supports_rounding();          // floor/ceil/rint
   static bool cpu_supports_popcount();          // bitCount_i/bitCount_l
   static bool cpu_supports_spin_wait();         // onSpinWait
-  static bool cpu_supports_string_simd();       // >=128-bit integer SIMD
+  static bool supports_vectorized_mismatch_medium_path();
 
   // ========================================================================
   // Shared emit helpers

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -278,6 +278,16 @@
       llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace),    \
       llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))    \
                                                                                     \
+  def(StubRoutines_vectorizedMismatch,                                              \
+      StubRoutines::vectorizedMismatch(),                                           \
+      true,                                                                         \
+      true,                                                                         \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::Type::getInt32Ty(context),                                              \
+      llvm::Type::getInt32Ty(context))                                              \
+                                                                                    \
   def(SharedRuntime_OSR_migration_end,                                              \
       SharedRuntime::OSR_migration_end,                                             \
       false,                                                                        \

--- a/test/hotspot/jtreg/compiler/intrinsics/VectorizedMismatchTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/VectorizedMismatchTest.java
@@ -25,6 +25,7 @@ package compiler.intrinsics;
 
 /*
  * @test
+ * @requires vm.opt.final.UseJeandleCompiler == false
  * @requires vm.opt.final.UseVectorizedMismatchIntrinsic == true
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.util

--- a/test/hotspot/jtreg/compiler/intrinsics/VectorizedMismatchTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/VectorizedMismatchTest.java
@@ -25,17 +25,18 @@ package compiler.intrinsics;
 
 /*
  * @test
- * @requires vm.opt.final.UseJeandleCompiler == false
  * @requires vm.opt.final.UseVectorizedMismatchIntrinsic == true
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.util
  *
- *  @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test*
+ *  @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                    -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test*
  *                    -Xbatch -XX:-TieredCompilation
  *                    -XX:UseAVX=3
  *                     compiler.intrinsics.VectorizedMismatchTest
  *
- *  @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test*
+ *  @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                    -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test*
  *                    -Xbatch -XX:-TieredCompilation
  *                    -XX:+UnlockDiagnosticVMOptions -XX:UseAVX=3 -XX:AVX3Threshold=0
  *                     compiler.intrinsics.VectorizedMismatchTest

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/VectorizedMismatchTest.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/VectorizedMismatchTest.java
@@ -25,7 +25,6 @@ package compiler.jeandle.intrinsic;
 
 /*
  * @test
- * @requires vm.opt.final.UseJeandleCompiler == true
  * @requires vm.opt.final.UseVectorizedMismatchIntrinsic == true
  * @summary Test Jeandle vectorizedMismatch intrinsic lowering and semantics
  * @modules java.base/jdk.internal.misc
@@ -57,6 +56,7 @@ import java.util.stream.Stream;
 
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.ArraysSupport;
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -69,6 +69,8 @@ public class VectorizedMismatchTest {
             "(?m)\\bmismatch_inline_small_a_i64\\b");
     private static final Pattern INLINE_VECTOR_LOAD = Pattern.compile(
             "(?m)\\bmismatch_inline_vector_a\\b");
+    private static final Pattern ARRAY_OPERATION_PARTIAL_INLINE_SIZE = Pattern.compile(
+            "(?m)^\\s*intx\\s+ArrayOperationPartialInlineSize\\s*=\\s*(\\d+)\\b");
     private static final Pattern DIRECT_MEMORY_GEP = Pattern.compile(
             "(?m)getelementptr i8, ptr addrspace\\(1\\) null");
 
@@ -575,6 +577,7 @@ public class VectorizedMismatchTest {
                 "-Xbatch", "-XX:-TieredCompilation",
                 "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseJeandleCompiler",
                 "-XX:+UseVectorizedMismatchIntrinsic",
+                "-XX:+PrintFlagsFinal",
                 "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
                 "-XX:JeandleDumpDirectory=" + dumpDirectory,
                 "-XX:CompileCommand=quiet",
@@ -605,8 +608,19 @@ public class VectorizedMismatchTest {
             }
             boolean foundInlineVectorPath = irFiles.stream()
                                                     .anyMatch(VectorizedMismatchTest::containsInlineVectorPath);
-            if (!foundInlineVectorPath) {
+            var inlineSizeMatcher =
+                    ARRAY_OPERATION_PARTIAL_INLINE_SIZE.matcher(output.getOutput());
+            if (!inlineSizeMatcher.find()) {
+                throw new AssertionError("ArrayOperationPartialInlineSize is missing from VM flags");
+            }
+            int partialInlineSize = Integer.parseInt(inlineSizeMatcher.group(1));
+            boolean expectInlineVectorPath =
+                    Platform.isAArch64() && partialInlineSize >= 16;
+            if (expectInlineVectorPath && !foundInlineVectorPath) {
                 throw new AssertionError("compiled IR does not contain inline vector mismatch loads");
+            } else if (!expectInlineVectorPath && foundInlineVectorPath) {
+                throw new AssertionError(
+                        "compiled IR unexpectedly contains inline vector mismatch loads");
             }
             boolean foundDirectMemoryGep = irFiles.stream()
                                                    .anyMatch(VectorizedMismatchTest::containsDirectMemoryGep);

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/VectorizedMismatchTest.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/VectorizedMismatchTest.java
@@ -1,0 +1,670 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.jeandle.intrinsic;
+
+/*
+ * @test
+ * @requires vm.opt.final.UseJeandleCompiler == true
+ * @requires vm.opt.final.UseVectorizedMismatchIntrinsic == true
+ * @summary Test Jeandle vectorizedMismatch intrinsic lowering and semantics
+ * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.util
+ * @library /test/lib /
+ *
+ *  @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test*
+ *                    -XX:CompileCommand=compileonly,*::mismatch*
+ *                    -Xbatch -XX:-TieredCompilation
+ *                    -XX:+IgnoreUnrecognizedVMOptions
+ *                    -XX:UseAVX=3
+ *                     compiler.jeandle.intrinsic.VectorizedMismatchTest
+ *
+ *  @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test*
+ *                    -XX:CompileCommand=compileonly,*::mismatch*
+ *                    -Xbatch -XX:-TieredCompilation
+ *                    -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions
+ *                    -XX:UseAVX=3 -XX:AVX3Threshold=0
+ *                     compiler.jeandle.intrinsic.VectorizedMismatchTest
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import jdk.internal.misc.Unsafe;
+import jdk.internal.util.ArraysSupport;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class VectorizedMismatchTest {
+    private static final Pattern STUB_CALL = Pattern.compile(
+            "(?m)\\bcall\\b[^\\r\\n]*@StubRoutines_vectorizedMismatch\\b");
+    private static final Pattern INLINE_SMALL_LOAD = Pattern.compile(
+            "(?m)\\bmismatch_inline_small_a_i(?:64|32|16|8)\\b");
+    private static final Pattern INLINE_SMALL_I64_LOAD = Pattern.compile(
+            "(?m)\\bmismatch_inline_small_a_i64\\b");
+    private static final Pattern INLINE_VECTOR_LOAD = Pattern.compile(
+            "(?m)\\bmismatch_inline_vector_a\\b");
+    private static final Pattern DIRECT_MEMORY_GEP = Pattern.compile(
+            "(?m)getelementptr i8, ptr addrspace\\(1\\) null");
+
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    // Dedicated wrappers keep the length constant at each compiled call site.
+    // The selected lengths exercise the inline and platform-stub boundaries
+    // after the element count is converted to a byte count.
+
+    // Boolean cases
+    private boolean[] boolean_a = new boolean[128];
+    private boolean[] boolean_b = new boolean[128];
+
+    int testBooleanConstantLength(int length) {
+        boolean[] obja = boolean_a;
+        boolean[] objb = boolean_b;
+        long offset = Unsafe.ARRAY_BOOLEAN_BASE_OFFSET;
+        int scale = ArraysSupport.LOG2_ARRAY_BOOLEAN_INDEX_SCALE;
+        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
+    }
+
+    int testBooleanConstantLength0()   { return testBooleanConstantLength(0);   }
+    int testBooleanConstantLength1()   { return testBooleanConstantLength(1);   }
+    int testBooleanConstantLength64()  { return testBooleanConstantLength(64);  }
+    int testBooleanConstantLength128() { return testBooleanConstantLength(128); }
+
+    // Byte cases
+    private byte[] byte_a = new byte[128];
+    private byte[] byte_b = new byte[128];
+
+    int testByteConstantLength(int length) {
+        byte[] obja = byte_a;
+        byte[] objb = byte_b;
+        long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
+        int scale = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
+        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
+    }
+
+    int testByteConstantLength0()   { return testByteConstantLength(0);   }
+    int testByteConstantLength1()   { return testByteConstantLength(1);   }
+    int testByteConstantLength8()   { return testByteConstantLength(8);   }
+    int testByteConstantLength15()  { return testByteConstantLength(15);  }
+    int testByteConstantLength16()  { return testByteConstantLength(16);  }
+    int testByteConstantLength32()  { return testByteConstantLength(32);  }
+    int testByteConstantLength63()  { return testByteConstantLength(63);  }
+    int testByteConstantLength64()  { return testByteConstantLength(64);  }
+    int testByteConstantLength128() { return testByteConstantLength(128); }
+
+    // Short cases
+    private short[] short_a = new short[64];
+    private short[] short_b = new short[64];
+
+    int testShortConstantLength(int length) {
+        short[] obja = short_a;
+        short[] objb = short_b;
+        long offset = Unsafe.ARRAY_SHORT_BASE_OFFSET;
+        int scale = ArraysSupport.LOG2_ARRAY_SHORT_INDEX_SCALE;
+        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
+    }
+
+    int testShortConstantLength0()  { return testShortConstantLength(0);  }
+    int testShortConstantLength1()  { return testShortConstantLength(1);  }
+    int testShortConstantLength32() { return testShortConstantLength(32); }
+    int testShortConstantLength64() { return testShortConstantLength(64); }
+
+    // Char cases
+    private char[] char_a = new char[64];
+    private char[] char_b = new char[64];
+
+    int testCharConstantLength(int length) {
+        char[] obja = char_a;
+        char[] objb = char_b;
+        long offset = Unsafe.ARRAY_CHAR_BASE_OFFSET;
+        int scale = ArraysSupport.LOG2_ARRAY_CHAR_INDEX_SCALE;
+        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
+    }
+
+    int testCharConstantLength0()  { return testCharConstantLength(0);  }
+    int testCharConstantLength1()  { return testCharConstantLength(1);  }
+    int testCharConstantLength32() { return testCharConstantLength(32); }
+    int testCharConstantLength64() { return testCharConstantLength(64); }
+
+    // Int cases
+    private int[] int_a = new int[32];
+    private int[] int_b = new int[32];
+
+    int testIntConstantLength(int length) {
+        int[] obja = int_a;
+        int[] objb = int_b;
+        long offset = Unsafe.ARRAY_INT_BASE_OFFSET;
+        int scale = ArraysSupport.LOG2_ARRAY_INT_INDEX_SCALE;
+        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
+    }
+
+    int testIntConstantLength0()  { return testIntConstantLength(0);  }
+    int testIntConstantLength1()  { return testIntConstantLength(1);  }
+    int testIntConstantLength16() { return testIntConstantLength(16); }
+    int testIntConstantLength32() { return testIntConstantLength(32); }
+
+    // Float cases
+    private float[] float_a = new float[32];
+    private float[] float_b = new float[32];
+
+    int testFloatConstantLength(int length) {
+        float[] obja = float_a;
+        float[] objb = float_b;
+        long offset = Unsafe.ARRAY_FLOAT_BASE_OFFSET;
+        int scale = ArraysSupport.LOG2_ARRAY_FLOAT_INDEX_SCALE;
+        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
+    }
+
+    int testFloatConstantLength0()  { return testFloatConstantLength(0);  }
+    int testFloatConstantLength1()  { return testFloatConstantLength(1);  }
+    int testFloatConstantLength16() { return testFloatConstantLength(16); }
+    int testFloatConstantLength32() { return testFloatConstantLength(32); }
+
+    // Long cases
+    private long[] long_a = new long[16];
+    private long[] long_b = new long[16];
+
+    int testLongConstantLength(int length) {
+        long[] obja = long_a;
+        long[] objb = long_b;
+        long offset = Unsafe.ARRAY_LONG_BASE_OFFSET;
+        int scale = ArraysSupport.LOG2_ARRAY_LONG_INDEX_SCALE;
+        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
+    }
+
+    int testLongConstantLength0()  { return testLongConstantLength(0);  }
+    int testLongConstantLength1()  { return testLongConstantLength(1);  }
+    int testLongConstantLength8()  { return testLongConstantLength(8);  }
+    int testLongConstantLength16() { return testLongConstantLength(16); }
+
+    // Double cases
+    private double[] double_a = new double[16];
+    private double[] double_b = new double[16];
+
+    int testDoubleConstantLength(int length) {
+        double[] obja = double_a;
+        double[] objb = double_b;
+        long offset = Unsafe.ARRAY_DOUBLE_BASE_OFFSET;
+        int  scale  = ArraysSupport.LOG2_ARRAY_DOUBLE_INDEX_SCALE;
+        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
+    }
+
+    int testDoubleConstantLength0()  { return testDoubleConstantLength(0);  }
+    int testDoubleConstantLength1()  { return testDoubleConstantLength(1);  }
+    int testDoubleConstantLength8()  { return testDoubleConstantLength(8);  }
+    int testDoubleConstantLength16() { return testDoubleConstantLength(16); }
+
+    // Class-initialization and loop-optimization cases
+    static class ClassInitTest {
+        static final int LENGTH = 64;
+        static final int RESULT;
+        static {
+            byte[] arr1 = new byte[LENGTH];
+            byte[] arr2 = new byte[LENGTH];
+            for (int i = 0; i < 20_000; i++) {
+                test(arr1, arr2);
+            }
+            RESULT = test(arr1, arr2);
+        }
+
+        static int test(byte[] obja, byte[] objb) {
+            long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
+            int  scale  = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
+            return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, LENGTH, scale); // LENGTH is not considered a constant
+        }
+    }
+
+    int testConstantBeingInitialized() {
+        return ClassInitTest.RESULT; // trigger class initialization
+    }
+
+    int testLoopUnswitch(int length) {
+        long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
+        int  scale  = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
+
+        int acc = 0;
+        for (int i = 0; i < 32; i++) {
+            acc += ArraysSupport.vectorizedMismatch(byte_a, offset, byte_b, offset, length, scale);
+        }
+        return acc;
+    }
+
+    int testLoopHoist(int length, int stride) {
+        long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
+        int  scale  = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
+
+        int acc = 0;
+
+        for (int i = 0; i < 32; i += stride) {
+            acc += ArraysSupport.vectorizedMismatch(byte_a, offset, byte_b, offset, length, scale);
+        }
+        return acc;
+    }
+
+    /* ==================================================================================== */
+
+    public static void main(String[] args) throws Exception {
+        VectorizedMismatchTest t = new VectorizedMismatchTest();
+        for (int i = 0; i < 20_000; i++) {
+            t.testBooleanConstantLength0();
+            t.testBooleanConstantLength1();
+            t.testBooleanConstantLength64();
+            t.testBooleanConstantLength128();
+
+            t.testByteConstantLength0();
+            t.testByteConstantLength1();
+            t.testByteConstantLength8();
+            t.testByteConstantLength15();
+            t.testByteConstantLength16();
+            t.testByteConstantLength32();
+            t.testByteConstantLength63();
+            t.testByteConstantLength64();
+            t.testByteConstantLength128();
+
+            t.testShortConstantLength0();
+            t.testShortConstantLength1();
+            t.testShortConstantLength32();
+            t.testShortConstantLength64();
+
+            t.testCharConstantLength0();
+            t.testCharConstantLength1();
+            t.testCharConstantLength32();
+            t.testCharConstantLength64();
+
+            t.testIntConstantLength0();
+            t.testIntConstantLength1();
+            t.testIntConstantLength16();
+            t.testIntConstantLength32();
+
+            t.testFloatConstantLength0();
+            t.testFloatConstantLength1();
+            t.testFloatConstantLength16();
+            t.testFloatConstantLength32();
+
+            t.testLongConstantLength0();
+            t.testLongConstantLength1();
+            t.testLongConstantLength8();
+            t.testLongConstantLength16();
+
+            t.testDoubleConstantLength0();
+            t.testDoubleConstantLength1();
+            t.testDoubleConstantLength8();
+            t.testDoubleConstantLength16();
+
+            t.testConstantBeingInitialized();
+            t.testLoopUnswitch(32);
+            t.testLoopHoist(128, 2);
+        }
+
+        t.byte_b[7] = 1;
+        expect(7, t.testByteConstantLength8());
+        t.byte_b[7] = 0;
+        t.byte_b[14] = 1;
+        expect(14, t.testByteConstantLength15());
+        t.byte_b[14] = 0;
+        t.byte_b[15] = 1;
+        expect(15, t.testByteConstantLength16());
+        t.byte_b[15] = 0;
+        t.byte_b[31] = 1;
+        expect(31, t.testByteConstantLength32());
+        t.byte_b[31] = 0;
+        t.byte_b[62] = 1;
+        expect(62, t.testByteConstantLength63());
+        t.byte_b[62] = 0;
+
+        verifyResultValues();
+        verifyDirectMemoryValues();
+        if (args.length == 0) {
+            verifyIntrinsicLowering();
+        } else {
+            testBulkByteRanges();
+        }
+    }
+
+    private static int mismatchBytes(byte[] a, byte[] b, int length) {
+        return ArraysSupport.vectorizedMismatch(a, Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                                                b, Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                                                length,
+                                                ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE);
+    }
+
+    private static int mismatchBytesAt(byte[] a, int aIndex,
+                                       byte[] b, int bIndex, int length) {
+        return ArraysSupport.vectorizedMismatch(a, Unsafe.ARRAY_BYTE_BASE_OFFSET + aIndex,
+                                                b, Unsafe.ARRAY_BYTE_BASE_OFFSET + bIndex,
+                                                length,
+                                                ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE);
+    }
+
+    private static int testDirectBothNull(long aAddress, long bAddress, int length) {
+        return ArraysSupport.vectorizedMismatch(null, aAddress, null, bAddress, length, 0);
+    }
+
+    private static int testDirectLeftNull(long aAddress, byte[] b, int bIndex, int length) {
+        return ArraysSupport.vectorizedMismatch(null, aAddress,
+                                                b, Unsafe.ARRAY_BYTE_BASE_OFFSET + bIndex,
+                                                length, 0);
+    }
+
+    private static int testDirectRightNull(byte[] a, int aIndex, long bAddress, int length) {
+        return ArraysSupport.vectorizedMismatch(a, Unsafe.ARRAY_BYTE_BASE_OFFSET + aIndex,
+                                                null, bAddress, length, 0);
+    }
+
+    private static void verifyResultValues() {
+        byte[] bytesA = new byte[65];
+        byte[] bytesB = new byte[65];
+        char[] charsA = new char[33];
+        char[] charsB = new char[33];
+        int[] intsA = new int[17];
+        int[] intsB = new int[17];
+        long[] longsA = new long[9];
+        long[] longsB = new long[9];
+        byte[] shiftedA = new byte[68];
+        byte[] shiftedB = new byte[70];
+        byte[] smallBytesA = new byte[15];
+        byte[] smallBytesB = new byte[15];
+        byte[] boundaryBytesA = new byte[16];
+        byte[] boundaryBytesB = new byte[16];
+        char[] smallCharsA = new char[7];
+        char[] smallCharsB = new char[7];
+        int[] smallIntsA = new int[3];
+        int[] smallIntsB = new int[3];
+        long[] smallLongsA = new long[1];
+        long[] smallLongsB = new long[1];
+
+        bytesB[0] = 1;
+        charsB[7] = 1;
+        intsB[5] = 1;
+        longsB[3] = 1;
+        shiftedB[5 + 17] = 1;
+        smallBytesB[7] = 1;
+        boundaryBytesB[15] = 1;
+        smallCharsB[3] = 1;
+        smallIntsB[1] = 1;
+        smallLongsB[0] = 1;
+
+        for (int i = 0; i < 20_000; i++) {
+            expect(0, mismatchBytes(bytesA, bytesB, bytesA.length));
+            expect(7, ArraysSupport.vectorizedMismatch(charsA, Unsafe.ARRAY_CHAR_BASE_OFFSET,
+                                                        charsB, Unsafe.ARRAY_CHAR_BASE_OFFSET,
+                                                        charsA.length,
+                                                        ArraysSupport.LOG2_ARRAY_CHAR_INDEX_SCALE));
+            expect(5, ArraysSupport.vectorizedMismatch(intsA, Unsafe.ARRAY_INT_BASE_OFFSET,
+                                                        intsB, Unsafe.ARRAY_INT_BASE_OFFSET,
+                                                        intsA.length,
+                                                        ArraysSupport.LOG2_ARRAY_INT_INDEX_SCALE));
+            expect(3, ArraysSupport.vectorizedMismatch(longsA, Unsafe.ARRAY_LONG_BASE_OFFSET,
+                                                        longsB, Unsafe.ARRAY_LONG_BASE_OFFSET,
+                                                        longsA.length,
+                                                        ArraysSupport.LOG2_ARRAY_LONG_INDEX_SCALE));
+            expect(17, mismatchBytesAt(shiftedA, 3, shiftedB, 5, 65));
+            expect(7, mismatchBytes(smallBytesA, smallBytesB, smallBytesA.length));
+            expect(15, mismatchBytes(boundaryBytesA, boundaryBytesB, boundaryBytesA.length));
+            expect(3, ArraysSupport.vectorizedMismatch(smallCharsA, Unsafe.ARRAY_CHAR_BASE_OFFSET,
+                                                        smallCharsB, Unsafe.ARRAY_CHAR_BASE_OFFSET,
+                                                        smallCharsA.length,
+                                                        ArraysSupport.LOG2_ARRAY_CHAR_INDEX_SCALE));
+            expect(1, ArraysSupport.vectorizedMismatch(smallIntsA, Unsafe.ARRAY_INT_BASE_OFFSET,
+                                                        smallIntsB, Unsafe.ARRAY_INT_BASE_OFFSET,
+                                                        smallIntsA.length,
+                                                        ArraysSupport.LOG2_ARRAY_INT_INDEX_SCALE));
+            expect(0, ArraysSupport.vectorizedMismatch(smallLongsA, Unsafe.ARRAY_LONG_BASE_OFFSET,
+                                                        smallLongsB, Unsafe.ARRAY_LONG_BASE_OFFSET,
+                                                        smallLongsA.length,
+                                                        ArraysSupport.LOG2_ARRAY_LONG_INDEX_SCALE));
+        }
+
+        bytesB[0] = 0;
+        charsB[7] = 0;
+        intsB[5] = 0;
+        longsB[3] = 0;
+        shiftedB[5 + 17] = 0;
+        smallBytesB[7] = 0;
+        boundaryBytesB[15] = 0;
+        smallCharsB[3] = 0;
+        smallIntsB[1] = 0;
+        smallLongsB[0] = 0;
+        expectNegative(mismatchBytes(bytesA, bytesB, bytesA.length));
+        expectNegative(mismatchBytesAt(shiftedA, 3, shiftedB, 5, 65));
+        expectNegative(mismatchBytes(smallBytesA, smallBytesB, smallBytesA.length));
+        expectNegative(mismatchBytes(boundaryBytesA, boundaryBytesB, boundaryBytesA.length));
+    }
+
+    private static void verifyDirectMemoryValues() {
+        // Exercise unaligned raw addresses and mixed heap/native bases across
+        // the small, medium, and stub tiers.
+        final int[] lengths = {8, 32, 64};
+        final int aOffset = 1;
+        final int bOffset = 3;
+        final int maxLength = lengths[lengths.length - 1];
+        long nativeA = UNSAFE.allocateMemory(maxLength + aOffset);
+        long nativeB = UNSAFE.allocateMemory(maxLength + bOffset);
+        byte[] heapA = new byte[maxLength + aOffset];
+        byte[] heapB = new byte[maxLength + bOffset];
+
+        try {
+            for (int length : lengths) {
+                fillNative(nativeA + aOffset, length);
+                fillNative(nativeB + bOffset, length);
+                fillHeap(heapA, aOffset, length);
+                fillHeap(heapB, bOffset, length);
+            }
+
+            for (int i = 0; i < 20_000; i++) {
+                for (int length : lengths) {
+                    expectNegative(testDirectBothNull(nativeA + aOffset, nativeB + bOffset, length));
+                    expectNegative(testDirectLeftNull(nativeA + aOffset, heapB, bOffset, length));
+                    expectNegative(testDirectRightNull(heapA, aOffset, nativeB + bOffset, length));
+                }
+            }
+
+            for (int length : lengths) {
+                verifyDirectBothNull(nativeA + aOffset, nativeB + bOffset, length);
+                verifyDirectLeftNull(nativeA + aOffset, heapB, bOffset, length);
+                verifyDirectRightNull(heapA, aOffset, nativeB + bOffset, length);
+            }
+        } finally {
+            UNSAFE.freeMemory(nativeA);
+            UNSAFE.freeMemory(nativeB);
+        }
+    }
+
+    private static void verifyDirectBothNull(long aAddress, long bAddress, int length) {
+        fillNative(aAddress, length);
+        fillNative(bAddress, length);
+        expectNegative(testDirectBothNull(aAddress, bAddress, length));
+        UNSAFE.putByte(bAddress, (byte) (UNSAFE.getByte(aAddress) ^ 1));
+        expect(0, testDirectBothNull(aAddress, bAddress, length));
+        fillNative(bAddress, length);
+        UNSAFE.putByte(bAddress + length - 1, (byte) (UNSAFE.getByte(aAddress + length - 1) ^ 1));
+        expect(length - 1, testDirectBothNull(aAddress, bAddress, length));
+    }
+
+    private static void verifyDirectLeftNull(long aAddress, byte[] b, int bIndex, int length) {
+        fillNative(aAddress, length);
+        fillHeap(b, bIndex, length);
+        expectNegative(testDirectLeftNull(aAddress, b, bIndex, length));
+        b[bIndex] ^= 1;
+        expect(0, testDirectLeftNull(aAddress, b, bIndex, length));
+        fillHeap(b, bIndex, length);
+        b[bIndex + length - 1] ^= 1;
+        expect(length - 1, testDirectLeftNull(aAddress, b, bIndex, length));
+    }
+
+    private static void verifyDirectRightNull(byte[] a, int aIndex, long bAddress, int length) {
+        fillHeap(a, aIndex, length);
+        fillNative(bAddress, length);
+        expectNegative(testDirectRightNull(a, aIndex, bAddress, length));
+        UNSAFE.putByte(bAddress, (byte) (a[aIndex] ^ 1));
+        expect(0, testDirectRightNull(a, aIndex, bAddress, length));
+        fillNative(bAddress, length);
+        UNSAFE.putByte(bAddress + length - 1, (byte) (a[aIndex + length - 1] ^ 1));
+        expect(length - 1, testDirectRightNull(a, aIndex, bAddress, length));
+    }
+
+    private static void fillNative(long address, int length) {
+        for (int i = 0; i < length; i++) {
+            UNSAFE.putByte(address + i, mismatchValue(i));
+        }
+    }
+
+    private static void fillHeap(byte[] array, int offset, int length) {
+        for (int i = 0; i < length; i++) {
+            array[offset + i] = mismatchValue(i);
+        }
+    }
+
+    private static byte mismatchValue(int index) {
+        return (byte) (index * 31 + 7);
+    }
+
+    private static void testBulkByteRanges() {
+        int[] lengths = { 255, 256, 257, 512, 513 };
+        int[] mismatchIndices = { 0, 63, 64, 127, 128, 191, 192, 255, 256, 511, 512 };
+        byte[] a = new byte[513];
+        byte[] b = new byte[513];
+
+        for (int i = 0; i < a.length; i++) {
+            a[i] = b[i] = (byte) (i * 13);
+        }
+
+        for (int length : lengths) {
+            expectNegative(mismatchBytes(a, b, length));
+            for (int index : mismatchIndices) {
+                if (index >= length) {
+                    continue;
+                }
+                b[index] ^= 1;
+                expect(index, mismatchBytes(a, b, length));
+                b[index] = a[index];
+            }
+        }
+    }
+
+    private static void verifyIntrinsicLowering() throws Exception {
+        Path dumpDirectory = Files.createTempDirectory("jeandle_vectorized_mismatch");
+        ArrayList<String> command = new ArrayList<>(List.of(
+                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                "--add-exports=java.base/jdk.internal.util=ALL-UNNAMED",
+                "-Xbatch", "-XX:-TieredCompilation",
+                "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseJeandleCompiler",
+                "-XX:+UseVectorizedMismatchIntrinsic",
+                "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
+                "-XX:JeandleDumpDirectory=" + dumpDirectory,
+                "-XX:CompileCommand=quiet",
+                "-XX:CompileCommand=compileonly,compiler.jeandle.intrinsic.VectorizedMismatchTest::*",
+                VectorizedMismatchTest.class.getName(), "functional"));
+
+        OutputAnalyzer output = ProcessTools.executeCommand(
+                ProcessTools.createLimitedTestJavaProcessBuilder(command));
+        output.shouldHaveExitValue(0)
+              .shouldContain("jdk.internal.util.ArraysSupport.vectorizedMismatch")
+              .shouldContain("is parsed as intrinsic");
+
+        try (Stream<Path> files = Files.walk(dumpDirectory)) {
+            List<Path> irFiles = files.filter(path -> path.toString().endsWith(".ll")).toList();
+            boolean foundStubCall = irFiles.stream().anyMatch(VectorizedMismatchTest::containsStubCall);
+            if (!foundStubCall) {
+                throw new AssertionError("compiled IR does not call StubRoutines_vectorizedMismatch");
+            }
+            boolean foundInlineSmallPath = irFiles.stream()
+                                                   .anyMatch(VectorizedMismatchTest::containsInlineSmallPath);
+            if (!foundInlineSmallPath) {
+                throw new AssertionError("compiled IR does not contain inline small mismatch loads");
+            }
+            boolean foundInlineSmallI64Path = irFiles.stream()
+                                                      .anyMatch(VectorizedMismatchTest::containsInlineSmallI64Path);
+            if (!foundInlineSmallI64Path) {
+                throw new AssertionError("compiled IR does not contain inline 64-bit mismatch loads");
+            }
+            boolean foundInlineVectorPath = irFiles.stream()
+                                                    .anyMatch(VectorizedMismatchTest::containsInlineVectorPath);
+            if (!foundInlineVectorPath) {
+                throw new AssertionError("compiled IR does not contain inline vector mismatch loads");
+            }
+            boolean foundDirectMemoryGep = irFiles.stream()
+                                                   .anyMatch(VectorizedMismatchTest::containsDirectMemoryGep);
+            if (!foundDirectMemoryGep) {
+                throw new AssertionError("compiled IR does not contain a direct-memory mismatch GEP");
+            }
+        }
+    }
+
+    private static boolean containsStubCall(Path path) {
+        try {
+            return STUB_CALL.matcher(Files.readString(path)).find();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean containsInlineSmallPath(Path path) {
+        try {
+            return INLINE_SMALL_LOAD.matcher(Files.readString(path)).find();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean containsInlineVectorPath(Path path) {
+        try {
+            return INLINE_VECTOR_LOAD.matcher(Files.readString(path)).find();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean containsInlineSmallI64Path(Path path) {
+        try {
+            return INLINE_SMALL_I64_LOAD.matcher(Files.readString(path)).find();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean containsDirectMemoryGep(Path path) {
+        try {
+            return DIRECT_MEMORY_GEP.matcher(Files.readString(path)).find();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void expect(int expected, int actual) {
+        if (actual != expected) {
+            throw new AssertionError("expected " + expected + ", got " + actual);
+        }
+    }
+
+    private static void expectNegative(int actual) {
+        if (actual >= 0) {
+            throw new AssertionError("expected negative no-mismatch result, got " + actual);
+        }
+    }
+}

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -382,7 +382,6 @@ public class VMProps implements Callable<Map<String, String>> {
         vmOptFinalFlag(map, "EliminateAllocations");
         vmOptFinalFlag(map, "UnlockExperimentalVMOptions");
         vmOptFinalFlag(map, "UseCompressedOops");
-        vmOptFinalFlag(map, "UseJeandleCompiler");
         vmOptFinalFlag(map, "UseVectorizedMismatchIntrinsic");
         vmOptFinalFlag(map, "UseVtableBasedCHA");
         vmOptFinalFlag(map, "ZGenerational");

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -382,6 +382,7 @@ public class VMProps implements Callable<Map<String, String>> {
         vmOptFinalFlag(map, "EliminateAllocations");
         vmOptFinalFlag(map, "UnlockExperimentalVMOptions");
         vmOptFinalFlag(map, "UseCompressedOops");
+        vmOptFinalFlag(map, "UseJeandleCompiler");
         vmOptFinalFlag(map, "UseVectorizedMismatchIntrinsic");
         vmOptFinalFlag(map, "UseVtableBasedCHA");
         vmOptFinalFlag(map, "ZGenerational");

--- a/test/micro/org/openjdk/bench/java/util/VectorizedMismatchIntrinsic.java
+++ b/test/micro/org/openjdk/bench/java/util/VectorizedMismatchIntrinsic.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package org.openjdk.bench.java.util;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import jdk.internal.misc.Unsafe;
+import jdk.internal.util.ArraysSupport;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures the _vectorizedMismatch intrinsic directly. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3, jvmArgsAppend = {
+        "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+        "--add-exports=java.base/jdk.internal.util=ALL-UNNAMED"
+})
+public class VectorizedMismatchIntrinsic {
+
+    // Cover the inline byte path (< 16 bytes), the 16-byte boundary, and the
+    // existing vector-tier cases.
+    @Param({"8", "32", "64", "8192"})
+    public int length;
+
+    private byte[] bytes;
+    private byte[] otherBytes;
+    private char[] chars;
+    private char[] otherChars;
+    private int[] ints;
+    private int[] otherInts;
+    private long[] longs;
+    private long[] otherLongs;
+
+    @Setup
+    public void setup() {
+        bytes = new byte[length];
+        otherBytes = new byte[length];
+        chars = new char[length];
+        otherChars = new char[length];
+        ints = new int[length];
+        otherInts = new int[length];
+        longs = new long[length];
+        otherLongs = new long[length];
+
+        Arrays.fill(bytes, (byte) 0x5a);
+        Arrays.fill(otherBytes, (byte) 0x5a);
+        Arrays.fill(chars, (char) 0x5a5a);
+        Arrays.fill(otherChars, (char) 0x5a5a);
+        Arrays.fill(ints, 0x5a5a5a5a);
+        Arrays.fill(otherInts, 0x5a5a5a5a);
+        Arrays.fill(longs, 0x5a5a5a5a5a5a5a5aL);
+        Arrays.fill(otherLongs, 0x5a5a5a5a5a5a5a5aL);
+
+    }
+
+    @Benchmark
+    public int byteMismatch() {
+        return ArraysSupport.vectorizedMismatch(bytes, Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                otherBytes, Unsafe.ARRAY_BYTE_BASE_OFFSET, length,
+                ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE);
+    }
+
+    @Benchmark
+    public int charMismatch() {
+        return ArraysSupport.vectorizedMismatch(chars, Unsafe.ARRAY_CHAR_BASE_OFFSET,
+                otherChars, Unsafe.ARRAY_CHAR_BASE_OFFSET, length,
+                ArraysSupport.LOG2_ARRAY_CHAR_INDEX_SCALE);
+    }
+
+    @Benchmark
+    public int intMismatch() {
+        return ArraysSupport.vectorizedMismatch(ints, Unsafe.ARRAY_INT_BASE_OFFSET,
+                otherInts, Unsafe.ARRAY_INT_BASE_OFFSET, length,
+                ArraysSupport.LOG2_ARRAY_INT_INDEX_SCALE);
+    }
+
+    @Benchmark
+    public int longMismatch() {
+        return ArraysSupport.vectorizedMismatch(longs, Unsafe.ARRAY_LONG_BASE_OFFSET,
+                otherLongs, Unsafe.ARRAY_LONG_BASE_OFFSET, length,
+                ArraysSupport.LOG2_ARRAY_LONG_INDEX_SCALE);
+    }
+}


### PR DESCRIPTION
## Related issue(s):

issue #548 

## What this PR does / why we need it:

Implement _vectorizedMismatch intrinsic support in Jeandle with a size-tiered
LLVM IR and platform-stub design. Inputs below 16 bytes use width-tiered
8/4/2/1-byte integer IR,
16-63-byte inputs use fixed 128-bit vector IR on supported targets, and larger
inputs use StubRoutines::vectorizedMismatch. The AArch64 stub compares
256-byte blocks with NEON and precisely locates the first differing element.

This avoids stub overhead and byte-wise loops for small inputs, enables NEON lowering for medium
inputs, and preserves the optimized stub loop for large arrays. The intrinsic
is enabled by default only when Jeandle is enabled on AArch64 and remains
user-controllable through UseVectorizedMismatchIntrinsic.

The change includes Jeandle-specific semantic and IR coverage, boundary tests
for all three tiers, and a direct JMH benchmark for
ArraysSupport.vectorizedMismatch.
