### PR TITLE
feat: implement Math/StrictMath min/max/fma intrinsics (closes #547)

### DIFF
--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -113,6 +113,37 @@ bool JeandleIntrinsicLowering::is_supported(vmIntrinsics::ID id) {
     case vmIntrinsics::_dlog10:
     case vmIntrinsics::_dexp:
 
+    // min/max: no CPU gating needed. llvm.smin/smax always lower to a
+    // compare+select/cmov sequence and llvm.minimum/maximum always lower to
+    // a NaN/signed-zero-correct sequence on every target Jeandle supports;
+    // neither ever falls back to a libcall the way llvm.floor/ceil/rint can.
+    // Math and StrictMath share the same vmIntrinsics ID space and identical
+    // javadoc-specified semantics here (strictfp has no effect on min/max),
+    // so one lowering covers both.
+    case vmIntrinsics::_min:
+    case vmIntrinsics::_max:
+    case vmIntrinsics::_min_strict:
+    case vmIntrinsics::_max_strict:
+    case vmIntrinsics::_minF:
+    case vmIntrinsics::_maxF:
+    case vmIntrinsics::_minD:
+    case vmIntrinsics::_maxD:
+    case vmIntrinsics::_minF_strict:
+    case vmIntrinsics::_maxF_strict:
+    case vmIntrinsics::_minD_strict:
+    case vmIntrinsics::_maxD_strict:
+
+    // fmaD/fmaF: no separate cpu_supports_fma() gate needed. Unlike
+    // rounding/popcount (which have no shared-infrastructure flag check),
+    // vmIntrinsics::is_disabled_by_flags() already requires UseFMA for these
+    // two IDs and runs unconditionally after is_supported() in
+    // try_lower_intrinsic(), so a hardware-less target is rejected there.
+    // (apply_vm_flag_feature_overrides() also strips the LLVM "fma" target
+    // feature when UseFMA is off, so even a hypothetical direct call here
+    // would still lower correctly, just via a libcall instead of hardware.)
+    case vmIntrinsics::_fmaD:
+    case vmIntrinsics::_fmaF:
+
     // getClass
     case vmIntrinsics::_getClass:
 
@@ -219,6 +250,36 @@ bool JeandleIntrinsicLowering::lower(vmIntrinsics::ID id, const ciMethod* target
     case vmIntrinsics::_labs:
       return emit_llvm_builtin(llvm::Intrinsic::abs,
                                 {_interp->_ir_builder.getInt1(false)});
+
+    // Math/StrictMath.min|max(int,int): plain two's-complement signed min/max,
+    // identical for both classes.
+    case vmIntrinsics::_min:
+    case vmIntrinsics::_min_strict:
+      return emit_llvm_builtin(llvm::Intrinsic::smin);
+    case vmIntrinsics::_max:
+    case vmIntrinsics::_max_strict:
+      return emit_llvm_builtin(llvm::Intrinsic::smax);
+
+    // Math/StrictMath.min|max(float|double,...): llvm.minimum/maximum
+    // implement IEEE-754-2019 minimum/maximum (NaN propagates, -0.0 < +0.0),
+    // matching the Math.{min,max} javadoc contract exactly.
+    case vmIntrinsics::_minF:
+    case vmIntrinsics::_minF_strict:
+    case vmIntrinsics::_minD:
+    case vmIntrinsics::_minD_strict:
+      return emit_llvm_builtin(llvm::Intrinsic::minimum);
+    case vmIntrinsics::_maxF:
+    case vmIntrinsics::_maxF_strict:
+    case vmIntrinsics::_maxD:
+    case vmIntrinsics::_maxD_strict:
+      return emit_llvm_builtin(llvm::Intrinsic::maximum);
+
+    // Math.fma(float|double,...): llvm.fma is always a correctly-rounded
+    // single-rounding fused multiply-add (never contracted like
+    // llvm.fmuladd), matching the Math.fma javadoc contract.
+    case vmIntrinsics::_fmaD:
+    case vmIntrinsics::_fmaF:
+      return emit_llvm_builtin(llvm::Intrinsic::fma);
 
     case vmIntrinsics::_bitCount_i:
     case vmIntrinsics::_bitCount_l:

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestFma.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestFma.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @key randomness
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @summary Test the intrinsics implementation of Math.fma(double,double,double) and (float,float,float)
+ * @library /test/lib /
+ * @run main/othervm compiler.jeandle.intrinsic.TestFma
+ */
+
+package compiler.jeandle.intrinsic;
+
+import compiler.jeandle.fileCheck.FileCheck;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestFma {
+    public static void main(String[] args) throws Exception {
+        String dumpPath = Files.createTempDirectory("jeandle_fma").toString();
+
+        ArrayList<String> commandArgs = new ArrayList<>(List.of(
+                "-Xbatch",
+                "-XX:-TieredCompilation",
+                "-XX:+UseJeandleCompiler",
+                "-Xcomp",
+                "-Xlog:jeandle=debug",
+                "-XX:+JeandleDumpIR",
+                "-XX:JeandleDumpDirectory=" + dumpPath,
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::fma_double",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::fma_float",
+                TestWrapper.class.getName()));
+
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(commandArgs);
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+
+        output.shouldHaveExitValue(0)
+              .shouldContain("Method `static jdouble java.lang.Math.fma(jdouble, jdouble, jdouble)` is parsed as intrinsic")
+              .shouldContain("Method `static jfloat java.lang.Math.fma(jfloat, jfloat, jfloat)` is parsed as intrinsic");
+
+        // Verify the llvm intrinsic is used for each variant.
+        FileCheck doubleCheck = new FileCheck(dumpPath,
+                TestWrapper.class.getMethod("fma_double", double.class, double.class, double.class), false);
+        doubleCheck.checkPattern("call double @llvm.fma.f64");
+
+        FileCheck floatCheck = new FileCheck(dumpPath,
+                TestWrapper.class.getMethod("fma_float", float.class, float.class, float.class), false);
+        floatCheck.checkPattern("call float @llvm.fma.f32");
+    }
+
+    static class TestWrapper {
+        static final double DUMMY = Math.fma(0.0d, 0.0d, 0.0d); // force load java.lang.Math
+
+        public static void main(String[] args) {
+            var random = Utils.getRandomInstance();
+
+            // ---- double ----
+
+            // Basic values (mirrors compiler/floatingpoint/TestFMA.java's sanity vectors)
+            Asserts.assertEquals(57.0d, fma_double(5.0d, 10.0d, 7.0d), "fma(5,10,7)");
+            Asserts.assertEquals(-43.0d, fma_double(-5.0d, 10.0d, 7.0d), "fma(-5,10,7)");
+            Asserts.assertEquals(-43.0d, fma_double(5.0d, -10.0d, 7.0d), "fma(5,-10,7)");
+            Asserts.assertEquals(43.0d, fma_double(5.0d, 10.0d, -7.0d), "fma(5,10,-7)");
+            Asserts.assertEquals(-57.0d, fma_double(-5.0d, 10.0d, -7.0d), "fma(-5,10,-7)");
+
+            // NaN propagates from any argument.
+            Asserts.assertEquals(Double.NaN, fma_double(Double.NaN, 2.0d, 3.0d), "fma(NaN,2,3)");
+            Asserts.assertEquals(Double.NaN, fma_double(2.0d, Double.NaN, 3.0d), "fma(2,NaN,3)");
+            Asserts.assertEquals(Double.NaN, fma_double(2.0d, 3.0d, Double.NaN), "fma(2,3,NaN)");
+
+            // One of the first two arguments is infinite, the other is zero -> NaN.
+            Asserts.assertEquals(Double.NaN, fma_double(Double.POSITIVE_INFINITY, 0.0d, 1.0d), "fma(+Inf,0,1)");
+            Asserts.assertEquals(Double.NaN, fma_double(0.0d, Double.POSITIVE_INFINITY, 1.0d), "fma(0,+Inf,1)");
+            Asserts.assertEquals(Double.NaN, fma_double(Double.NEGATIVE_INFINITY, 0.0d, 1.0d), "fma(-Inf,0,1)");
+
+            // Exact product is infinite and the addend is an infinity of the opposite sign -> NaN;
+            // same sign -> that infinity.
+            Asserts.assertEquals(Double.NaN, fma_double(Double.POSITIVE_INFINITY, 2.0d, Double.NEGATIVE_INFINITY), "fma(+Inf,2,-Inf)");
+            Asserts.assertEquals(Double.POSITIVE_INFINITY, fma_double(Double.POSITIVE_INFINITY, 2.0d, Double.POSITIVE_INFINITY), "fma(+Inf,2,+Inf)");
+
+            // Documented divergence from a plain multiply: fma(-0.0,+0.0,+0.0) is +0.0
+            // while (-0.0 * +0.0) is -0.0.
+            Asserts.assertEquals(0.0d, fma_double(-0.0d, 0.0d, 0.0d), "fma(-0,+0,+0)");
+            Asserts.assertTrue(Double.doubleToRawLongBits(fma_double(-0.0d, 0.0d, 0.0d)) == Double.doubleToRawLongBits(0.0d),
+                    "fma(-0,+0,+0) should be +0.0");
+
+            // Random values, compared against the interpreter's (uncompiled, unintrinsified)
+            // Math.fma, which is the JLS-authoritative correctly-rounded reference.
+            for (int i = 0; i < 2000; i++) {
+                double a = (random.nextDouble() - 0.5d) * 1.0e10d;
+                double b = (random.nextDouble() - 0.5d) * 1.0e10d;
+                double c = (random.nextDouble() - 0.5d) * 1.0e10d;
+                Asserts.assertEquals(fma_double_verified(a, b, c), fma_double(a, b, c), "fma(" + a + "," + b + "," + c + ")");
+            }
+            // Adversarial: c nearly cancels a*b, stressing the single- vs double-rounding path
+            // that distinguishes a true fused multiply-add from "a*b+c".
+            for (int i = 0; i < 2000; i++) {
+                double a = (random.nextDouble() - 0.5d) * 1.0e8d;
+                double b = (random.nextDouble() - 0.5d) * 1.0e8d;
+                double c = -(a * b) + (random.nextDouble() - 0.5d) * 1.0e-6d;
+                Asserts.assertEquals(fma_double_verified(a, b, c), fma_double(a, b, c), "fma_cancel(" + a + "," + b + "," + c + ")");
+            }
+
+            // ---- float ----
+
+            Asserts.assertEquals(57.0f, fma_float(5.0f, 10.0f, 7.0f), "fma(5,10,7)");
+            Asserts.assertEquals(-43.0f, fma_float(-5.0f, 10.0f, 7.0f), "fma(-5,10,7)");
+            Asserts.assertEquals(-43.0f, fma_float(5.0f, -10.0f, 7.0f), "fma(5,-10,7)");
+            Asserts.assertEquals(43.0f, fma_float(5.0f, 10.0f, -7.0f), "fma(5,10,-7)");
+            Asserts.assertEquals(-57.0f, fma_float(-5.0f, 10.0f, -7.0f), "fma(-5,10,-7)");
+
+            Asserts.assertEquals(Float.NaN, fma_float(Float.NaN, 2.0f, 3.0f), "fma(NaN,2,3)");
+            Asserts.assertEquals(Float.NaN, fma_float(2.0f, Float.NaN, 3.0f), "fma(2,NaN,3)");
+            Asserts.assertEquals(Float.NaN, fma_float(2.0f, 3.0f, Float.NaN), "fma(2,3,NaN)");
+
+            Asserts.assertEquals(Float.NaN, fma_float(Float.POSITIVE_INFINITY, 0.0f, 1.0f), "fma(+Inf,0,1)");
+            Asserts.assertEquals(Float.NaN, fma_float(0.0f, Float.POSITIVE_INFINITY, 1.0f), "fma(0,+Inf,1)");
+            Asserts.assertEquals(Float.NaN, fma_float(Float.NEGATIVE_INFINITY, 0.0f, 1.0f), "fma(-Inf,0,1)");
+
+            Asserts.assertEquals(Float.NaN, fma_float(Float.POSITIVE_INFINITY, 2.0f, Float.NEGATIVE_INFINITY), "fma(+Inf,2,-Inf)");
+            Asserts.assertEquals(Float.POSITIVE_INFINITY, fma_float(Float.POSITIVE_INFINITY, 2.0f, Float.POSITIVE_INFINITY), "fma(+Inf,2,+Inf)");
+
+            Asserts.assertEquals(0.0f, fma_float(-0.0f, 0.0f, 0.0f), "fma(-0,+0,+0)");
+            Asserts.assertTrue(Float.floatToRawIntBits(fma_float(-0.0f, 0.0f, 0.0f)) == Float.floatToRawIntBits(0.0f),
+                    "fma(-0,+0,+0) should be +0.0");
+
+            for (int i = 0; i < 2000; i++) {
+                float a = (random.nextFloat() - 0.5f) * 1.0e4f;
+                float b = (random.nextFloat() - 0.5f) * 1.0e4f;
+                float c = (random.nextFloat() - 0.5f) * 1.0e4f;
+                Asserts.assertEquals(fma_float_verified(a, b, c), fma_float(a, b, c), "fma(" + a + "," + b + "," + c + ")");
+            }
+            for (int i = 0; i < 2000; i++) {
+                float a = (random.nextFloat() - 0.5f) * 1.0e3f;
+                float b = (random.nextFloat() - 0.5f) * 1.0e3f;
+                float c = -(a * b) + (random.nextFloat() - 0.5f) * 1.0e-3f;
+                Asserts.assertEquals(fma_float_verified(a, b, c), fma_float(a, b, c), "fma_cancel(" + a + "," + b + "," + c + ")");
+            }
+        }
+
+        public static double fma_double(double a, double b, double c) {
+            return Math.fma(a, b, c);
+        }
+
+        // Not in the compileonly list, so this stays interpreted: the JLS-authoritative
+        // reference implementation, independent of Jeandle's intrinsic lowering.
+        public static double fma_double_verified(double a, double b, double c) {
+            return Math.fma(a, b, c);
+        }
+
+        public static float fma_float(float a, float b, float c) {
+            return Math.fma(a, b, c);
+        }
+
+        public static float fma_float_verified(float a, float b, float c) {
+            return Math.fma(a, b, c);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestFpMinMax.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestFpMinMax.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @key randomness
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @summary Test the intrinsics implementation of Math/StrictMath.min|max(float,float) and (double,double)
+ * @library /test/lib /
+ * @run main/othervm compiler.jeandle.intrinsic.TestFpMinMax
+ */
+
+package compiler.jeandle.intrinsic;
+
+import compiler.jeandle.fileCheck.FileCheck;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestFpMinMax {
+    public static void main(String[] args) throws Exception {
+        String dumpPath = Files.createTempDirectory("jeandle_fp_min_max").toString();
+
+        ArrayList<String> commandArgs = new ArrayList<>(List.of(
+                "-Xbatch",
+                "-XX:-TieredCompilation",
+                "-XX:+UseJeandleCompiler",
+                "-Xcomp",
+                "-Xlog:jeandle=debug",
+                "-XX:+JeandleDumpIR",
+                "-XX:JeandleDumpDirectory=" + dumpPath,
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::min_float",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::max_float",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::min_double",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::max_double",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::min_float_strict",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::max_float_strict",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::min_double_strict",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::max_double_strict",
+                TestWrapper.class.getName()));
+
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(commandArgs);
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+
+        output.shouldHaveExitValue(0)
+              .shouldContain("Method `static jfloat java.lang.Math.min(jfloat, jfloat)` is parsed as intrinsic")
+              .shouldContain("Method `static jfloat java.lang.Math.max(jfloat, jfloat)` is parsed as intrinsic")
+              .shouldContain("Method `static jdouble java.lang.Math.min(jdouble, jdouble)` is parsed as intrinsic")
+              .shouldContain("Method `static jdouble java.lang.Math.max(jdouble, jdouble)` is parsed as intrinsic")
+              .shouldContain("Method `static jfloat java.lang.StrictMath.min(jfloat, jfloat)` is parsed as intrinsic")
+              .shouldContain("Method `static jfloat java.lang.StrictMath.max(jfloat, jfloat)` is parsed as intrinsic")
+              .shouldContain("Method `static jdouble java.lang.StrictMath.min(jdouble, jdouble)` is parsed as intrinsic")
+              .shouldContain("Method `static jdouble java.lang.StrictMath.max(jdouble, jdouble)` is parsed as intrinsic");
+
+        // Verify the llvm intrinsic is used for each variant.
+        FileCheck minFloatCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("min_float", float.class, float.class), false);
+        minFloatCheck.checkPattern("call float @llvm.minimum.f32");
+
+        FileCheck maxFloatCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("max_float", float.class, float.class), false);
+        maxFloatCheck.checkPattern("call float @llvm.maximum.f32");
+
+        FileCheck minDoubleCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("min_double", double.class, double.class), false);
+        minDoubleCheck.checkPattern("call double @llvm.minimum.f64");
+
+        FileCheck maxDoubleCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("max_double", double.class, double.class), false);
+        maxDoubleCheck.checkPattern("call double @llvm.maximum.f64");
+
+        FileCheck minFloatStrictCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("min_float_strict", float.class, float.class), false);
+        minFloatStrictCheck.checkPattern("call float @llvm.minimum.f32");
+
+        FileCheck maxFloatStrictCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("max_float_strict", float.class, float.class), false);
+        maxFloatStrictCheck.checkPattern("call float @llvm.maximum.f32");
+
+        FileCheck minDoubleStrictCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("min_double_strict", double.class, double.class), false);
+        minDoubleStrictCheck.checkPattern("call double @llvm.minimum.f64");
+
+        FileCheck maxDoubleStrictCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("max_double_strict", double.class, double.class), false);
+        maxDoubleStrictCheck.checkPattern("call double @llvm.maximum.f64");
+    }
+
+    static class TestWrapper {
+        static final float  DUMMY1 = Math.min(0.0f, 0.0f);       // force load java.lang.Math
+        static final double DUMMY2 = StrictMath.min(0.0d, 0.0d); // force load java.lang.StrictMath
+
+        public static void main(String[] args) {
+            var random = Utils.getRandomInstance();
+
+            // ---- float ----
+
+            // NaN propagates regardless of argument position.
+            Asserts.assertEquals(Float.NaN, min_float(Float.NaN, 1.0f), "min(NaN,1.0)");
+            Asserts.assertEquals(Float.NaN, min_float(1.0f, Float.NaN), "min(1.0,NaN)");
+            Asserts.assertEquals(Float.NaN, min_float(Float.NaN, Float.NaN), "min(NaN,NaN)");
+            Asserts.assertEquals(Float.NaN, max_float(Float.NaN, 1.0f), "max(NaN,1.0)");
+            Asserts.assertEquals(Float.NaN, max_float(1.0f, Float.NaN), "max(1.0,NaN)");
+            Asserts.assertEquals(Float.NaN, max_float(Float.NaN, Float.NaN), "max(NaN,NaN)");
+
+            // Signed zero: -0.0 is strictly smaller than +0.0.
+            Asserts.assertEquals(0.0f, min_float(0.0f, 0.0f), "min(+0,+0)");
+            Asserts.assertEquals(-0.0f, min_float(0.0f, -0.0f), "min(+0,-0)");
+            Asserts.assertEquals(-0.0f, min_float(-0.0f, 0.0f), "min(-0,+0)");
+            Asserts.assertEquals(-0.0f, min_float(-0.0f, -0.0f), "min(-0,-0)");
+            Asserts.assertEquals(0.0f, max_float(0.0f, 0.0f), "max(+0,+0)");
+            Asserts.assertEquals(0.0f, max_float(0.0f, -0.0f), "max(+0,-0)");
+            Asserts.assertEquals(0.0f, max_float(-0.0f, 0.0f), "max(-0,+0)");
+            Asserts.assertEquals(-0.0f, max_float(-0.0f, -0.0f), "max(-0,-0)");
+            // Explicit raw-bits check for the sign of the zero result.
+            Asserts.assertTrue(Float.floatToRawIntBits(min_float(0.0f, -0.0f)) == Float.floatToRawIntBits(-0.0f),
+                    "min(+0,-0) should be -0.0");
+            Asserts.assertTrue(Float.floatToRawIntBits(max_float(0.0f, -0.0f)) == Float.floatToRawIntBits(0.0f),
+                    "max(+0,-0) should be +0.0");
+
+            // Infinity
+            Asserts.assertEquals(1.0f, min_float(Float.POSITIVE_INFINITY, 1.0f), "min(+Inf,1.0)");
+            Asserts.assertEquals(Float.NEGATIVE_INFINITY, min_float(Float.NEGATIVE_INFINITY, 1.0f), "min(-Inf,1.0)");
+            Asserts.assertEquals(Float.POSITIVE_INFINITY, max_float(Float.POSITIVE_INFINITY, 1.0f), "max(+Inf,1.0)");
+            Asserts.assertEquals(1.0f, max_float(Float.NEGATIVE_INFINITY, 1.0f), "max(-Inf,1.0)");
+            Asserts.assertEquals(Float.NEGATIVE_INFINITY, min_float(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY), "min(+Inf,-Inf)");
+            Asserts.assertEquals(Float.POSITIVE_INFINITY, max_float(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY), "max(+Inf,-Inf)");
+
+            // StrictMath shares Math's exact semantics.
+            Asserts.assertEquals(Float.NaN, min_float_strict(Float.NaN, 1.0f), "strictMin(NaN,1.0)");
+            Asserts.assertEquals(-0.0f, min_float_strict(0.0f, -0.0f), "strictMin(+0,-0)");
+            Asserts.assertEquals(0.0f, max_float_strict(0.0f, -0.0f), "strictMax(+0,-0)");
+
+            // Random values (never exactly zero/NaN/Inf, so a plain comparison is a valid reference)
+            for (int i = 0; i < 2000; i++) {
+                float x = (random.nextFloat() - 0.5f) * 2000.0f;
+                float y = (random.nextFloat() - 0.5f) * 2000.0f;
+                float expectedMin = (x <= y) ? x : y;
+                float expectedMax = (x >= y) ? x : y;
+                Asserts.assertEquals(expectedMin, min_float(x, y), "min(" + x + "," + y + ")");
+                Asserts.assertEquals(expectedMax, max_float(x, y), "max(" + x + "," + y + ")");
+                Asserts.assertEquals(expectedMin, min_float_strict(x, y), "strictMin(" + x + "," + y + ")");
+                Asserts.assertEquals(expectedMax, max_float_strict(x, y), "strictMax(" + x + "," + y + ")");
+            }
+
+            // ---- double ----
+
+            // NaN propagates regardless of argument position.
+            Asserts.assertEquals(Double.NaN, min_double(Double.NaN, 1.0d), "min(NaN,1.0)");
+            Asserts.assertEquals(Double.NaN, min_double(1.0d, Double.NaN), "min(1.0,NaN)");
+            Asserts.assertEquals(Double.NaN, min_double(Double.NaN, Double.NaN), "min(NaN,NaN)");
+            Asserts.assertEquals(Double.NaN, max_double(Double.NaN, 1.0d), "max(NaN,1.0)");
+            Asserts.assertEquals(Double.NaN, max_double(1.0d, Double.NaN), "max(1.0,NaN)");
+            Asserts.assertEquals(Double.NaN, max_double(Double.NaN, Double.NaN), "max(NaN,NaN)");
+
+            // Signed zero: -0.0 is strictly smaller than +0.0.
+            Asserts.assertEquals(0.0d, min_double(0.0d, 0.0d), "min(+0,+0)");
+            Asserts.assertEquals(-0.0d, min_double(0.0d, -0.0d), "min(+0,-0)");
+            Asserts.assertEquals(-0.0d, min_double(-0.0d, 0.0d), "min(-0,+0)");
+            Asserts.assertEquals(-0.0d, min_double(-0.0d, -0.0d), "min(-0,-0)");
+            Asserts.assertEquals(0.0d, max_double(0.0d, 0.0d), "max(+0,+0)");
+            Asserts.assertEquals(0.0d, max_double(0.0d, -0.0d), "max(+0,-0)");
+            Asserts.assertEquals(0.0d, max_double(-0.0d, 0.0d), "max(-0,+0)");
+            Asserts.assertEquals(-0.0d, max_double(-0.0d, -0.0d), "max(-0,-0)");
+            // Explicit raw-bits check for the sign of the zero result.
+            Asserts.assertTrue(Double.doubleToRawLongBits(min_double(0.0d, -0.0d)) == Double.doubleToRawLongBits(-0.0d),
+                    "min(+0,-0) should be -0.0");
+            Asserts.assertTrue(Double.doubleToRawLongBits(max_double(0.0d, -0.0d)) == Double.doubleToRawLongBits(0.0d),
+                    "max(+0,-0) should be +0.0");
+
+            // Infinity
+            Asserts.assertEquals(1.0d, min_double(Double.POSITIVE_INFINITY, 1.0d), "min(+Inf,1.0)");
+            Asserts.assertEquals(Double.NEGATIVE_INFINITY, min_double(Double.NEGATIVE_INFINITY, 1.0d), "min(-Inf,1.0)");
+            Asserts.assertEquals(Double.POSITIVE_INFINITY, max_double(Double.POSITIVE_INFINITY, 1.0d), "max(+Inf,1.0)");
+            Asserts.assertEquals(1.0d, max_double(Double.NEGATIVE_INFINITY, 1.0d), "max(-Inf,1.0)");
+            Asserts.assertEquals(Double.NEGATIVE_INFINITY, min_double(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY), "min(+Inf,-Inf)");
+            Asserts.assertEquals(Double.POSITIVE_INFINITY, max_double(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY), "max(+Inf,-Inf)");
+
+            // StrictMath shares Math's exact semantics.
+            Asserts.assertEquals(Double.NaN, min_double_strict(Double.NaN, 1.0d), "strictMin(NaN,1.0)");
+            Asserts.assertEquals(-0.0d, min_double_strict(0.0d, -0.0d), "strictMin(+0,-0)");
+            Asserts.assertEquals(0.0d, max_double_strict(0.0d, -0.0d), "strictMax(+0,-0)");
+
+            // Random values (never exactly zero/NaN/Inf, so a plain comparison is a valid reference)
+            for (int i = 0; i < 2000; i++) {
+                double x = (random.nextDouble() - 0.5d) * 2000.0d;
+                double y = (random.nextDouble() - 0.5d) * 2000.0d;
+                double expectedMin = (x <= y) ? x : y;
+                double expectedMax = (x >= y) ? x : y;
+                Asserts.assertEquals(expectedMin, min_double(x, y), "min(" + x + "," + y + ")");
+                Asserts.assertEquals(expectedMax, max_double(x, y), "max(" + x + "," + y + ")");
+                Asserts.assertEquals(expectedMin, min_double_strict(x, y), "strictMin(" + x + "," + y + ")");
+                Asserts.assertEquals(expectedMax, max_double_strict(x, y), "strictMax(" + x + "," + y + ")");
+            }
+        }
+
+        public static float min_float(float a, float b) {
+            return Math.min(a, b);
+        }
+
+        public static float max_float(float a, float b) {
+            return Math.max(a, b);
+        }
+
+        public static double min_double(double a, double b) {
+            return Math.min(a, b);
+        }
+
+        public static double max_double(double a, double b) {
+            return Math.max(a, b);
+        }
+
+        public static float min_float_strict(float a, float b) {
+            return StrictMath.min(a, b);
+        }
+
+        public static float max_float_strict(float a, float b) {
+            return StrictMath.max(a, b);
+        }
+
+        public static double min_double_strict(double a, double b) {
+            return StrictMath.min(a, b);
+        }
+
+        public static double max_double_strict(double a, double b) {
+            return StrictMath.max(a, b);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestMinMax.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestMinMax.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @key randomness
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @summary Test the intrinsics implementation of Math/StrictMath.min|max(int,int)
+ * @library /test/lib /
+ * @run main/othervm compiler.jeandle.intrinsic.TestMinMax
+ */
+
+package compiler.jeandle.intrinsic;
+
+import compiler.jeandle.fileCheck.FileCheck;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestMinMax {
+    public static void main(String[] args) throws Exception {
+        String dumpPath = Files.createTempDirectory("jeandle_min_max").toString();
+
+        ArrayList<String> commandArgs = new ArrayList<>(List.of(
+                "-Xbatch",
+                "-XX:-TieredCompilation",
+                "-XX:+UseJeandleCompiler",
+                "-Xcomp",
+                "-Xlog:jeandle=debug",
+                "-XX:+JeandleDumpIR",
+                "-XX:JeandleDumpDirectory=" + dumpPath,
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::min_int",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::max_int",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::min_int_strict",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::max_int_strict",
+                TestWrapper.class.getName()));
+
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(commandArgs);
+        OutputAnalyzer output = ProcessTools.executeCommand(pb);
+
+        output.shouldHaveExitValue(0)
+              .shouldContain("Method `static jint java.lang.Math.min(jint, jint)` is parsed as intrinsic")
+              .shouldContain("Method `static jint java.lang.Math.max(jint, jint)` is parsed as intrinsic")
+              .shouldContain("Method `static jint java.lang.StrictMath.min(jint, jint)` is parsed as intrinsic")
+              .shouldContain("Method `static jint java.lang.StrictMath.max(jint, jint)` is parsed as intrinsic");
+
+        // Verify the llvm intrinsic is used for each variant.
+        FileCheck minCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("min_int", int.class, int.class), false);
+        minCheck.checkPattern("call i32 @llvm.smin.i32");
+
+        FileCheck maxCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("max_int", int.class, int.class), false);
+        maxCheck.checkPattern("call i32 @llvm.smax.i32");
+
+        FileCheck minStrictCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("min_int_strict", int.class, int.class), false);
+        minStrictCheck.checkPattern("call i32 @llvm.smin.i32");
+
+        FileCheck maxStrictCheck = new FileCheck(dumpPath, TestWrapper.class.getMethod("max_int_strict", int.class, int.class), false);
+        maxStrictCheck.checkPattern("call i32 @llvm.smax.i32");
+    }
+
+    static class TestWrapper {
+        static final int DUMMY1 = Math.min(0, 0);       // force load java.lang.Math
+        static final int DUMMY2 = StrictMath.min(0, 0); // force load java.lang.StrictMath
+
+        public static void main(String[] args) {
+            var random = Utils.getRandomInstance();
+
+            // Basic values
+            Asserts.assertEquals(3, min_int(3, 5), "min(3,5)");
+            Asserts.assertEquals(5, max_int(3, 5), "max(3,5)");
+            Asserts.assertEquals(-5, min_int(-3, -5), "min(-3,-5)");
+            Asserts.assertEquals(-3, max_int(-3, -5), "max(-3,-5)");
+            Asserts.assertEquals(-3, min_int(-3, 5), "min(-3,5)");
+            Asserts.assertEquals(5, max_int(-3, 5), "max(-3,5)");
+
+            // Equal values
+            Asserts.assertEquals(5, min_int(5, 5), "min(5,5)");
+            Asserts.assertEquals(5, max_int(5, 5), "max(5,5)");
+
+            // Zero
+            Asserts.assertEquals(0, min_int(0, 0), "min(0,0)");
+            Asserts.assertEquals(-1, min_int(0, -1), "min(0,-1)");
+            Asserts.assertEquals(0, max_int(0, -1), "max(0,-1)");
+
+            // Boundary values
+            Asserts.assertEquals(Integer.MIN_VALUE, min_int(Integer.MIN_VALUE, Integer.MAX_VALUE), "min(MIN,MAX)");
+            Asserts.assertEquals(Integer.MAX_VALUE, max_int(Integer.MIN_VALUE, Integer.MAX_VALUE), "max(MIN,MAX)");
+            Asserts.assertEquals(Integer.MIN_VALUE, min_int(Integer.MIN_VALUE, Integer.MIN_VALUE), "min(MIN,MIN)");
+            Asserts.assertEquals(Integer.MAX_VALUE, max_int(Integer.MAX_VALUE, Integer.MAX_VALUE), "max(MAX,MAX)");
+
+            // StrictMath variants share the exact same semantics as Math for ints.
+            Asserts.assertEquals(3, min_int_strict(3, 5), "strictMin(3,5)");
+            Asserts.assertEquals(5, max_int_strict(3, 5), "strictMax(3,5)");
+            Asserts.assertEquals(Integer.MIN_VALUE, min_int_strict(Integer.MIN_VALUE, Integer.MAX_VALUE), "strictMin(MIN,MAX)");
+            Asserts.assertEquals(Integer.MAX_VALUE, max_int_strict(Integer.MIN_VALUE, Integer.MAX_VALUE), "strictMax(MIN,MAX)");
+
+            // Random values
+            for (int i = 0; i < 2000; i++) {
+                int x = random.nextInt();
+                int y = random.nextInt();
+                int expectedMin = (x <= y) ? x : y;
+                int expectedMax = (x >= y) ? x : y;
+                Asserts.assertEquals(expectedMin, min_int(x, y), "min(" + x + "," + y + ")");
+                Asserts.assertEquals(expectedMax, max_int(x, y), "max(" + x + "," + y + ")");
+                Asserts.assertEquals(expectedMin, min_int_strict(x, y), "strictMin(" + x + "," + y + ")");
+                Asserts.assertEquals(expectedMax, max_int_strict(x, y), "strictMax(" + x + "," + y + ")");
+            }
+        }
+
+        public static int min_int(int a, int b) {
+            return Math.min(a, b);
+        }
+
+        public static int max_int(int a, int b) {
+            return Math.max(a, b);
+        }
+
+        public static int min_int_strict(int a, int b) {
+            return StrictMath.min(a, b);
+        }
+
+        public static int max_int_strict(int a, int b) {
+            return StrictMath.max(a, b);
+        }
+    }
+}


