### PR TITLE
fix: clear last_Java_sp/last_Java_pc on exception path in call_VM stub

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCallVM.cpp
+++ b/src/hotspot/share/jeandle/jeandleCallVM.cpp
@@ -83,6 +83,15 @@ void JeandleCallVM::generate_call_VM(const char* name, address routine_address, 
   call_routine_address->addFnAttr(id_attr);
   call_routine_address->addFnAttr(patch_bytes_attr);
 
+  // Clear the last_Java_sp and last_Java_pc before checking exceptions.
+  // This must be done on both the exception and no-exception paths to avoid
+  // stale values causing invalid stack walks during GC. See C2's GraphKit::gen_stub.
+  ir_builder.CreateStore(ir_builder.getInt64((intptr_t)nullptr), last_Java_sp_ptr);
+
+  llvm::Value* last_Java_pc_ptr = ir_builder.CreateIntToPtr(ir_builder.getInt64((uint64_t)JavaThread::last_Java_pc_offset()),
+                                                            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::TLSAddrSpace));
+  ir_builder.CreateStore(ir_builder.getInt64((intptr_t)nullptr), last_Java_pc_ptr);
+
   // Check exceptions.
   llvm::Value* pending_exception_addr = ir_builder.CreateIntToPtr(ir_builder.getInt64((uint64_t)Thread::pending_exception_offset()),
                                                                   llvm::PointerType::get(context, llvm::jeandle::AddrSpace::TLSAddrSpace));
@@ -116,14 +125,6 @@ void JeandleCallVM::generate_call_VM(const char* name, address routine_address, 
   }
 
   ir_builder.SetInsertPoint(no_exception_block);
-
-  // Clear the last_Java_sp.
-  ir_builder.CreateStore(ir_builder.getInt64((intptr_t)nullptr), last_Java_sp_ptr);
-
-  // Clear the last_Java_pc.
-  llvm::Value* last_Java_pc_ptr = ir_builder.CreateIntToPtr(ir_builder.getInt64((uint64_t)JavaThread::last_Java_pc_offset()),
-                                                            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::TLSAddrSpace));
-  ir_builder.CreateStore(ir_builder.getInt64((intptr_t)nullptr), last_Java_pc_ptr);
 
   // Return.
   if (func_type->getReturnType()->isVoidTy()) {


### PR DESCRIPTION
## Related issue
Fixes #483

## Summary
Move the clearing of `last_Java_sp` and `last_Java_pc` from `no_exception_block` to before the exception check in `JeandleCallVM::generate_call_VM`, so both the exception and no-exception paths clear these values. This prevents stale `last_Java_sp` from causing invalid stack walks during GC.

## Changes
- Move `last_Java_sp`/`last_Java_pc` clearing before the exception check (refer to C2's `GraphKit::gen_stub`).
- No functional change to the no-exception path; the exception path now also clears these values.

## Testing
Build verified on macOS aarch64. Full jeandle testing requires Linux environment with jeandle feature enabled.