### PR TITLE
fix: handle null operands for unresolved type checks

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -2367,9 +2367,7 @@ void JeandleAbstractInterpreter::checkcast() {
   ciKlass* ci_super_klass = _bytecodes.get_klass(will_link);
 
   if (!will_link) {
-    uncommon_trap(Deoptimization::Reason_unloaded,
-                  Deoptimization::Action_reinterpret);
-    _block->set(JeandleBasicBlock::always_uncommon_trap);
+    null_assert(obj);
     return;
   }
 
@@ -2404,9 +2402,9 @@ void JeandleAbstractInterpreter::instanceof(int klass_index) {
   ciKlass* ci_super_klass = _bytecodes.get_klass(will_link);
 
   if (!will_link) {
-    uncommon_trap(Deoptimization::Reason_unloaded,
-                  Deoptimization::Action_reinterpret);
-    _block->set(JeandleBasicBlock::always_uncommon_trap);
+    null_assert(obj);
+    _jvm->apop(); // Object was already fetched by raw_peek().
+    _jvm->ipush(JeandleType::int_const(_ir_builder, 0));
     return;
   }
 
@@ -3674,6 +3672,29 @@ void JeandleAbstractInterpreter::null_check(llvm::Value* obj) {
 
   _ir_builder.SetInsertPoint(null_check_pass);
   _block->set_tail_llvm_block(null_check_pass);
+}
+
+void JeandleAbstractInterpreter::null_assert(llvm::Value* obj) {
+  assert(obj->getType() == llvm::PointerType::get(*_context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), "must be a java object");
+
+  int cur_bci = _bytecodes.cur_bci();
+  llvm::BasicBlock* null_assert_pass = llvm::BasicBlock::Create(*_context,
+                                                                 "bci_" + std::to_string(cur_bci) + "_null_assert_pass",
+                                                                 _llvm_func);
+  llvm::BasicBlock* null_assert_fail = llvm::BasicBlock::Create(*_context,
+                                                                 "bci_" + std::to_string(cur_bci) + "_null_assert_fail",
+                                                                 _llvm_func);
+  llvm::Value* is_null = _ir_builder.CreateIsNull(obj);
+  _ir_builder.CreateCondBr(is_null, null_assert_pass, null_assert_fail);
+
+  // The type-flow path says the operand must be null, so only an unexpected
+  // non-null value deoptimizes and makes this compilation not entrant.
+  uncommon_trap(Deoptimization::Reason_null_assert,
+                Deoptimization::Action_make_not_entrant,
+                null_assert_fail);
+
+  _ir_builder.SetInsertPoint(null_assert_pass);
+  _block->set_tail_llvm_block(null_assert_pass);
 }
 
 void JeandleAbstractInterpreter::zero_check(llvm::Value* divisor) {

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -485,7 +485,12 @@ class JeandleAbstractInterpreter : public StackObj {
   void monitorenter();
   void monitorexit();
 
+  // Assert that an object is non-null: continue on the non-null path and
+  // route the null path to the null-check failure handler.
   void null_check(llvm::Value* obj);
+  // Assert that an object is null: keep the null path and deoptimize the
+  // unexpected non-null path.
+  void null_assert(llvm::Value* obj);
 
   void zero_check(llvm::Value* divisor);
 

--- a/test/hotspot/jtreg/compiler/jeandle/TestNullAssert.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestNullAssert.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @summary Test that checkcast and instanceof on null do not trigger an uncommon trap
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -Xbatch -XX:-TieredCompilation -XX:+UseJeandleCompiler
+ *      -XX:CompileCommand=compileonly,TestNullAssert::checkcastNull
+ *      -XX:CompileCommand=compileonly,TestNullAssert::instanceofNull
+ *      TestNullAssert
+ */
+
+import java.lang.reflect.Method;
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+public class TestNullAssert {
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static final int COMP_LEVEL_FULL_OPTIMIZATION = 4;
+
+    public static void main(String[] args) throws Exception {
+        Asserts.assertFalse(WB.isClassAlive("UnloadedCheckcastTarget"));
+        Method checkcast = compile("checkcastNull");
+        Asserts.assertFalse(WB.isClassAlive("UnloadedCheckcastTarget"));
+
+        Asserts.assertTrue(checkcastNull(null) == null);
+        Asserts.assertTrue(WB.isMethodCompiled(checkcast),
+                "checkcast on null triggered an uncommon trap");
+
+        Asserts.assertFalse(WB.isClassAlive("UnloadedInstanceofTarget"));
+        Method instanceOf = compile("instanceofNull");
+        Asserts.assertFalse(WB.isClassAlive("UnloadedInstanceofTarget"));
+
+        Asserts.assertFalse(instanceofNull(null));
+        Asserts.assertTrue(WB.isMethodCompiled(instanceOf),
+                "instanceof on null triggered an uncommon trap");
+    }
+
+    private static Method compile(String name) throws Exception {
+        Method method = TestNullAssert.class.getDeclaredMethod(name, Object.class);
+        Asserts.assertTrue(WB.enqueueMethodForCompilation(method, COMP_LEVEL_FULL_OPTIMIZATION),
+                "failed to enqueue " + name + " for compilation");
+        while (!WB.isMethodCompiled(method)) {
+            Thread.onSpinWait();
+        }
+        return method;
+    }
+
+    private static Object checkcastNull(Object obj) {
+        return (UnloadedCheckcastTarget) obj;
+    }
+
+    private static boolean instanceofNull(Object obj) {
+        return obj instanceof UnloadedInstanceofTarget;
+    }
+}
+
+class UnloadedCheckcastTarget {
+}
+
+class UnloadedInstanceofTarget {
+}

--- a/test/hotspot/jtreg/compiler/jeandle/deoptimize/TestDeoptUnload.java
+++ b/test/hotspot/jtreg/compiler/jeandle/deoptimize/TestDeoptUnload.java
@@ -84,8 +84,10 @@ public class TestDeoptUnload {
         ));
 
         runTestHelper(commandPrefix, "testInvoke");
-        runTestHelper(commandPrefix, "testCheckCast");
-        runTestHelper(commandPrefix, "testInstanceof");
+        runTestHelper(commandPrefix, "testCheckCast", "testCheckCast",
+                "null_assert_or_unreached\\d+ make_not_entrant");
+        runTestHelper(commandPrefix, "testInstanceof", "testInstanceof",
+                "null_assert_or_unreached\\d+ make_not_entrant");
         runTestHelper(commandPrefix, "testLoadField");
         runTestHelper(commandPrefix, "testStoreField");
         runTestHelper(commandPrefix, "testNewInstance");
@@ -102,10 +104,15 @@ public class TestDeoptUnload {
     }
 
     public static void runTestHelper(ArrayList<String> commandPrefix, String testMethod) throws Exception {
-        runTestHelper(commandPrefix, testMethod, testMethod);
+        runTestHelper(commandPrefix, testMethod, testMethod, "unloaded reinterpret");
     }
 
     public static void runTestHelper(ArrayList<String> commandPrefix, String testMethod, String deoptMethod) throws Exception {
+        runTestHelper(commandPrefix, testMethod, deoptMethod, "unloaded reinterpret");
+    }
+
+    public static void runTestHelper(ArrayList<String> commandPrefix, String testMethod,
+                                     String deoptMethod, String deoptReasonAndAction) throws Exception {
         ArrayList<String> commandArgs = new ArrayList<>(commandPrefix);
         commandArgs.add(testMethod);
 
@@ -113,7 +120,7 @@ public class TestDeoptUnload {
         OutputAnalyzer output = ProcessTools.executeCommand(pb);
 
         output.shouldHaveExitValue(0);
-        output.shouldMatch("\\[debug\\]\\[deoptimization\\].*" + deoptMethod + ".*unloaded reinterpret");
+        output.shouldMatch("\\[debug\\]\\[deoptimization\\].*" + deoptMethod + ".*" + deoptReasonAndAction);
     }
 
     private static void testInvoke() {


### PR DESCRIPTION
## Related issue(s):

issue #556

## What this PR does / why we need it:

- Preserve the null path for checkcast and instanceof when the target class is unresolved
- Deoptimize only when the operand unexpectedly becomes non-null
- Add a regression test ensuring null operands do not trigger uncommon traps