### PR DESCRIPTION
## Related issue(s)

issue #547

## What this PR does / why we need it

Jeandle did not lower Math/StrictMath min/max or Math.fma directly, so
these methods depended on the normal call/inlining path instead of
emitting the expected LLVM IR at intrinsic lowering time.

This adds direct Jeandle intrinsic lowering for:

- Math/StrictMath.min|max(int,int) via llvm.smin/llvm.smax
- Math/StrictMath.min|max(float,float) and (double,double) via
  llvm.minimum/llvm.maximum
- Math.fma(double,double,double) and (float,float,float) via llvm.fma

## Approach

- All 14 intrinsics map 1:1 onto the existing emit_llvm_builtin()
  helper (pop args per signature, emit the llvm.* call, push the
  result), the same pattern already used for dabs/fabs/dsqrt etc., so
  no new per-intrinsic handler methods are needed.
- llvm.smin/smax are used for the int variants: Math and StrictMath
  share the same vmIntrinsics ID space and identical (bit-for-bit)
  semantics for integers, since strictfp has no effect on integer ops.
- llvm.minimum/maximum are used for the float/double variants because
  they implement IEEE-754-2019 minimum/maximum (NaN propagates, -0.0 is
  strictly less than +0.0), which is exactly the Math.{min,max} javadoc
  contract - unlike llvm.minnum/maxnum (IEEE 754-2008, non-NaN operand
  wins) which would be wrong here.
