### PR TITLE
fix: handle late predecessor VM state merges

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -184,6 +184,24 @@ bool JeandleVMState::update_phi_nodes(JeandleVMState* income_jvm, llvm::BasicBlo
   return true;
 }
 
+void JeandleVMState::invalidate_debug_only_locals(MethodLivenessResult raw_liveness) {
+  if (!raw_liveness.is_valid()) {
+    return;
+  }
+  assert((size_t)raw_liveness.size() == _locals.size(), "liveness size must match locals");
+
+  for (size_t i = 0; i < _locals.size(); ++i) {
+    if (raw_liveness.at(i) || _locals[i].is_null()) {
+      continue;
+    }
+
+    llvm::PHINode* phi_node = llvm::cast<llvm::PHINode>(_locals[i].value());
+    assert(phi_node->use_empty(), "debug-only local must be unused before block parsing");
+    phi_node->eraseFromParent();
+    invalidate_local(i);
+  }
+}
+
 // Stack operations:
 
 void JeandleVMState::push(BasicType type, llvm::Value* value) {
@@ -410,12 +428,24 @@ JeandleBasicBlock::JeandleBasicBlock(int block_id,
                                      _limit_bci(limit_bci),
                                      _reverse_post_order(-1),
                                      _jvm(nullptr),
+                                     _merged_predecessor_count(0),
                                      _predecessors(),
                                      _successors(),
                                      _header_llvm_block(header_llvm_block),
                                      _tail_llvm_block(header_llvm_block),
                                      _ci_block(ci_block),
                                      _initial_jvm(nullptr) {}
+
+bool JeandleBasicBlock::record_predecessor_merge(bool merged) {
+  // Handler incoming states are generated per throwing bytecode rather than
+  // per static CFG edge, and handler readiness is handled conservatively.
+  if (merged && !is_exception_handler()) {
+    assert(_merged_predecessor_count < _predecessors.size(),
+           "more successful predecessor merges than CFG predecessor edges");
+    ++_merged_predecessor_count;
+  }
+  return merged;
+}
 
 bool JeandleBasicBlock::merge_VM_state_from(JeandleVMState* vm_state, llvm::BasicBlock* incoming, ciMethod* method, bool is_osr) {
   if (_jvm == nullptr) {
@@ -435,24 +465,30 @@ bool JeandleBasicBlock::merge_VM_state_from(JeandleVMState* vm_state, llvm::Basi
       initialize_VM_state_from(vm_state, incoming, method->liveness_at_bci(_start_bci), is_osr);
     }
 
-    return true;
+    return record_predecessor_merge(true);
 
   } else if (!is_set(is_compiled) && !is_set(is_loop_header)) {
     assert(_predecessors.size() > 1 || is_exception_handler(), "more than one predecessors are needed for phi nodes");
-    return _jvm->update_phi_nodes(vm_state, incoming, is_osr);
-  } else if (is_set(is_loop_header)) {
+    return record_predecessor_merge(_jvm->update_phi_nodes(vm_state, incoming, is_osr));
+  } else if (is_set(is_loop_header) || _initial_jvm != nullptr) {
     if (_initial_jvm == nullptr) {
-      return _jvm->update_phi_nodes(vm_state, incoming, is_osr);
+      assert(is_set(is_loop_header), "only an uncompiled loop header can lack an initial VM state");
+      return record_predecessor_merge(_jvm->update_phi_nodes(vm_state, incoming, is_osr));
     }
-    assert(_initial_jvm != nullptr, "loop header initial JeandleVMState is needed");
-    return _initial_jvm->update_phi_nodes(vm_state, incoming, is_osr);
+    // The block may already have been compiled before all of its predecessors
+    // were visited. Update the PHIs in its saved entry state rather than the
+    // VM state mutated while interpreting the block.
+    return record_predecessor_merge(_initial_jvm->update_phi_nodes(vm_state, incoming, is_osr));
   }
 
   // Bad bytecodes.
   return false;
 }
 
-void JeandleBasicBlock::initialize_VM_state_from(JeandleVMState* incoming_state, llvm::BasicBlock* incoming_block, MethodLivenessResult liveness, bool is_osr) {
+void JeandleBasicBlock::initialize_VM_state_from(JeandleVMState* incoming_state,
+                                                 llvm::BasicBlock* incoming_block,
+                                                 MethodLivenessResult liveness,
+                                                 bool is_osr) {
   assert(_jvm == nullptr, "cannot initialize twice");
 
   llvm::IRBuilder<> ir_builder(_header_llvm_block);
@@ -1139,8 +1175,24 @@ void JeandleAbstractInterpreter::interpret_block(JeandleBasicBlock* block) {
     return;
   }
 
-  if (block->is_set(JeandleBasicBlock::is_loop_header)) {
-    // Copy loop header's initial JeandleVMState.
+  if (block->is_set(JeandleBasicBlock::is_loop_header) ||
+      block->is_exception_handler() ||
+      !block->is_ready()) {
+    // A local kept alive only for debugging is never read by bytecodes from
+    // this block. If an incoming edge can arrive after the block is parsed, its
+    // first value does not establish a stable LLVM PHI type. Keep the local
+    // unavailable instead of consulting another compiler's type-flow analysis.
+    _jvm->invalidate_debug_only_locals(_method->raw_liveness_at_bci(block->start_bci()));
+
+    // This follows C2's Parse::do_all_blocks(): loop headers and exception
+    // handlers always preserve their entry state, and a block that is not ready
+    // preserves it for late predecessor merges. C2 gates the readiness check
+    // with has_irreducible because ciTypeFlow models irreducible loops and its
+    // RPO guarantees that ordinary blocks in reducible control flow are ready.
+    // Jeandle builds a separate OSR-rooted CFG and does not model
+    // irreducibility, so check readiness directly. This may preserve an extra
+    // state for a dead or pruned predecessor, but does not delay parsing or
+    // affect correctness.
     block->set_initial_jvm(_jvm->copy());
   }
 
@@ -1666,12 +1718,18 @@ bool JeandleAbstractInterpreter::path_is_suitable_for_unstable_if_prune(
   return !too_many_traps(_method, bci, Deoptimization::Reason_unstable_if);
 }
 
-void JeandleAbstractInterpreter::do_if_branch(llvm::Value* cond) {
+void JeandleAbstractInterpreter::do_if_branch(llvm::Value* cond, unsigned operands) {
   int bci = _bytecodes.cur_bci();
   JeandleBasicBlock* taken_jbb = bci2block()[_bytecodes.get_dest()];
   JeandleBasicBlock* fallthrough_jbb = bci2block()[_bytecodes.next_bci()];
   llvm::BasicBlock* taken_block = taken_jbb->header_llvm_block();
   llvm::BasicBlock* fallthrough_block = fallthrough_jbb->header_llvm_block();
+  auto consume_operands = [&]() {
+    while (operands != 0) {
+      --operands;
+      _jvm->raw_pop();
+    }
+  };
 
   // Degenerate `if (cond) {}` where taken == fallthrough. BasicBlockBuilder
   // pushes the shared target into _successors twice, so the post-loop merge
@@ -1679,7 +1737,10 @@ void JeandleAbstractInterpreter::do_if_branch(llvm::Value* cond) {
   // skip branch weights and the unstable-if prune; !prof on a same-target CondBr trips a
   // verifier null-deref on LLVM 22 aarch64.
   if (taken_jbb == fallthrough_jbb) {
+    consume_operands();
     if (taken_jbb->is_exception_handler()) {
+      // The CondBr contributes two distinct CFG edges to the shared target.
+      merge_into_exception_handler(taken_jbb);
       merge_into_exception_handler(taken_jbb);
     }
     _ir_builder.CreateCondBr(cond, taken_block, fallthrough_block);
@@ -1687,18 +1748,14 @@ void JeandleAbstractInterpreter::do_if_branch(llvm::Value* cond) {
   }
 
   // Unstable-if prune: strict-zero one-side prune into uncommon_trap(Reason_unstable_if).
-  // Operands are still on the stack here -- if_* helpers defer the pop until
-  // after this returns so the trap deopt bundle sees pre-if state, same effect
-  // as C2's repush_if_args() without re-pushing.
+  // Operands are still on the stack here so the trap deopt bundle sees the
+  // pre-if state, same effect as C2's repush_if_args() without re-pushing.
   JeandleProfile::BranchCounts counts = _profile.branch_at(bci);
   if (path_is_suitable_for_unstable_if_prune(bci, counts)) {
     auto emit_pruned_branch = [&](JeandleBasicBlock* hot_jbb,
                                   llvm::BasicBlock* hot_block,
                                   bool cond_true_is_hot,
                                   JeandleBasicBlock* pruned_jbb) {
-      if (hot_jbb->is_exception_handler()) {
-        merge_into_exception_handler(hot_jbb);
-      }
       llvm::BasicBlock* trap_block =
           llvm::BasicBlock::Create(*_context, "unstable_if_trap", _llvm_func);
       llvm::BranchInst* br =
@@ -1715,6 +1772,10 @@ void JeandleAbstractInterpreter::do_if_branch(llvm::Value* cond) {
       // then the liveness info will be more accurate.
       uncommon_trap(Deoptimization::Reason_unstable_if,
                     Deoptimization::Action_reinterpret, trap_block);
+      consume_operands();
+      if (hot_jbb->is_exception_handler()) {
+        merge_into_exception_handler(hot_jbb);
+      }
       // Skip the pruned JBB in the post-loop successor merge; its preallocated
       // header_llvm_block is reclaimed by remove_dead_blocks.
       _pruned_successor = pruned_jbb;
@@ -1732,6 +1793,7 @@ void JeandleAbstractInterpreter::do_if_branch(llvm::Value* cond) {
     }
   }
 
+  consume_operands();
   if (taken_jbb->is_exception_handler()) {
     merge_into_exception_handler(taken_jbb);
   }
@@ -1749,8 +1811,7 @@ void JeandleAbstractInterpreter::if_zero(llvm::CmpInst::Predicate p) {
   // Peek (do not pop): a pruned uncommon_trap must see the operand on the stack.
   llvm::Value* v = _jvm->raw_peek(0).value();
   llvm::Value* cond = _ir_builder.CreateICmp(p, v, JeandleType::int_const(_ir_builder, 0));
-  do_if_branch(cond);
-  _jvm->ipop();
+  do_if_branch(cond, 1);
 }
 
 void JeandleAbstractInterpreter::if_icmp(llvm::CmpInst::Predicate p) {
@@ -1761,9 +1822,7 @@ void JeandleAbstractInterpreter::if_icmp(llvm::CmpInst::Predicate p) {
   llvm::Value* r = _jvm->raw_peek(0).value();
   llvm::Value* l = _jvm->raw_peek(1).value();
   llvm::Value* cond = _ir_builder.CreateICmp(p, l, r);
-  do_if_branch(cond);
-  _jvm->ipop();
-  _jvm->ipop();
+  do_if_branch(cond, 2);
 }
 
 void JeandleAbstractInterpreter::lcmp() {
@@ -1784,9 +1843,7 @@ void JeandleAbstractInterpreter::if_acmp(llvm::CmpInst::Predicate p) {
   llvm::Value* r = _jvm->raw_peek(0).value();
   llvm::Value* l = _jvm->raw_peek(1).value();
   llvm::Value* cond = _ir_builder.CreateICmp(p, l, r);
-  do_if_branch(cond);
-  _jvm->apop();
-  _jvm->apop();
+  do_if_branch(cond, 2);
 }
 
 void JeandleAbstractInterpreter::if_null(llvm::CmpInst::Predicate p) {
@@ -1796,8 +1853,7 @@ void JeandleAbstractInterpreter::if_null(llvm::CmpInst::Predicate p) {
   // Peek (do not pop): a pruned uncommon_trap must see the operand on the stack.
   llvm::Value* v = _jvm->raw_peek(0).value();
   llvm::Value* cond = _ir_builder.CreateICmp(p, v, llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(v->getType())));
-  do_if_branch(cond);
-  _jvm->apop();
+  do_if_branch(cond, 1);
 }
 
 /*

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -119,6 +119,7 @@ class JeandleVMState : public JeandleCompilationResourceObj {
   size_t max_locals() const { return _locals.size(); }
 
   void invalidate_local(int index) { _locals[index] = TypedValue::null_value(); }
+  void invalidate_debug_only_locals(MethodLivenessResult raw_liveness);
 
   llvm::Value* locals_at(int index) { return _locals[index].value(); }
   BasicType locals_type_at(int index) { return _locals[index].actual_type(); }
@@ -203,6 +204,13 @@ class JeandleBasicBlock : public JeandleCompilationResourceObj {
   JeandleVMState* VM_state() { return _jvm; }
   void set_VM_state(JeandleVMState* jvm) { _jvm = jvm; }
 
+  // A normal predecessor contributes one successful VM-state merge for each
+  // incoming CFG edge. Exception handlers are kept conservative because their
+  // incoming states are created at individual throwing bytecodes.
+  bool is_ready() const {
+    return _merged_predecessor_count == _predecessors.size();
+  }
+
   int block_id() const { return _block_id; }
   int start_bci() const { return _start_bci; }
   int limit_bci() const { return _limit_bci; }
@@ -226,6 +234,7 @@ class JeandleBasicBlock : public JeandleCompilationResourceObj {
   int _reverse_post_order;
 
   JeandleVMState* _jvm;
+  size_t _merged_predecessor_count;
 
   // Use vector to allow duplicate predecessors/successors, except for exception handlers.
   llvm::SmallVector<JeandleBasicBlock*, 8> _predecessors;
@@ -235,11 +244,12 @@ class JeandleBasicBlock : public JeandleCompilationResourceObj {
   llvm::BasicBlock* _tail_llvm_block;
   ciBlock* _ci_block;
 
-  // The JeandleVMState recording the initial state of a loop header.
-  // When a loop tail block is interpreted, we need to update the loop header's
-  // phi nodes. Use this variable to find the right phi nodes to update.
+  // The JeandleVMState recording the initial state of a block entered through
+  // PHIs. If another predecessor is visited after the block was interpreted,
+  // use this state to update its entry PHIs.
   JeandleVMState* _initial_jvm;
 
+  bool record_predecessor_merge(bool merged);
   void initialize_VM_state_from(JeandleVMState* incoming_state, llvm::BasicBlock* incoming_block, MethodLivenessResult liveness, bool is_osr);
 };
 
@@ -375,10 +385,10 @@ class JeandleAbstractInterpreter : public StackObj {
   void if_acmp(llvm::CmpInst::Predicate p);
   void if_null(llvm::CmpInst::Predicate p);
   // Shared emission for if_* helpers. Either prunes a strict-zero edge into
-  // an uncommon_trap, or emits a two-way branch with MDO weights. Must be
-  // called before the if_* helper pops its operands, so a pruned trap's deopt
-  // bundle still captures the pre-if operand stack.
-  void do_if_branch(llvm::Value* cond);
+  // an uncommon_trap, or emits a two-way branch with MDO weights. It consumes
+  // the if operands after emitting a pruned trap's deopt bundle but before
+  // merging normal Java successors.
+  void do_if_branch(llvm::Value* cond, unsigned operands);
   bool path_is_suitable_for_unstable_if_prune(int bci, JeandleProfile::BranchCounts counts);
   void attach_branch_weights(llvm::BranchInst* br, int bci);
   void attach_switch_weights(llvm::SwitchInst* switch_inst, int bci);

--- a/test/jdk/ProblemList-jeandle.txt
+++ b/test/jdk/ProblemList-jeandle.txt
@@ -198,7 +198,6 @@ jdk/jfr/event/io/TestSocketChannelEvents.java                             linux-
 # JDI not support
 ###
 com/sun/jdi/EATests.java#id0                                              linux-aarch64, linux-x64
-com/sun/jdi/JdbOptions.java                                               linux-x64
 com/sun/jdi/JdwpAllowTest.java                                            linux-aarch64
 com/sun/jdi/JdwpAttachTest.java                                           linux-aarch64
 com/sun/jdi/JdwpListenTest.java                                           linux-aarch64


### PR DESCRIPTION
## Related issue(s):

issue #569 

## What this PR does / why we need it:
This PR fixes several related Jeandle abstract-interpreter issues caused by basic blocks receiving incoming control-flow edges after the block has already been parsed.

  ### Late predecessor VM-state merges

  Jeandle parses blocks in reverse-post-order, but this does not guarantee that every predecessor of every block has already been processed. This is especially relevant for unusual control flow, OSR-rooted CFGs, dead or pruned edges, and control flow that behaves like an irreducible graph.

  Previously, Jeandle preserved a block’s entry JeandleVMState only for loop headers. If a non-loop block was parsed before all of its predecessors were visited, _jvm was subsequently mutated while interpreting the block’s bytecodes. A later incoming edge could therefore no longer update the block-entry PHIs safely:

  - the current _jvm no longer represented the block entry;
  - the block might already be marked as compiled;
  - a late merge could fail or update values belonging to the parsed block body instead of its entry PHIs.

  This PR adds _merged_predecessor_count to JeandleBasicBlock and introduces is_ready():
  For ordinary blocks, every successful VM-state merge corresponds to one incoming CFG edge and increments this counter. Duplicate CFG edges are intentionally counted separately because both the Jeandle CFG and LLVM PHIs preserve such edges.

  When Jeandle starts interpreting a block, it now preserves the entry state for:

  - loop headers;
  - exception handlers;
  - any ordinary block that is not yet ready.

  This follows the general approach used by C2’s Parse::do_all_blocks(): retain a block-entry state whenever another incoming edge may still need to update its PHIs after parsing begins.

  C2 gates the non-ready case using its irreducible-loop information. Jeandle builds a separate CFG, including an OSR-rooted CFG, and does not currently model irreducibility in the same way. Instead of adding another whole-graph analysis, this change directly uses the actual number of successfully merged predecessor edges.

  Dead or pruned predecessor edges may cause a block to remain conservatively not ready. In that case Jeandle may preserve an extra entry-state copy, but parsing is not delayed and correctness is unaffected.

  ### Debug-only local PHIs

  Preserving entry states for more blocks exposed another issue in serviceability configurations.

  liveness_at_bci() may keep locals alive solely to improve debugger and JVMTI support, even when raw_liveness_at_bci() proves that Java bytecodes will never read those locals again. Such a local can have different or unavailable values on different incoming edges.

  The first incoming edge therefore cannot establish a stable LLVM PHI type for that local. If the block is parsed before another predecessor arrives, the PHI may already have uses. A later incompatible incoming value would then attempt to invalidate an already-used PHI and trigger:
```
  assert(phi_node->use_empty()) failed: cannot use invalid local variable
```
  Before parsing a block whose entry state must be preserved, this PR now removes locals that are live only for debugging:

  This happens before interpreting any bytecode in the block, so the corresponding PHIs must still be unused and can be safely erased. The local is then marked unavailable and is ignored by later incoming-state merges.

  ### Correct VM state for branches entering exception handlers

  The late-merge fix also exposed an existing stack-state problem in conditional branches that target exception-handler blocks through normal control flow.

  The if_* helpers intentionally kept their operands on _jvm while calling do_if_branch(). This is required for unstable-if pruning: an uncommon trap must capture the pre-bytecode operand stack in its deoptimization bundle.

  However, do_if_branch() also merged normal control flow into exception-handler blocks before those operands were removed. For example, an if_icmp targeting a handler merged a state containing:
```
  [exception, int, int]
```
  while the handler entry expected the post-bytecode state:
```
  [exception]
```
  This caused:
```
  failed to merge VM state into exception handler block from normal flow
```
  do_if_branch() now receives the number of operands consumed by the current conditional bytecode:

  - if_zero and if_null consume one operand;
  - if_icmp and if_acmp consume two operands.

  The order is now:

  1. Keep the operands on _jvm while emitting an uncommon trap, so the deoptimization bundle still describes the pre-if interpreter state.
  2. Consume the operands from the actual _jvm.
  3. Merge the resulting post-bytecode state into normal successors, including exception-handler targets.

  ### Same-target conditional branches

  A conditional branch may have the same block as both its taken and fall-through target:

  CreateCondBr(cond, target, target);

  LLVM still represents this as two distinct CFG edges. Its predecessor iterator reports two entries, and every PHI in the target block must contain two identical incoming entries from the source block.

  When that shared target is an exception handler, this PR performs two handler merges, one for each CondBr edge. Merging only once would leave the target PHIs incomplete and fail LLVM verification with:
```
  PHINode should have one entry for each predecessor
```
  The operands themselves are consumed only once because both edges represent the same Java bytecode execution.
