### PR TITLE
feat: Late insertion for array's GC barrier

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -2896,11 +2896,10 @@ void JeandleAbstractInterpreter::do_array_load(BasicType basic_type) {
   }
 }
 
-llvm::Value* JeandleAbstractInterpreter::do_array_store_inner(BasicType basic_type, llvm::Type* store_type, llvm::Value* value) {
+void JeandleAbstractInterpreter::do_array_store_inner(BasicType basic_type, llvm::Type* store_type, llvm::Value* value) {
   llvm::Value* element_address = compute_array_element_address(basic_type, store_type);
   llvm::StoreInst* store_inst = _ir_builder.CreateStore(value, element_address);
   store_inst->setAtomic(llvm::AtomicOrdering::Unordered);
-  return element_address;
 }
 
 void JeandleAbstractInterpreter::do_array_store(BasicType basic_type) {
@@ -2946,18 +2945,13 @@ void JeandleAbstractInterpreter::do_array_store(BasicType basic_type) {
     }
     case T_OBJECT: {
       value = _jvm->apop();
-      llvm::Value* element_address;
+      llvm::Type* store_type = llvm::PointerType::get(*_context, UseCompressedOops
+          ? llvm::jeandle::AddrSpace::NarrowOopAddrSpace
+          : llvm::jeandle::AddrSpace::JavaHeapAddrSpace);
       if (UseCompressedOops) {
-        llvm::Type* store_type = llvm::PointerType::get(*_context, llvm::jeandle::AddrSpace::NarrowOopAddrSpace);
-        element_address = do_array_store_inner(T_OBJECT, store_type, _ir_builder.CreateAddrSpaceCast(value, store_type));
-      } else {
-        llvm::Type* store_type = llvm::PointerType::get(*_context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace);
-        element_address = do_array_store_inner(T_OBJECT, store_type, value);
+        value = _ir_builder.CreateAddrSpaceCast(value, store_type);
       }
-      // TODO: A workaround for card table barrier of array element, not to block the development progress.
-      // Currently, we can't get array type in LLVM pass. Once a clearer design is available, the barrier
-      // insertion operation will be moved to the LLVM pass.
-      call_java_op("jeandle.post_barrier", {element_address, value});
+      do_array_store_inner(T_OBJECT, store_type, value);
       break;
     }
     case T_BYTE: {

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -443,7 +443,7 @@ class JeandleAbstractInterpreter : public StackObj {
   void do_array_load(BasicType basic_type);
   void do_array_store(BasicType basic_type);
   llvm::Value* do_array_load_inner(BasicType basic_type, llvm::Type* load_type);
-  llvm::Value* do_array_store_inner(BasicType basic_type, llvm::Type* store_type, llvm::Value* value);
+  void do_array_store_inner(BasicType basic_type, llvm::Type* store_type, llvm::Value* value);
   void array_store_check(llvm::Value* value, llvm::Value* array_ref);
   llvm::Value* compute_array_element_address(BasicType basic_type, llvm::Type* type);
 


### PR DESCRIPTION
feat: Late insertion for array's GC barrier

## Related issue(s):

issue https://github.com/jeandle/jeandle-jdk/issues/464

## What this PR does / why we need it:

Remove array GC barrier insertion in `do_array_store`