### PR TITLE
feat: support profile-guided virtual call devirtualization

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -763,7 +763,7 @@ JeandleAbstractInterpreter::JeandleAbstractInterpreter(const JeandleParseContext
                                                        _parse_context(parse_context),
                                                        _method(parse_context.method()),
                                                        _profile(_method),
-                                                       _llvm_func(JeandleFuncSig::create_llvm_func(_method, target_module, entry_bci != InvocationEntryBci)),
+                                                       _llvm_func(JeandleFuncSig::create_llvm_func(_method, target_module, entry_bci)),
                                                        _entry_bci(entry_bci),
                                                        _context(&target_module.getContext()),
                                                        _bytecodes(_method),
@@ -2088,12 +2088,14 @@ void JeandleAbstractInterpreter::invoke() {
   // Decide call type and destination.
   JeandleCompiledCall::Type call_type = JeandleCompiledCall::NOT_A_CALL;
   address dest = nullptr;
+  bool is_opt_virtual_call = false;
   switch (bc) {
     case Bytecodes::_invokevirtual:  // fall through
     case Bytecodes::_invokeinterface: {
       if (target->can_be_statically_bound()) {
         call_type = JeandleCompiledCall::STATIC_CALL;
         dest = SharedRuntime::get_resolve_opt_virtual_call_stub();
+        is_opt_virtual_call = true;
       } else {
         call_type = JeandleCompiledCall::DYNAMIC_CALL;
         dest = SharedRuntime::get_resolve_virtual_call_stub();
@@ -2113,12 +2115,14 @@ void JeandleAbstractInterpreter::invoke() {
       } else {
         assert(target->can_be_statically_bound(), "sanity");
         dest = SharedRuntime::get_resolve_opt_virtual_call_stub();
+        is_opt_virtual_call = true;
       }
       break;
     }
     case Bytecodes::_invokespecial: {
       call_type = JeandleCompiledCall::STATIC_CALL;
       dest = SharedRuntime::get_resolve_opt_virtual_call_stub();
+      is_opt_virtual_call = true;
       break;
     }
     default: ShouldNotReachHere();
@@ -2163,6 +2167,12 @@ void JeandleAbstractInterpreter::invoke() {
   invoke->addFnAttr(patch_bytes_attr);
   invoke->addFnAttr(bc_attr);
   invoke->addFnAttr(declared_holder_attr);
+  if (is_opt_virtual_call) {
+    assert(receiver, "opt virtual call must have a receiver");
+    invoke->addParamAttr(0, llvm::Attribute::NoUndef);
+    invoke->addParamAttr(0, llvm::Attribute::get(
+        *_context, llvm::jeandle::Attribute::RuntimeLive));
+  }
   if (target->can_be_statically_bound()) {
     invoke->addFnAttr(llvm::Attribute::get(*_context,
                                             llvm::jeandle::Attribute::MonomorphicTarget));

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -2132,8 +2132,12 @@ void JeandleAbstractInterpreter::invoke() {
   assert(dest != nullptr, "legal destination");
 
   // Record this call.
+  ciInstanceKlass* declared_holder =
+      ciEnv::get_instance_klass_for_declared_method_holder(holder);
   uint32_t id = _compiled_code.next_statepoint_id();
-  _compiled_code.push_non_routine_call_site(new CallSiteInfo(call_type, dest, is_method_handle_invoke, id));
+  _compiled_code.push_non_routine_call_site(new CallSiteInfo(
+      call_type, dest, is_method_handle_invoke, id, _method, target,
+      declared_holder, _bytecodes.cur_bci(), static_cast<int>(bc)));
 
   // Every invoke instruction may throw exceptions, handle them here.
   DispatchedDest dispatched = dispatch_exception_for_invoke();
@@ -2162,7 +2166,7 @@ void JeandleAbstractInterpreter::invoke() {
                                                  Bytecodes::name(bc));
   llvm::Attribute declared_holder_attr = llvm::Attribute::get(*_context,
                                                  llvm::jeandle::Attribute::DeclaredHolder,
-                                                 std::to_string(reinterpret_cast<uintptr_t>(ciEnv::get_instance_klass_for_declared_method_holder(holder))));
+                                                 std::to_string(reinterpret_cast<uintptr_t>(declared_holder)));
   invoke->addFnAttr(id_attr);
   invoke->addFnAttr(patch_bytes_attr);
   invoke->addFnAttr(bc_attr);

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -261,7 +261,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                        _inline_tree_root(nullptr),
                                        _oops(),
                                        _oop_idx(0),
-                                        _code(env, method, entry_bci),
+                                       _code(env, method, entry_bci),
                                        _error_msg(nullptr),
                                        _has_monitors(false),
                                        _const_section_alignment(-1) {
@@ -432,9 +432,7 @@ bool JeandleCompilation::over_inlining_cutoff() const {
   }
 
   std::string root_name =
-      _entry_bci == InvocationEntryBci
-          ? JeandleFuncSig::method_name_with_signature(_method)
-          : JeandleFuncSig::osr_method_name_with_signature(_method, _entry_bci);
+      JeandleFuncSig::method_name_with_signature(_method, _entry_bci);
   llvm::Function* root = _llvm_module->getFunction(root_name);
   assert(root != nullptr, "root Java method function must exist");
 
@@ -1198,8 +1196,6 @@ void JeandleCompilation::print_inline_tree(outputStream* out) const {
   print_inline_tree_method(out, _inline_tree_root->method());
   out->cr();
   print_inline_tree_impl(out, _inline_tree_root, -1, "");
-  out->print_cr("Jeandle inline summary: nodes=%d, bytecodes=%u",
-                _inline_tree_root->count(), _inline_tree_root->count_inline_bcs());
 }
 
 void JeandleCompilation::dump_inline_data(outputStream* out) {
@@ -1247,9 +1243,7 @@ void JeandleCompilation::dump_inline_callee_replay_module() {
   std::unique_ptr<llvm::Module> replay_module = llvm::CloneModule(*_llvm_module);
   assert(replay_module != nullptr, "failed to clone inline callee replay module");
   std::string root_name =
-      _entry_bci == InvocationEntryBci
-          ? JeandleFuncSig::method_name_with_signature(_method)
-          : JeandleFuncSig::osr_method_name_with_signature(_method, _entry_bci);
+      JeandleFuncSig::method_name_with_signature(_method, _entry_bci);
 
   // Keep only non-root Java method bodies for replay. Calls inside those methods
   // may still reference helper/runtime declarations, so non-replay functions are

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -261,7 +261,7 @@ JeandleCompilation::JeandleCompilation(llvm::TargetMachine* target_machine,
                                        _inline_tree_root(nullptr),
                                        _oops(),
                                        _oop_idx(0),
-                                       _code(env, method, entry_bci != InvocationEntryBci),
+                                        _code(env, method, entry_bci),
                                        _error_msg(nullptr),
                                        _has_monitors(false),
                                        _const_section_alignment(-1) {
@@ -431,8 +431,10 @@ bool JeandleCompilation::over_inlining_cutoff() const {
     return true;
   }
 
-  std::string root_name = JeandleFuncSig::method_name_with_signature(
-      _method, is_osr_compilation());
+  std::string root_name =
+      _entry_bci == InvocationEntryBci
+          ? JeandleFuncSig::method_name_with_signature(_method)
+          : JeandleFuncSig::osr_method_name_with_signature(_method, _entry_bci);
   llvm::Function* root = _llvm_module->getFunction(root_name);
   assert(root != nullptr, "root Java method function must exist");
 
@@ -1196,6 +1198,8 @@ void JeandleCompilation::print_inline_tree(outputStream* out) const {
   print_inline_tree_method(out, _inline_tree_root->method());
   out->cr();
   print_inline_tree_impl(out, _inline_tree_root, -1, "");
+  out->print_cr("Jeandle inline summary: nodes=%d, bytecodes=%u",
+                _inline_tree_root->count(), _inline_tree_root->count_inline_bcs());
 }
 
 void JeandleCompilation::dump_inline_data(outputStream* out) {
@@ -1242,7 +1246,10 @@ void JeandleCompilation::dump_inline_callee_replay_module() {
   assert(_llvm_module != nullptr, "llvm module must exist");
   std::unique_ptr<llvm::Module> replay_module = llvm::CloneModule(*_llvm_module);
   assert(replay_module != nullptr, "failed to clone inline callee replay module");
-  std::string root_name = JeandleFuncSig::method_name_with_signature(_method, is_osr_compilation());
+  std::string root_name =
+      _entry_bci == InvocationEntryBci
+          ? JeandleFuncSig::method_name_with_signature(_method)
+          : JeandleFuncSig::osr_method_name_with_signature(_method, _entry_bci);
 
   // Keep only non-root Java method bodies for replay. Calls inside those methods
   // may still reference helper/runtime declarations, so non-replay functions are

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -156,7 +156,7 @@ class JeandleCompiledCode : public StackObj {
   // For compiled Java methods.
   JeandleCompiledCode(ciEnv* env,
                       ciMethod* method,
-                      bool is_osr_entry) :
+                       int entry_bci) :
                       _obj(nullptr),
                       _elf(nullptr),
                       _code_buffer("JeandleCompiledCode"),
@@ -174,7 +174,9 @@ class JeandleCompiledCode : public StackObj {
                       _env(env),
                       _method(method),
                       _routine_entry(nullptr),
-                      _func_name(JeandleFuncSig::method_name_with_signature(_method, is_osr_entry)),
+                       _func_name(entry_bci == InvocationEntryBci
+                                      ? JeandleFuncSig::method_name_with_signature(_method)
+                                      : JeandleFuncSig::osr_method_name_with_signature(_method, entry_bci)),
                       _orig_pc_slot(nullptr),
                       _orig_pc_offset_in_bytes(-1),
                       _interpreter_frame_size_in_bytes(0),

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -50,6 +50,7 @@
 #include "runtime/sharedRuntime.hpp"
 
 class JeandleReloc;
+class ciInstanceKlass;
 
 using llvm::jeandle::DeoptValueEncoding;
 
@@ -80,17 +81,32 @@ class CallSiteInfo : public JeandleCompilationResourceObj {
   CallSiteInfo(JeandleCompiledCall::Type type,
                address target,
                bool is_method_handle_invoke = false,
-               uint64_t statepoint_id = llvm::StatepointDirectives::DefaultStatepointID) :
+               uint64_t statepoint_id = llvm::StatepointDirectives::DefaultStatepointID,
+               ciMethod* caller = nullptr,
+               ciMethod* callee = nullptr,
+               ciInstanceKlass* declared_holder = nullptr,
+               int bci = -1,
+               int bytecode = -1) :
                _type(type),
                _target(target),
                _is_method_handle_invoke(is_method_handle_invoke),
-               _statepoint_id(statepoint_id) {
+               _statepoint_id(statepoint_id),
+               _caller(caller),
+               _callee(callee),
+               _declared_holder(declared_holder),
+               _bci(bci),
+               _bytecode(bytecode) {
 #ifdef ASSERT
     // We don't need to assign a unique statepoint id for each routine call site, only call type and target is used.
     bool use_default_statepoint_id = (statepoint_id == llvm::StatepointDirectives::DefaultStatepointID);
     bool is_routine_call = (type == JeandleCompiledCall::ROUTINE_CALL);
     bool is_external_call = (type == JeandleCompiledCall::EXTERNAL_CALL);
     assert(use_default_statepoint_id == (is_routine_call || is_external_call), "routine calls and external calls should use the default statepoint id");
+    bool has_java_call_context = caller != nullptr;
+    assert(has_java_call_context ==
+               (callee != nullptr && declared_holder != nullptr && bci >= 0 &&
+                bytecode >= 0),
+           "Java call-site context must be complete");
 #endif // ASSERT
   }
 
@@ -101,6 +117,12 @@ class CallSiteInfo : public JeandleCompilationResourceObj {
   address target() const { return _target; }
   void set_target(address target) { _target = target; }
   bool is_method_handle_invoke() const { return _is_method_handle_invoke; }
+  bool has_java_call_context() const { return _caller != nullptr; }
+  ciMethod* caller() const { return _caller; }
+  ciMethod* callee() const { return _callee; }
+  ciInstanceKlass* declared_holder() const { return _declared_holder; }
+  int bci() const { return _bci; }
+  int bytecode() const { return _bytecode; }
 
  private:
   JeandleCompiledCall::Type _type;
@@ -109,6 +131,15 @@ class CallSiteInfo : public JeandleCompilationResourceObj {
 
   // Used to distinguish each call site in stackmaps.
   uint64_t _statepoint_id;
+
+  // Profile queries use the statepoint id to recover the Java call context.
+  // Keeping this context in CallSiteInfo avoids duplicating it in VM callback
+  // arguments and remains valid when LLVM clones a call site during inlining.
+  ciMethod* _caller;
+  ciMethod* _callee;
+  ciInstanceKlass* _declared_holder;
+  int _bci;
+  int _bytecode;
 };
 
 class JeandleStackMap : public JeandleCompilationResourceObj {
@@ -156,7 +187,7 @@ class JeandleCompiledCode : public StackObj {
   // For compiled Java methods.
   JeandleCompiledCode(ciEnv* env,
                       ciMethod* method,
-                       int entry_bci) :
+                      int entry_bci) :
                       _obj(nullptr),
                       _elf(nullptr),
                       _code_buffer("JeandleCompiledCode"),
@@ -174,9 +205,8 @@ class JeandleCompiledCode : public StackObj {
                       _env(env),
                       _method(method),
                       _routine_entry(nullptr),
-                       _func_name(entry_bci == InvocationEntryBci
-                                      ? JeandleFuncSig::method_name_with_signature(_method)
-                                      : JeandleFuncSig::osr_method_name_with_signature(_method, entry_bci)),
+                      _func_name(JeandleFuncSig::method_name_with_signature(
+                          _method, entry_bci)),
                       _orig_pc_slot(nullptr),
                       _orig_pc_offset_in_bytes(-1),
                       _interpreter_frame_size_in_bytes(0),
@@ -211,12 +241,20 @@ class JeandleCompiledCode : public StackObj {
 
   void push_non_routine_call_site(CallSiteInfo* call_site) { _non_routine_call_sites.push_back(call_site); }
   uint64_t next_statepoint_id() { return _non_routine_call_sites.size(); }
-  int64_t duplicate_non_routine_call_site(uint64_t old_statepoint_id) {
-    assert(old_statepoint_id < _non_routine_call_sites.size(), "old statepoint id must exist");
-    CallSiteInfo* old_call_site = _non_routine_call_sites[old_statepoint_id];
-    assert(old_call_site != nullptr, "non-routine call site must exist");
-    assert(old_call_site->statepoint_id() == old_statepoint_id,
+  CallSiteInfo* non_routine_call_site_at(uint64_t statepoint_id) const {
+    if (statepoint_id >= _non_routine_call_sites.size()) {
+      return nullptr;
+    }
+    CallSiteInfo* call_site = _non_routine_call_sites[statepoint_id];
+    assert(call_site != nullptr, "non-routine call site must exist");
+    assert(call_site->statepoint_id() == statepoint_id,
            "statepoint id must match its call-site index");
+    return call_site;
+  }
+  int64_t duplicate_non_routine_call_site(uint64_t old_statepoint_id) {
+    CallSiteInfo* old_call_site =
+        non_routine_call_site_at(old_statepoint_id);
+    assert(old_call_site != nullptr, "old statepoint id must exist");
 
     // LLVM may duplicate an inlined call site. Keep the stackmap contract that
     // a non-routine statepoint id directly indexes _non_routine_call_sites.
@@ -224,7 +262,12 @@ class JeandleCompiledCode : public StackObj {
     push_non_routine_call_site(new CallSiteInfo(old_call_site->type(),
                                                 old_call_site->target(),
                                                 old_call_site->is_method_handle_invoke(),
-                                                new_statepoint_id));
+                                                new_statepoint_id,
+                                                old_call_site->caller(),
+                                                old_call_site->callee(),
+                                                old_call_site->declared_holder(),
+                                                old_call_site->bci(),
+                                                old_call_site->bytecode()));
     return static_cast<int64_t>(new_statepoint_id);
   }
   llvm::SmallVector<CallSiteInfo*>& non_routine_call_sites() { return _non_routine_call_sites; }

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -46,7 +46,8 @@ bool JeandleProfile::is_mature() const {
   return _mdo != nullptr && _mdo->is_mature();
 }
 
-bool JeandleProfile::has_trap_at(int bci, Deoptimization::DeoptReason reason) const {
+bool JeandleProfile::has_trap_at(
+    int bci, Deoptimization::DeoptReason reason) const {
   if (_mdo == nullptr) {
     return false;
   }
@@ -56,24 +57,31 @@ bool JeandleProfile::has_trap_at(int bci, Deoptimization::DeoptReason reason) co
   return _mdo->has_trap_at(bci, nullptr, reason) != 0;
 }
 
-bool JeandleProfile::has_too_many_traps(Deoptimization::DeoptReason reason) const {
+bool JeandleProfile::has_too_many_traps(
+    Deoptimization::DeoptReason reason) const {
   if (_mdo == nullptr || _mdo->is_empty()) {
     return false;
   }
-  return _mdo->trap_count(reason) >= Deoptimization::per_method_trap_limit(reason);
+  return _mdo->trap_count(reason) >=
+         Deoptimization::per_method_trap_limit(reason);
 }
 
-bool JeandleProfile::has_too_many_recompiles(int bci, Deoptimization::DeoptReason reason) const {
+bool JeandleProfile::has_too_many_recompiles(
+    int bci, Deoptimization::DeoptReason reason) const {
   if (_mdo == nullptr || _mdo->is_empty()) {
     return false;
   }
 
-  uint bc_cutoff = (uint) PerBytecodeRecompilationCutoff / 8;
-  uint method_cutoff = (uint) PerMethodRecompilationCutoff / 2 + 1;
-  Deoptimization::DeoptReason per_bc_reason = Deoptimization::reason_recorded_per_bytecode_if_any(reason);
-  ciMethod* trap_method = Deoptimization::reason_is_speculate(reason) ? _method : nullptr;
+  uint bc_cutoff = static_cast<uint>(PerBytecodeRecompilationCutoff) / 8;
+  uint method_cutoff =
+      static_cast<uint>(PerMethodRecompilationCutoff) / 2 + 1;
+  Deoptimization::DeoptReason per_bc_reason =
+      Deoptimization::reason_recorded_per_bytecode_if_any(reason);
+  ciMethod* trap_method =
+      Deoptimization::reason_is_speculate(reason) ? _method : nullptr;
 
-  if ((per_bc_reason == Deoptimization::Reason_none || _mdo->has_trap_at(bci, trap_method, reason) != 0) &&
+  if ((per_bc_reason == Deoptimization::Reason_none ||
+       _mdo->has_trap_at(bci, trap_method, reason) != 0) &&
       _mdo->trap_recompiled_at(bci, trap_method) &&
       _mdo->overflow_recompile_count() >= bc_cutoff) {
     return true;
@@ -111,11 +119,10 @@ static ciMethod* resolve_profile_virtual_target(ciMethod* caller,
   return callee->resolve_invoke(caller->holder(), receiver_klass);
 }
 
-JeandleProfileDevirtualizationInfo JeandleProfile::devirtualization_at(
+JeandleProfile::DevirtualizationInfo JeandleProfile::devirtualization_at(
     ciMethod* callee, ciInstanceKlass* holder, int bci) const {
   if (_method == nullptr || callee == nullptr || holder == nullptr ||
-      callee->can_be_statically_bound() || !is_mature() || !UseTypeProfile ||
-      !UseJeandleCompiler ||
+      !is_mature() || !UseTypeProfile || !UseJeandleCompiler ||
       !JeandleUseProfiledVirtualCallDevirtualization) {
     return {};
   }
@@ -129,8 +136,9 @@ JeandleProfileDevirtualizationInfo JeandleProfile::devirtualization_at(
   int64_t receiver_count = call_profile.receiver_count(0);
   int64_t total_count = call_profile.count();
   int morphism = call_profile.morphism();
-  bool has_major_receiver = 100.0 * call_profile.receiver_prob(0) >=
-                            (float)TypeProfileMajorReceiverPercent;
+  bool has_major_receiver =
+      100.0 * call_profile.receiver_prob(0) >=
+      static_cast<float>(TypeProfileMajorReceiverPercent);
   bool bimorphic_candidate = morphism == 2 && UseBimorphicInlining;
   if (morphism != 1 && !has_major_receiver && !bimorphic_candidate) {
     return {};

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -22,9 +22,17 @@
 #include "jeandle/jeandle_globals.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "ci/ciCallProfile.hpp"
+#include "ci/ciEnv.hpp"
+#include "ci/ciInstanceKlass.hpp"
+#include "ci/ciKlass.hpp"
 #include "ci/ciMethod.hpp"
 #include "ci/ciMethodData.hpp"
+#include "ci/ciSymbols.hpp"
+#include "logging/log.hpp"
 #include "oops/methodData.hpp"
+#include "opto/c2_globals.hpp"
+#include "runtime/globals.hpp"
 
 JeandleProfile::JeandleProfile(ciMethod* method)
   : _method(method),
@@ -36,6 +44,165 @@ bool JeandleProfile::has_profile() const {
 
 bool JeandleProfile::is_mature() const {
   return _mdo != nullptr && _mdo->is_mature();
+}
+
+bool JeandleProfile::has_trap_at(int bci, Deoptimization::DeoptReason reason) const {
+  if (_mdo == nullptr) {
+    return false;
+  }
+  // Treat the conservative "maybe trapped here" answer as a real trap for
+  // speculation gating. Metadata-only uses such as branch_weights do not need
+  // this guard; uncommon-trap/speculative transforms do.
+  return _mdo->has_trap_at(bci, nullptr, reason) != 0;
+}
+
+bool JeandleProfile::has_too_many_traps(Deoptimization::DeoptReason reason) const {
+  if (_mdo == nullptr || _mdo->is_empty()) {
+    return false;
+  }
+  return _mdo->trap_count(reason) >= Deoptimization::per_method_trap_limit(reason);
+}
+
+bool JeandleProfile::has_too_many_recompiles(int bci, Deoptimization::DeoptReason reason) const {
+  if (_mdo == nullptr || _mdo->is_empty()) {
+    return false;
+  }
+
+  uint bc_cutoff = (uint) PerBytecodeRecompilationCutoff / 8;
+  uint method_cutoff = (uint) PerMethodRecompilationCutoff / 2 + 1;
+  Deoptimization::DeoptReason per_bc_reason = Deoptimization::reason_recorded_per_bytecode_if_any(reason);
+  ciMethod* trap_method = Deoptimization::reason_is_speculate(reason) ? _method : nullptr;
+
+  if ((per_bc_reason == Deoptimization::Reason_none || _mdo->has_trap_at(bci, trap_method, reason) != 0) &&
+      _mdo->trap_recompiled_at(bci, trap_method) &&
+      _mdo->overflow_recompile_count() >= bc_cutoff) {
+    return true;
+  }
+
+  return _mdo->trap_count(reason) != 0 && _mdo->decompile_count() >= method_cutoff;
+}
+
+static ciMethod* resolve_profile_virtual_target(ciMethod* caller,
+                                                ciMethod* callee,
+                                                ciInstanceKlass* holder,
+                                                ciKlass* receiver) {
+  if (receiver == nullptr) {
+    return nullptr;
+  }
+
+  if (receiver->is_array_klass()) {
+    if (callee->holder() == ciEnv::current()->Object_klass() &&
+        callee->name() != ciSymbols::finalize_method_name()) {
+      return callee;
+    }
+    return nullptr;
+  }
+
+  if (!receiver->is_instance_klass()) {
+    return nullptr;
+  }
+
+  ciInstanceKlass* receiver_klass = receiver->as_instance_klass();
+  if (!receiver_klass->is_loaded() || !receiver_klass->is_initialized() ||
+      receiver_klass->is_interface() ||
+      !receiver_klass->is_subtype_of(holder)) {
+    return nullptr;
+  }
+  return callee->resolve_invoke(caller->holder(), receiver_klass);
+}
+
+JeandleProfileDevirtualizationInfo JeandleProfile::devirtualization_at(
+    ciMethod* callee, ciInstanceKlass* holder, int bci) const {
+  if (_method == nullptr || callee == nullptr || holder == nullptr ||
+      callee->can_be_statically_bound() || !is_mature() || !UseTypeProfile ||
+      !UseJeandleCompiler ||
+      !JeandleUseProfiledVirtualCallDevirtualization) {
+    return {};
+  }
+
+  ciCallProfile call_profile = _method->call_profile_at_bci(bci);
+  if (!call_profile.has_receiver(0) || call_profile.count() <= 0 ||
+      call_profile.receiver_count(0) <= 0) {
+    return {};
+  }
+
+  int64_t receiver_count = call_profile.receiver_count(0);
+  int64_t total_count = call_profile.count();
+  int morphism = call_profile.morphism();
+  bool has_major_receiver = 100.0 * call_profile.receiver_prob(0) >=
+                            (float)TypeProfileMajorReceiverPercent;
+  bool bimorphic_candidate = morphism == 2 && UseBimorphicInlining;
+  if (morphism != 1 && !has_major_receiver && !bimorphic_candidate) {
+    return {};
+  }
+
+  ciKlass* receiver = call_profile.receiver(0);
+  ciMethod* target =
+      resolve_profile_virtual_target(_method, callee, holder, receiver);
+  if (target == nullptr || target->is_abstract()) {
+    return {};
+  }
+
+  ciKlass* receiver2 = nullptr;
+  ciMethod* target2 = nullptr;
+  int64_t receiver_count2 = 0;
+  if (bimorphic_candidate) {
+    if (!call_profile.has_receiver(1) ||
+        call_profile.receiver_count(1) <= 0) {
+      if (!has_major_receiver) {
+        return {};
+      }
+    } else {
+      receiver2 = call_profile.receiver(1);
+      target2 =
+          resolve_profile_virtual_target(_method, callee, holder, receiver2);
+      if (target2 == nullptr || target2->is_abstract()) {
+        if (!has_major_receiver) {
+          return {};
+        }
+        receiver2 = nullptr;
+        target2 = nullptr;
+      } else {
+        receiver_count2 = call_profile.receiver_count(1);
+      }
+    }
+  }
+
+  Deoptimization::DeoptReason reason =
+      receiver2 == nullptr ? Deoptimization::Reason_class_check
+                           : Deoptimization::Reason_bimorphic;
+  bool too_many_traps_or_recompiles =
+      has_trap_at(bci, reason) || has_too_many_traps(reason) ||
+      has_too_many_recompiles(bci, reason);
+  // Match C2's hysteresis: an initial miss refreshes receiver profiling through
+  // deoptimization. Once the same BCI/reason has trapped, subsequent compiles
+  // keep the guarded fast path but select a dynamic virtual-call miss path.
+  bool deoptimize_on_miss =
+      (morphism == 1 || receiver2 != nullptr) && !too_many_traps_or_recompiles;
+
+  if (receiver2 == nullptr) {
+    log_debug(jeandle)("profile_devirt_candidate: caller=%s bci=%d receiver=%s "
+                       "target=%s count=" INT64_FORMAT " total=" INT64_FORMAT
+                       " morphism=%d miss=%s",
+                       _method->name()->as_utf8(), bci,
+                       receiver->name()->as_utf8(), target->name()->as_utf8(),
+                       receiver_count, total_count, morphism,
+                       deoptimize_on_miss ? "uncommon_trap" : "virtual_call");
+  } else {
+    log_debug(jeandle)(
+        "profile_devirt_candidate: caller=%s bci=%d receiver=%s "
+        "receiver2=%s target=%s target2=%s count=" INT64_FORMAT
+        " count2=" INT64_FORMAT " total=" INT64_FORMAT
+        " morphism=%d miss=%s",
+        _method->name()->as_utf8(), bci, receiver->name()->as_utf8(),
+        receiver2->name()->as_utf8(), target->name()->as_utf8(),
+        target2->name()->as_utf8(), receiver_count, receiver_count2,
+        total_count, morphism,
+        deoptimize_on_miss ? "uncommon_trap" : "virtual_call");
+  }
+
+  return {receiver, target, receiver_count, total_count, reason,
+          deoptimize_on_miss, receiver2, target2, receiver_count2};
 }
 
 // A branch/case count too large to fit in a signed int is treated as

--- a/src/hotspot/share/jeandle/jeandleProfile.hpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.hpp
@@ -35,21 +35,6 @@
 class ciInstanceKlass;
 class ciKlass;
 
-struct JeandleProfileDevirtualizationInfo {
-  ciKlass* receiver = nullptr;
-  ciMethod* target = nullptr;
-  int64_t receiver_count = 0;
-  int64_t total_count = 0;
-  Deoptimization::DeoptReason deopt_reason = Deoptimization::Reason_none;
-  bool deoptimize_on_miss = false;
-  ciKlass* receiver2 = nullptr;
-  ciMethod* target2 = nullptr;
-  int64_t receiver_count2 = 0;
-
-  bool is_valid() const { return receiver != nullptr && target != nullptr; }
-  bool is_bimorphic() const { return receiver2 != nullptr; }
-};
-
 // Read-only view of a method's MDO for the Jeandle JIT. Callers must treat
 // has_profile()==false as "emit the conservative shape", never as an error --
 // methods compiled under -Xcomp or never run interpreted will hit it.
@@ -57,7 +42,29 @@ class JeandleProfile : public StackObj {
   ciMethod*     _method;
   ciMethodData* _mdo;
 
+  // C2-compatible speculation failure gates. Keep them private so callers use
+  // devirtualization_at() as the single receiver-profile policy entry point.
+  bool has_trap_at(int bci, Deoptimization::DeoptReason reason) const;
+  bool has_too_many_traps(Deoptimization::DeoptReason reason) const;
+  bool has_too_many_recompiles(int bci,
+                               Deoptimization::DeoptReason reason) const;
+
  public:
+  struct DevirtualizationInfo {
+    ciKlass* receiver = nullptr;
+    ciMethod* target = nullptr;
+    int64_t receiver_count = 0;
+    int64_t total_count = 0;
+    Deoptimization::DeoptReason deopt_reason = Deoptimization::Reason_none;
+    bool deoptimize_on_miss = false;
+    ciKlass* receiver2 = nullptr;
+    ciMethod* target2 = nullptr;
+    int64_t receiver_count2 = 0;
+
+    bool is_valid() const { return receiver != nullptr && target != nullptr; }
+    bool is_bimorphic() const { return receiver2 != nullptr; }
+  };
+
   explicit JeandleProfile(ciMethod* method);
 
   bool has_profile() const;
@@ -66,13 +73,9 @@ class JeandleProfile : public StackObj {
   // transforms (unstable-if prune, guarded devirt) must gate on this.
   bool is_mature() const;
 
-  bool has_trap_at(int bci, Deoptimization::DeoptReason reason) const;
-  bool has_too_many_traps(Deoptimization::DeoptReason reason) const;
-  bool has_too_many_recompiles(int bci, Deoptimization::DeoptReason reason) const;
-
   // Single JDK-side entry point for receiver profile maturity, morphism,
   // target resolution, and speculative trap gating.
-  JeandleProfileDevirtualizationInfo devirtualization_at(
+  DevirtualizationInfo devirtualization_at(
       ciMethod* callee, ciInstanceKlass* holder, int bci) const;
 
   struct BranchCounts {

--- a/src/hotspot/share/jeandle/jeandleProfile.hpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.hpp
@@ -28,6 +28,27 @@
 #include "ci/ciMethod.hpp"
 #include "ci/ciMethodData.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/deoptimization.hpp"
+
+#include <cstdint>
+
+class ciInstanceKlass;
+class ciKlass;
+
+struct JeandleProfileDevirtualizationInfo {
+  ciKlass* receiver = nullptr;
+  ciMethod* target = nullptr;
+  int64_t receiver_count = 0;
+  int64_t total_count = 0;
+  Deoptimization::DeoptReason deopt_reason = Deoptimization::Reason_none;
+  bool deoptimize_on_miss = false;
+  ciKlass* receiver2 = nullptr;
+  ciMethod* target2 = nullptr;
+  int64_t receiver_count2 = 0;
+
+  bool is_valid() const { return receiver != nullptr && target != nullptr; }
+  bool is_bimorphic() const { return receiver2 != nullptr; }
+};
 
 // Read-only view of a method's MDO for the Jeandle JIT. Callers must treat
 // has_profile()==false as "emit the conservative shape", never as an error --
@@ -44,6 +65,15 @@ class JeandleProfile : public StackObj {
   // True when the MDO has enough samples to trust for speculation. Speculative
   // transforms (unstable-if prune, guarded devirt) must gate on this.
   bool is_mature() const;
+
+  bool has_trap_at(int bci, Deoptimization::DeoptReason reason) const;
+  bool has_too_many_traps(Deoptimization::DeoptReason reason) const;
+  bool has_too_many_recompiles(int bci, Deoptimization::DeoptReason reason) const;
+
+  // Single JDK-side entry point for receiver profile maturity, morphism,
+  // target resolution, and speculative trap gating.
+  JeandleProfileDevirtualizationInfo devirtualization_at(
+      ciMethod* callee, ciInstanceKlass* holder, int bci) const;
 
   struct BranchCounts {
     uint taken;

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -102,11 +102,11 @@ void attach_java_klass_ret_attr(llvm::CallBase* call,
   }
 }
 
-llvm::Function* JeandleFuncSig::create_llvm_func(ciMethod* method, llvm::Module& target_module, int entry_bci) {
+llvm::Function* JeandleFuncSig::create_llvm_func(ciMethod* method,
+                                                 llvm::Module& target_module,
+                                                 int entry_bci) {
   bool is_osr_entry = entry_bci != InvocationEntryBci;
-  std::string func_name = is_osr_entry
-                              ? osr_method_name_with_signature(method, entry_bci)
-                              : method_name_with_signature(method);
+  std::string func_name = method_name_with_signature(method, entry_bci);
 
   llvm::Function* existing = target_module.getFunction(func_name);
   if (existing != nullptr) {
@@ -218,20 +218,24 @@ std::string JeandleFuncSig::method_name(ciMethod* method) {
 }
 
 std::string JeandleFuncSig::method_name_with_signature(ciMethod* method) {
-  std::string signature = std::string(method->signature()->as_symbol()->as_utf8());
+  std::string signature =
+      std::string(method->signature()->as_symbol()->as_utf8());
   // A Java class is identified by both its defining class loader and its
-  // binary name.  Dynamically generated classes from different loaders may
+  // binary name. Dynamically generated classes from different loaders may
   // therefore have the same class/method/signature spelling while denoting
-  // different Methods.  Keep the readable spelling, but append the ciMethod
+  // different Methods. Keep the readable spelling, but append the ciMethod
   // identity used by the active compilation so every Java method gets a
   // distinct LLVM symbol in the module.
   return method_name(method) + signature + ".jeandle_method_" +
          std::to_string(reinterpret_cast<uintptr_t>(method));
 }
 
-std::string JeandleFuncSig::osr_method_name_with_signature(ciMethod* method, int entry_bci) {
-  assert(entry_bci != InvocationEntryBci, "OSR entry bci required");
-  return method_name_with_signature(method) + ".osr_" + std::to_string(entry_bci);
+std::string JeandleFuncSig::method_name_with_signature(ciMethod* method,
+                                                       int entry_bci) {
+  std::string name = method_name_with_signature(method);
+  return entry_bci == InvocationEntryBci
+             ? name
+             : name + ".osr_" + std::to_string(entry_bci);
 }
 
 bool is_jeandle_compiler_thread(Thread* t) {

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -102,8 +102,11 @@ void attach_java_klass_ret_attr(llvm::CallBase* call,
   }
 }
 
-llvm::Function* JeandleFuncSig::create_llvm_func(ciMethod* method, llvm::Module& target_module, bool is_osr_entry) {
-  std::string func_name = method_name_with_signature(method, is_osr_entry);
+llvm::Function* JeandleFuncSig::create_llvm_func(ciMethod* method, llvm::Module& target_module, int entry_bci) {
+  bool is_osr_entry = entry_bci != InvocationEntryBci;
+  std::string func_name = is_osr_entry
+                              ? osr_method_name_with_signature(method, entry_bci)
+                              : method_name_with_signature(method);
 
   llvm::Function* existing = target_module.getFunction(func_name);
   if (existing != nullptr) {
@@ -214,13 +217,21 @@ std::string JeandleFuncSig::method_name(ciMethod* method) {
   return class_name + "_" + method_name;
 }
 
-std::string JeandleFuncSig::method_name_with_signature(ciMethod* method, bool is_osr_entry) {
+std::string JeandleFuncSig::method_name_with_signature(ciMethod* method) {
   std::string signature = std::string(method->signature()->as_symbol()->as_utf8());
-  signature = method_name(method) + signature;
-  if (is_osr_entry) {
-    signature = "__jeandle_osr." + signature;
-  }
-  return signature;
+  // A Java class is identified by both its defining class loader and its
+  // binary name.  Dynamically generated classes from different loaders may
+  // therefore have the same class/method/signature spelling while denoting
+  // different Methods.  Keep the readable spelling, but append the ciMethod
+  // identity used by the active compilation so every Java method gets a
+  // distinct LLVM symbol in the module.
+  return method_name(method) + signature + ".jeandle_method_" +
+         std::to_string(reinterpret_cast<uintptr_t>(method));
+}
+
+std::string JeandleFuncSig::osr_method_name_with_signature(ciMethod* method, int entry_bci) {
+  assert(entry_bci != InvocationEntryBci, "OSR entry bci required");
+  return method_name_with_signature(method) + ".osr_" + std::to_string(entry_bci);
 }
 
 bool is_jeandle_compiler_thread(Thread* t) {

--- a/src/hotspot/share/jeandle/jeandleUtils.hpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.hpp
@@ -40,17 +40,19 @@ class SubtargetFeatures;
 class JeandleFuncSig : public AllStatic {
  public:
   // Create a llvm function according to the Java method.
-  static llvm::Function* create_llvm_func(ciMethod* method, llvm::Module& target_module, int entry_bci);
+  static llvm::Function* create_llvm_func(ciMethod* method,
+                                          llvm::Module& target_module,
+                                          int entry_bci);
   static std::string method_name(ciMethod* method);
   // Returns the unique LLVM symbol for a Java method. The symbol includes the
   // ciMethod identity because class/method/signature alone omits ClassLoader.
-  // TODO: Model Java method identity (name, ciMethod and function kind) in
-  // attributes and use it for lookup instead of encoding identity in symbols.
   static std::string method_name_with_signature(ciMethod* method);
-  // OSR and normal entries for one Java method have different LLVM signatures
-  // and must therefore use different symbols.
-  static std::string osr_method_name_with_signature(ciMethod* method, int entry_bci);
-  static void setup_description(llvm::Function* func, ciMethod* method, bool is_stub = false);
+  // Selects the normal symbol for InvocationEntryBci and an OSR-specific symbol
+  // otherwise. OSR and normal entries have different LLVM signatures.
+  static std::string method_name_with_signature(ciMethod* method,
+                                                int entry_bci);
+  static void setup_description(llvm::Function* func, ciMethod* method,
+                                bool is_stub = false);
 };
 
 // Check if a klass is an interface type that the bytecode verifier does not enforce.

--- a/src/hotspot/share/jeandle/jeandleUtils.hpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.hpp
@@ -40,9 +40,16 @@ class SubtargetFeatures;
 class JeandleFuncSig : public AllStatic {
  public:
   // Create a llvm function according to the Java method.
-  static llvm::Function* create_llvm_func(ciMethod* method, llvm::Module& target_module, bool is_osr_entry);
+  static llvm::Function* create_llvm_func(ciMethod* method, llvm::Module& target_module, int entry_bci);
   static std::string method_name(ciMethod* method);
-  static std::string method_name_with_signature(ciMethod* method, bool is_osr_entry = false);
+  // Returns the unique LLVM symbol for a Java method. The symbol includes the
+  // ciMethod identity because class/method/signature alone omits ClassLoader.
+  // TODO: Model Java method identity (name, ciMethod and function kind) in
+  // attributes and use it for lookup instead of encoding identity in symbols.
+  static std::string method_name_with_signature(ciMethod* method);
+  // OSR and normal entries for one Java method have different LLVM signatures
+  // and must therefore use different symbols.
+  static std::string osr_method_name_with_signature(ciMethod* method, int entry_bci);
   static void setup_description(llvm::Function* func, ciMethod* method, bool is_stub = false);
 };
 

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -23,6 +23,7 @@
 #include "llvm/IR/Jeandle/VMCallbackLog.h"
 #include "llvm/IR/Jeandle/InvokeType.h"
 #include "llvm/Transforms/Jeandle/CHADevirtualization.h"
+#include "llvm/Transforms/Jeandle/ProfileDevirtualization.h"
 
 #include "jeandle/jeandleAbstractInterpreter.hpp"
 #include "jeandle/jeandleCompilation.hpp"
@@ -30,6 +31,7 @@
 #include "jeandle/jeandleVMCallback.hpp"
 #include "jeandle/jeandleCompiledCall.hpp"
 #include "jeandle/jeandleCompiledCode.hpp"
+#include "jeandle/jeandleProfile.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciClassList.hpp"
@@ -45,6 +47,7 @@
 #include "ci/ciObject.hpp"
 #include "ci/ciType.hpp"
 #include "ci/ciUtilities.inline.hpp"
+#include "code/oopRecorder.hpp"
 #include "logging/log.hpp"
 #include "oops/fieldInfo.inline.hpp"
 #include "oops/fieldStreams.inline.hpp"
@@ -317,6 +320,10 @@ uintptr_t JeandleVMCallback::get_oop_klass(int oop_id) {
 // Inlining
 // ---------------------------------------------------------------------------
 
+std::string JeandleVMCallback::get_java_method_name(uintptr_t method) {
+  return JeandleFuncSig::method_name_with_signature(callback_method(method));
+}
+
 bool JeandleVMCallback::is_ok_to_inline(int scope_id, int bci, uintptr_t callee_method) {
   JeandleCompilation* comp = JeandleCompilation::current();
   assert(comp != nullptr, "Must be called in compile thread");
@@ -545,6 +552,66 @@ std::string JeandleVMCallback::get_cha_opt_info(uintptr_t caller_ptr, uintptr_t 
   return "";
 }
 
+static void record_profile_receiver(ciKlass* receiver) {
+  assert(receiver != nullptr, "profile receiver must be present");
+  ciEnv* env = ciEnv::current();
+  assert(env != nullptr && env->oop_recorder() != nullptr,
+         "profile devirtualization must run in an active compilation");
+  // LLVM embeds the Klass* value in the exact-receiver guard. Recording it in
+  // the nmethod metadata table lets class unloading discover the dependency
+  // and invalidate the nmethod before that address can be reused.
+  env->oop_recorder()->find_index(receiver->constant_encoding());
+}
+
+std::string JeandleVMCallback::get_profile_devirt_info(uintptr_t caller_ptr,
+                                                       uintptr_t callee_ptr,
+                                                       uintptr_t holder_ptr,
+                                                       int bci,
+                                                       int bytecode) {
+  if (caller_ptr == 0 || callee_ptr == 0 || holder_ptr == 0 || bci < 0) {
+    return "";
+  }
+
+  ciMethod* caller = reinterpret_cast<ciMethod*>(caller_ptr);
+  ciMethod* callee = reinterpret_cast<ciMethod*>(callee_ptr);
+  ciInstanceKlass* holder = reinterpret_cast<ciInstanceKlass*>(holder_ptr);
+
+  if (bytecode != llvm::jeandle::InvokeVirtual &&
+      bytecode != llvm::jeandle::InvokeInterface) {
+    return "";
+  }
+
+  JeandleProfileDevirtualizationInfo opt_info =
+      JeandleProfile(caller).devirtualization_at(callee, holder, bci);
+  if (!opt_info.is_valid()) {
+    return "";
+  }
+
+  record_profile_receiver(opt_info.receiver);
+  if (opt_info.receiver2 != nullptr) {
+    record_profile_receiver(opt_info.receiver2);
+  }
+
+  llvm::jeandle::ProfileDevirtInfo encoded_info;
+  encoded_info.ReceiverKlass = reinterpret_cast<uintptr_t>(
+      opt_info.receiver->constant_encoding());
+  encoded_info.TargetMethod = reinterpret_cast<uintptr_t>(opt_info.target);
+  encoded_info.Count = static_cast<uint64_t>(opt_info.receiver_count);
+  encoded_info.TotalCount = static_cast<uint64_t>(opt_info.total_count);
+  encoded_info.DeoptReason =
+      static_cast<llvm::jeandle::Deoptimization::DeoptReason>(
+          opt_info.deopt_reason);
+  encoded_info.DeoptimizeOnMiss = opt_info.deoptimize_on_miss;
+  encoded_info.ReceiverKlass2 =
+      !opt_info.is_bimorphic()
+          ? 0
+          : reinterpret_cast<uintptr_t>(
+                opt_info.receiver2->constant_encoding());
+  encoded_info.TargetMethod2 = reinterpret_cast<uintptr_t>(opt_info.target2);
+  encoded_info.Count2 = static_cast<uint64_t>(opt_info.receiver_count2);
+  return encoded_info.encode();
+}
+
 // Change a virtual callsite to opt virtual call site.
 bool JeandleVMCallback::update_to_static_opt_virtual_call(int64_t id) {
   JeandleCompilation* compilation = JeandleCompilation::current();
@@ -572,12 +639,14 @@ void JeandleVMCallback::register_callbacks() {
   callbacks.GetConstantFieldInfo = &JeandleVMCallback::get_constant_field_info;
   callbacks.GetOopHandleName = &JeandleVMCallback::get_oop_handle_name;
   callbacks.GetOopKlass = &JeandleVMCallback::get_oop_klass;
+  callbacks.GetJavaMethodName = &JeandleVMCallback::get_java_method_name;
   callbacks.GetInlineCalleeIR = &JeandleVMCallback::get_inline_callee_ir;
   callbacks.GetNewStatepointID = &JeandleVMCallback::get_new_statepoint_id;
   callbacks.IsOkToInline = &JeandleVMCallback::is_ok_to_inline;
   callbacks.RecordInlineResult = &JeandleVMCallback::record_inline_result;
   callbacks.RecordInliningComplete = &JeandleVMCallback::record_inlining_complete;
   callbacks.GetCHAOptInfo = &JeandleVMCallback::get_cha_opt_info;
+  callbacks.GetProfileDevirtInfo = &JeandleVMCallback::get_profile_devirt_info;
   callbacks.UpdateToStaticOptVirtualCall = &JeandleVMCallback::update_to_static_opt_virtual_call;
   llvm::jeandle::registerVMCallbacks(callbacks);
 

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -22,8 +22,8 @@
 #include "llvm/IR/Jeandle/VMCallback.h"
 #include "llvm/IR/Jeandle/VMCallbackLog.h"
 #include "llvm/IR/Jeandle/InvokeType.h"
+#include "llvm/IR/Jeandle/ProfileDevirtualizationInfo.h"
 #include "llvm/Transforms/Jeandle/CHADevirtualization.h"
-#include "llvm/Transforms/Jeandle/ProfileDevirtualization.h"
 
 #include "jeandle/jeandleAbstractInterpreter.hpp"
 #include "jeandle/jeandleCompilation.hpp"
@@ -49,6 +49,7 @@
 #include "ci/ciUtilities.inline.hpp"
 #include "code/oopRecorder.hpp"
 #include "logging/log.hpp"
+#include "interpreter/bytecodes.hpp"
 #include "oops/fieldInfo.inline.hpp"
 #include "oops/fieldStreams.inline.hpp"
 #include "oops/instanceMirrorKlass.hpp"
@@ -320,10 +321,6 @@ uintptr_t JeandleVMCallback::get_oop_klass(int oop_id) {
 // Inlining
 // ---------------------------------------------------------------------------
 
-std::string JeandleVMCallback::get_java_method_name(uintptr_t method) {
-  return JeandleFuncSig::method_name_with_signature(callback_method(method));
-}
-
 bool JeandleVMCallback::is_ok_to_inline(int scope_id, int bci, uintptr_t callee_method) {
   JeandleCompilation* comp = JeandleCompilation::current();
   assert(comp != nullptr, "Must be called in compile thread");
@@ -389,15 +386,6 @@ bool JeandleVMCallback::get_inline_callee_ir(uintptr_t callee_method) {
 
   resolved_func->setLinkage(llvm::GlobalValue::AvailableExternallyLinkage);
   return true;
-}
-
-int64_t JeandleVMCallback::get_new_statepoint_id(int64_t old_statepoint_id) {
-  JeandleCompilation* comp = JeandleCompilation::current();
-  assert(comp != nullptr, "Must be called in compile thread");
-  assert(old_statepoint_id >= 0, "old statepoint id must be non-negative");
-
-  return comp->compiled_code()->duplicate_non_routine_call_site(
-      static_cast<uint64_t>(old_statepoint_id));
 }
 
 bool JeandleVMCallback::record_inlining_complete() {
@@ -552,6 +540,10 @@ std::string JeandleVMCallback::get_cha_opt_info(uintptr_t caller_ptr, uintptr_t 
   return "";
 }
 
+// ---------------------------------------------------------------------------
+// Profile-guided devirtualization
+// ---------------------------------------------------------------------------
+
 static void record_profile_receiver(ciKlass* receiver) {
   assert(receiver != nullptr, "profile receiver must be present");
   ciEnv* env = ciEnv::current();
@@ -563,26 +555,34 @@ static void record_profile_receiver(ciKlass* receiver) {
   env->oop_recorder()->find_index(receiver->constant_encoding());
 }
 
-std::string JeandleVMCallback::get_profile_devirt_info(uintptr_t caller_ptr,
-                                                       uintptr_t callee_ptr,
-                                                       uintptr_t holder_ptr,
-                                                       int bci,
-                                                       int bytecode) {
-  if (caller_ptr == 0 || callee_ptr == 0 || holder_ptr == 0 || bci < 0) {
+std::string JeandleVMCallback::get_profile_devirtualization_info(
+    int64_t statepoint_id) {
+  if (statepoint_id < 0) {
     return "";
   }
 
-  ciMethod* caller = reinterpret_cast<ciMethod*>(caller_ptr);
-  ciMethod* callee = reinterpret_cast<ciMethod*>(callee_ptr);
-  ciInstanceKlass* holder = reinterpret_cast<ciInstanceKlass*>(holder_ptr);
-
-  if (bytecode != llvm::jeandle::InvokeVirtual &&
-      bytecode != llvm::jeandle::InvokeInterface) {
+  JeandleCompilation* compilation = JeandleCompilation::current();
+  assert(compilation != nullptr, "profile query requires an active compilation");
+  CallSiteInfo* call_site = compilation->compiled_code()
+                                ->non_routine_call_site_at(
+                                    static_cast<uint64_t>(statepoint_id));
+  if (call_site == nullptr || !call_site->has_java_call_context()) {
     return "";
   }
 
-  JeandleProfileDevirtualizationInfo opt_info =
-      JeandleProfile(caller).devirtualization_at(callee, holder, bci);
+  if (call_site->bytecode() != Bytecodes::_invokevirtual &&
+      call_site->bytecode() != Bytecodes::_invokeinterface) {
+    return "";
+  }
+  assert(call_site->type() == JeandleCompiledCall::DYNAMIC_CALL,
+         "profile devirtualization requires a virtual call site");
+  assert(!call_site->callee()->can_be_statically_bound(),
+         "statically bound calls are handled by the bytecode parser");
+
+  JeandleProfile::DevirtualizationInfo opt_info =
+      JeandleProfile(call_site->caller())
+          .devirtualization_at(call_site->callee(),
+                               call_site->declared_holder(), call_site->bci());
   if (!opt_info.is_valid()) {
     return "";
   }
@@ -592,7 +592,7 @@ std::string JeandleVMCallback::get_profile_devirt_info(uintptr_t caller_ptr,
     record_profile_receiver(opt_info.receiver2);
   }
 
-  llvm::jeandle::ProfileDevirtInfo encoded_info;
+  llvm::jeandle::ProfileDevirtualizationInfo encoded_info;
   encoded_info.ReceiverKlass = reinterpret_cast<uintptr_t>(
       opt_info.receiver->constant_encoding());
   encoded_info.TargetMethod = reinterpret_cast<uintptr_t>(opt_info.target);
@@ -609,7 +609,26 @@ std::string JeandleVMCallback::get_profile_devirt_info(uintptr_t caller_ptr,
                 opt_info.receiver2->constant_encoding());
   encoded_info.TargetMethod2 = reinterpret_cast<uintptr_t>(opt_info.target2);
   encoded_info.Count2 = static_cast<uint64_t>(opt_info.receiver_count2);
+  encoded_info.TargetMethodName =
+      JeandleFuncSig::method_name_with_signature(opt_info.target);
+  if (opt_info.target2 != nullptr) {
+    encoded_info.TargetMethodName2 =
+        JeandleFuncSig::method_name_with_signature(opt_info.target2);
+  }
   return encoded_info.encode();
+}
+
+// ---------------------------------------------------------------------------
+// Compiled call-site metadata
+// ---------------------------------------------------------------------------
+
+int64_t JeandleVMCallback::get_new_statepoint_id(int64_t old_statepoint_id) {
+  JeandleCompilation* comp = JeandleCompilation::current();
+  assert(comp != nullptr, "Must be called in compile thread");
+  assert(old_statepoint_id >= 0, "old statepoint id must be non-negative");
+
+  return comp->compiled_code()->duplicate_non_routine_call_site(
+      static_cast<uint64_t>(old_statepoint_id));
 }
 
 // Change a virtual callsite to opt virtual call site.
@@ -617,10 +636,17 @@ bool JeandleVMCallback::update_to_static_opt_virtual_call(int64_t id) {
   JeandleCompilation* compilation = JeandleCompilation::current();
   assert(compilation != nullptr, "no active compilation");
   JeandleCompiledCode* cc = compilation->compiled_code();
-  if (static_cast<size_t>(id) >= cc->non_routine_call_sites().size()) {
+  if (id < 0) {
     return false;
   }
-  CallSiteInfo* call_site = cc->non_routine_call_sites()[id];
+  CallSiteInfo* call_site =
+      cc->non_routine_call_site_at(static_cast<uint64_t>(id));
+  if (call_site == nullptr) {
+    return false;
+  }
+  // This callback updates only JDK installation metadata. LLVM owns the IR
+  // rewrite, while callback-log replay can reproduce it from the recorded
+  // return value without requiring a live CallSiteInfo.
   call_site->set_type(JeandleCompiledCall::STATIC_CALL);
   call_site->set_target(SharedRuntime::get_resolve_opt_virtual_call_stub());
   return true;
@@ -639,14 +665,14 @@ void JeandleVMCallback::register_callbacks() {
   callbacks.GetConstantFieldInfo = &JeandleVMCallback::get_constant_field_info;
   callbacks.GetOopHandleName = &JeandleVMCallback::get_oop_handle_name;
   callbacks.GetOopKlass = &JeandleVMCallback::get_oop_klass;
-  callbacks.GetJavaMethodName = &JeandleVMCallback::get_java_method_name;
   callbacks.GetInlineCalleeIR = &JeandleVMCallback::get_inline_callee_ir;
   callbacks.GetNewStatepointID = &JeandleVMCallback::get_new_statepoint_id;
   callbacks.IsOkToInline = &JeandleVMCallback::is_ok_to_inline;
   callbacks.RecordInlineResult = &JeandleVMCallback::record_inline_result;
   callbacks.RecordInliningComplete = &JeandleVMCallback::record_inlining_complete;
   callbacks.GetCHAOptInfo = &JeandleVMCallback::get_cha_opt_info;
-  callbacks.GetProfileDevirtInfo = &JeandleVMCallback::get_profile_devirt_info;
+  callbacks.GetProfileDevirtualizationInfo =
+      &JeandleVMCallback::get_profile_devirtualization_info;
   callbacks.UpdateToStaticOptVirtualCall = &JeandleVMCallback::update_to_static_opt_virtual_call;
   llvm::jeandle::registerVMCallbacks(callbacks);
 

--- a/src/hotspot/share/jeandle/jeandleVMCallback.hpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.hpp
@@ -56,9 +56,7 @@ class JeandleVMCallback : public AllStatic {
   static uintptr_t   get_oop_klass(int oop_id);
 
   // Inlining.
-  static std::string get_java_method_name(uintptr_t method);
   static bool      get_inline_callee_ir(uintptr_t callee_method);
-  static int64_t   get_new_statepoint_id(int64_t old_statepoint_id);
   static bool      is_ok_to_inline(int scope_id, int bci, uintptr_t callee_method);
   static bool      record_inline_result(int scope_id, int bci, uintptr_t callee_method, int result);
   static bool      record_inlining_complete();
@@ -67,10 +65,13 @@ class JeandleVMCallback : public AllStatic {
   static std::string get_cha_opt_info(uintptr_t caller_ptr, uintptr_t callee_ptr,
                                       uintptr_t holder_ptr, uintptr_t receiver_klass_ptr,
                                       bool is_exact, int bytecode);
-  static std::string get_profile_devirt_info(uintptr_t caller_ptr,
-                                             uintptr_t callee_ptr,
-                                             uintptr_t holder_ptr, int bci,
-                                             int bytecode);
+
+  // Profile-guided devirtualization.
+  static std::string get_profile_devirtualization_info(
+      int64_t statepoint_id);
+
+  // Compiled call-site metadata.
+  static int64_t get_new_statepoint_id(int64_t old_statepoint_id);
   static bool update_to_static_opt_virtual_call(int64_t id);
 
   // Replaces the now-removed ciEnv::get_instance_klass_for_klass: maps a raw

--- a/src/hotspot/share/jeandle/jeandleVMCallback.hpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.hpp
@@ -56,6 +56,7 @@ class JeandleVMCallback : public AllStatic {
   static uintptr_t   get_oop_klass(int oop_id);
 
   // Inlining.
+  static std::string get_java_method_name(uintptr_t method);
   static bool      get_inline_callee_ir(uintptr_t callee_method);
   static int64_t   get_new_statepoint_id(int64_t old_statepoint_id);
   static bool      is_ok_to_inline(int scope_id, int bci, uintptr_t callee_method);
@@ -66,6 +67,10 @@ class JeandleVMCallback : public AllStatic {
   static std::string get_cha_opt_info(uintptr_t caller_ptr, uintptr_t callee_ptr,
                                       uintptr_t holder_ptr, uintptr_t receiver_klass_ptr,
                                       bool is_exact, int bytecode);
+  static std::string get_profile_devirt_info(uintptr_t caller_ptr,
+                                             uintptr_t callee_ptr,
+                                             uintptr_t holder_ptr, int bci,
+                                             int bytecode);
   static bool update_to_static_opt_virtual_call(int64_t id);
 
   // Replaces the now-removed ciEnv::get_instance_klass_for_klass: maps a raw

--- a/src/hotspot/share/jeandle/jeandle_globals.hpp
+++ b/src/hotspot/share/jeandle/jeandle_globals.hpp
@@ -63,6 +63,10 @@
           "Use interpreter/C1 profile (MDO) for branch/switch weights, "    \
           "unstable-if branch pruning")                                     \
                                                                             \
+  product(bool, JeandleUseProfiledVirtualCallDevirtualization, true,        \
+          "Use receiver type profile to devirtualize "                       \
+          "invokevirtual/invokeinterface calls in Jeandle")                 \
+                                                                            \
   product(intx, JeandleNodeCountInliningCutoff, 18000,                      \
           "If root LLVM IR instruction count exceeds limit stop inlining."  \
           "This value roughly follows C2's cutoff today; tune it later"     \

--- a/src/hotspot/share/jeandle/templatemodule/template.ll
+++ b/src/hotspot/share/jeandle/templatemodule/template.ll
@@ -141,7 +141,7 @@ declare hotspotcc ptr addrspace(1) @jeandle.decode_heap_oop(ptr addrspace(3))
 declare hotspotcc ptr addrspace(3) @jeandle.encode_heap_oop(ptr addrspace(1))
 
 ; Load klass pointer from oop
-define hotspotcc ptr addrspace(0) @jeandle.load_klass(ptr addrspace(1) nocapture %oop) noinline "lower-phase"="0" #0 {
+define hotspotcc ptr addrspace(0) @jeandle.load_klass(ptr addrspace(1) nocapture %oop) noinline "lower-phase"="1" #0 {
   %klass_offset = load i32, ptr @oopDesc.klass_offset_in_bytes
   %klass_addr = getelementptr inbounds i8, ptr addrspace(1) %oop, i32 %klass_offset
 
@@ -156,6 +156,15 @@ compressed:
 uncompressed:
   %wide = load atomic ptr addrspace(0), ptr addrspace(1) %klass_addr unordered, align 8
   ret ptr addrspace(0) %wide
+}
+
+; Test whether a previously loaded dynamic Klass is exactly the expected Klass.
+; Profile devirtualization shares one phase-1 load across all exact checks for
+; a receiver. JavaType traces actual_klass back to that load for path-sensitive
+; type propagation before JavaOperationLower(1) expands both operations.
+define hotspotcc i1 @jeandle.check_exact_klass(ptr addrspace(0) nocapture %expected_klass, ptr addrspace(0) nocapture %actual_klass) noinline "lower-phase"="1" #0 {
+  %is_exact = icmp eq ptr addrspace(0) %actual_klass, %expected_klass
+  ret i1 %is_exact
 }
 
 ; This is the slow path for subtype checking when the fast path fails.

--- a/test/hotspot/jtreg/compiler/jeandle/TestProfileDevirtualizationClassLoader.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestProfileDevirtualizationClassLoader.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @summary Profile devirtualization must distinguish same-named methods from
+ *          different class loaders
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UseJeandleCompiler
+ *                   -XX:+JeandleUseProfiledVirtualCallDevirtualization
+ *                   -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,compiler.jeandle.TestProfileDevirtualizationClassLoader::profiledCall
+ *                   compiler.jeandle.TestProfileDevirtualizationClassLoader
+ */
+
+package compiler.jeandle;
+
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_FINAL;
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.ALOAD;
+import static jdk.internal.org.objectweb.asm.Opcodes.ICONST_1;
+import static jdk.internal.org.objectweb.asm.Opcodes.ICONST_2;
+import static jdk.internal.org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static jdk.internal.org.objectweb.asm.Opcodes.IRETURN;
+import static jdk.internal.org.objectweb.asm.Opcodes.RETURN;
+import static jdk.internal.org.objectweb.asm.Opcodes.V17;
+
+public class TestProfileDevirtualizationClassLoader {
+    private static final String TARGET_NAME =
+            "compiler.jeandle.generated.ProfileTarget";
+    private static final String TARGET_INTERNAL_NAME =
+            TARGET_NAME.replace('.', '/');
+    private static final String VALUE_INTERNAL_NAME =
+            Value.class.getName().replace('.', '/');
+
+    public interface Value {
+        int value();
+    }
+
+    private static final class ByteArrayLoader extends ClassLoader {
+        private final byte[] targetBytes;
+
+        ByteArrayLoader(byte[] targetBytes) {
+            super(TestProfileDevirtualizationClassLoader.class.getClassLoader());
+            this.targetBytes = targetBytes;
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (!TARGET_NAME.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return defineClass(name, targetBytes, 0, targetBytes.length);
+        }
+    }
+
+    private static int profiledCall(Value receiver) {
+        return receiver.value();
+    }
+
+    public static void main(String[] args) throws Exception {
+        Value first = newTarget(1);
+        Value second = newTarget(2);
+
+        if (first.getClass() == second.getClass() ||
+                first.getClass().getClassLoader() ==
+                        second.getClass().getClassLoader()) {
+            throw new AssertionError("test requires two defining class loaders");
+        }
+
+        int iterations = 20_000_000;
+        long actual = 0;
+        for (int i = 0; i < iterations; i++) {
+            actual += profiledCall((i & 1) == 0 ? first : second);
+        }
+
+        long expected = (long) iterations / 2 * 3;
+        if (actual != expected) {
+            throw new AssertionError("wrong result: expected=" + expected +
+                    ", actual=" + actual);
+        }
+    }
+
+    private static Value newTarget(int result) throws Exception {
+        Class<?> target = Class.forName(TARGET_NAME, true,
+                new ByteArrayLoader(generateTarget(result)));
+        return (Value) target.getDeclaredConstructor().newInstance();
+    }
+
+    private static byte[] generateTarget(int result) {
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS |
+                                             ClassWriter.COMPUTE_FRAMES);
+        writer.visit(V17, ACC_PUBLIC | ACC_FINAL, TARGET_INTERNAL_NAME, null,
+                "java/lang/Object", new String[] { VALUE_INTERNAL_NAME });
+
+        MethodVisitor init = writer.visitMethod(ACC_PUBLIC, "<init>", "()V",
+                null, null);
+        init.visitCode();
+        init.visitVarInsn(ALOAD, 0);
+        init.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>",
+                "()V", false);
+        init.visitInsn(RETURN);
+        init.visitMaxs(0, 0);
+        init.visitEnd();
+
+        MethodVisitor value = writer.visitMethod(ACC_PUBLIC, "value", "()I",
+                null, null);
+        value.visitCode();
+        value.visitInsn(result == 1 ? ICONST_1 : ICONST_2);
+        value.visitInsn(IRETURN);
+        value.visitMaxs(0, 0);
+        value.visitEnd();
+
+        writer.visitEnd();
+        return writer.toByteArray();
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds HotSpot-side support for profile-guided devirtualization of Jeandle `invokevirtual` and `invokeinterface` calls. HotSpot reads receiver profiles and resolves concrete Java targets, while the dependent LLVM pass performs the guarded IR transformations.

## Main changes

- Read mature receiver type profiles from the caller's MDO and select monomorphic or bimorphic candidates.
- Resolve concrete virtual targets and reject unloaded, uninitialized, abstract, or incompatible candidates.
- Use C2-style trap and recompilation limits to select either deoptimization or a virtual-call fallback for profile misses.
- Store the caller, callee, declared holder, BCI, and bytecode in `CallSiteInfo`, allowing LLVM to query a self-contained profile result using only the statepoint id, including for call sites cloned during inlining.
- Record profiled receiver klasses in the oop recorder so class unloading can invalidate dependent compiled code safely.
- Keep VM callbacks limited to runtime information and JDK call-site metadata; all LLVM IR and CFG changes remain in LLVM.
- Add `JeandleUseProfiledVirtualCallDevirtualization` to control the optimization.

## Correctness fixes

- Include the `ciMethod` identity in LLVM Java method symbols to distinguish same-named classes loaded by different class loaders.
- Add `.osr_<entry_bci>` to OSR function names so normal and OSR compilations cannot share one LLVM symbol.
- Mark the optimized-virtual receiver as `runtime-live` because the unresolved runtime stub may consume it even when the resolved Java target does not use `this`.

## Performance

Profile devirtualization was measured on 10 selected Renaissance benchmarks. Each OFF/ON configuration ran in a separate JVM for 10 repetitions, with the mean of iterations 5-9 reported. All 10 benchmarks improved, with a 20.1% geometric-mean speedup (`OFF / ON`) and a 15.0% time-weighted runtime reduction. Individual runtime reductions ranged from 6.7% to 43.0%, including `scala-kmeans` 43.0%, `finagle-http` 19.7%, `scrabble` 18.3%, and `gauss-mix` 16.3%.