- llvm.fma is used for both fma variants: it is always a correctly
  rounded, single-rounding fused multiply-add (never silently
  contracted into separate mul+add like llvm.fmuladd would allow),
  matching the Math.fma javadoc contract.
- No new cpu_supports_*() gate was added for fma. min/max never need
  CPU-feature gating (smin/smax/minimum/maximum always lower to a
  compare+select/cmov sequence, never a libcall). fma already gets a
  UseFMA check from the existing shared
  vmIntrinsics::is_disabled_by_flags(), which try_lower_intrinsic()
  consults right after is_supported() - so a target without hardware
  FMA is rejected there regardless of what is_supported() returns.

## Test

Added compiler/jeandle/intrinsic/TestMinMax.java,
TestFpMinMax.java and TestFma.java, following the existing FileCheck +
functional-correctness pattern in that directory. Coverage includes
NaN propagation, all four signed-zero combinations, +/-Infinity, the
fma special cases from the Math.fma javadoc (including the
fma(-0.0,+0.0,+0.0) vs plain-multiply divergence), and randomized
fuzzing (including near-cancellation triples for fma) checked against
the interpreter's own Math/StrictMath implementation.

Verified: the 3 new tests pass, and the full compiler/jeandle/ jtreg
suite (~189 tests) shows no regressions - the only errors observed are
pre-existing environment gaps unrelated to this change (native
test-image not built, and a couple of tests needing more than the
default 120s timeout under this fastdebug build).

Signed-off-by: Hongxu Wang <wanghongxu2001@163.com>