### PR TITLE
enhance: add constant folding for oop, mirror, and Klass metadata

### DIFF
--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -1013,9 +1013,7 @@ bool JeandleIntrinsicLowering::lower_new_array() {
   //   log2_esize  = lh & 0x1f   (_lh_log2_element_size_shift == 0; masked < 32 for the shift,
   //                              valid l2esz is <= LogBytesPerLong)
   builder.SetInsertPoint(fast_bb);
-  llvm::Value* lh_addr = builder.CreateInBoundsGEP(
-      builder.getInt8Ty(), klass, builder.getInt32(in_bytes(Klass::layout_helper_offset())));
-  llvm::Value* layout_helper = builder.CreateLoad(builder.getInt32Ty(), lh_addr);
+  llvm::Value* layout_helper = _interp->call_java_op("jeandle.layout_helper", {klass});
   llvm::Value* base_offset = builder.CreateAnd(
       builder.CreateLShr(layout_helper, builder.getInt32(Klass::_lh_header_size_shift)),
       builder.getInt32(Klass::_lh_header_size_mask));
@@ -1105,13 +1103,12 @@ bool JeandleIntrinsicLowering::lower_unsafe_allocate_instance() {
   llvm::BasicBlock* primitive_trap_bb = llvm::BasicBlock::Create(
       ctx, "unsafe_allocate_primitive_trap", _interp->_llvm_func);
 
-  // TODO: Fold constant mirrors, their Klass, and the dependent layout and
-  // initialization loads together in an LLVM pass.
-  llvm::Value* klass_addr = builder.CreateInBoundsGEP(
-      builder.getInt8Ty(), mirror,
-      builder.getInt32(java_lang_Class::klass_offset()));
-  llvm::Value* klass = builder.CreateLoad(
-      c_heap_ptr_ty, klass_addr, "unsafe_allocate.klass");
+  // Preserve the mirror-to-Klass query as a phase-1 JavaOp so
+  // ConstantFieldFolding can answer it for a constant Class mirror. Dynamic
+  // mirrors lower back to the same VM field load before code generation.
+  llvm::CallInst* klass =
+      _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  klass->setName("unsafe_allocate.klass");
   llvm::Value* klass_is_null = builder.CreateICmpEQ(
       klass, llvm::ConstantPointerNull::get(c_heap_ptr_ty));
   builder.CreateCondBr(klass_is_null, primitive_trap_bb, allocation_check_bb);
@@ -1121,31 +1118,27 @@ bool JeandleIntrinsicLowering::lower_unsafe_allocate_instance() {
                          true /* should_reexecute */);
 
   builder.SetInsertPoint(allocation_check_bb);
-  llvm::Value* layout_addr = builder.CreateInBoundsGEP(
-      builder.getInt8Ty(), klass,
-      builder.getInt32(in_bytes(Klass::layout_helper_offset())));
-  llvm::Value* layout = builder.CreateLoad(
-      builder.getInt32Ty(), layout_addr, "unsafe_allocate.layout");
+  llvm::CallInst* layout =
+      _interp->call_java_op("jeandle.layout_helper", {klass});
+  layout->setName("unsafe_allocate.layout");
 
-  llvm::Value* init_state_addr = builder.CreateInBoundsGEP(
-      builder.getInt8Ty(), klass,
-      builder.getInt32(in_bytes(InstanceKlass::init_state_offset())));
-  llvm::Value* init_state = builder.CreateLoad(
-      builder.getInt8Ty(), init_state_addr, "unsafe_allocate.init_state");
-  llvm::Value* init_delta = builder.CreateSub(
-      builder.CreateZExt(init_state, builder.getInt32Ty()),
-      builder.getInt32(InstanceKlass::fully_initialized),
-      "unsafe_allocate.init_delta");
+  llvm::CallInst* is_initialized =
+      _interp->call_java_op("jeandle.klass_is_initialized", {klass});
+  is_initialized->setName("unsafe_allocate.is_initialized");
+  llvm::Value* needs_initialization = builder.CreateNot(
+      is_initialized, "unsafe_allocate.needs_initialization");
 
   // Match GraphKit::new_instance's reflective slow test. This also routes
   // arrays, interfaces, abstract classes and java.lang.Class to the runtime.
   llvm::Value* slow_path_bits = builder.CreateAnd(
       layout, builder.getInt32(Klass::_lh_instance_slow_path_bit),
       "unsafe_allocate.slow_path_bits");
-  llvm::Value* slow_test = builder.CreateOr(
-      slow_path_bits, init_delta, "unsafe_allocate.slow_test");
-  llvm::Value* needs_slow_path = builder.CreateICmpNE(
-      slow_test, builder.getInt32(0));
+  llvm::Value* has_slow_path_bits = builder.CreateICmpNE(
+      slow_path_bits, builder.getInt32(0),
+      "unsafe_allocate.has_slow_path_bits");
+  llvm::Value* needs_slow_path = builder.CreateOr(
+      has_slow_path_bits, needs_initialization,
+      "unsafe_allocate.needs_slow_path");
 
   // The layout helper stores the aligned instance size in bytes; its low bits
   // contain allocation flags and must not be passed to the TLAB allocator.

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -421,12 +421,12 @@ bool JeandleIntrinsicLowering::lower(vmIntrinsics::ID id, const ciMethod* target
 
     // getClass
     //
-    // TODO 1: When the receiver's Java type is known at compile time (e.g., the
-    // result of a `new` bytecode which carries a `java-klass` return attribute),
-    // we can skip the `jeandle.load_klass` call that reads the object header and
-    // use the known Klass pointer directly.
+    // Exact receiver types are folded later by LLVM's ConstantFieldFolding
+    // pass using the GetJavaMirror VM callback. This lowering keeps the
+    // dynamic JavaOp so CFF can also see type information propagated by the
+    // inline/PEA pipeline.
     //
-    // TODO 2: Optimize the comparison between class pointers.
+    // TODO: Optimize the comparison between class pointers.
     case vmIntrinsics::_getClass:
       return lower_java_op("jeandle.get_class",
                            {CTRL_NONE, MEM_READ});

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -95,6 +95,23 @@ ciObject* oop_by_id(int oop_id) {
   return compilation->compiled_code()->oop_at(oop_id);
 }
 
+uintptr_t record_klass_metadata(ciKlass* klass) {
+  assert(klass != nullptr && klass->is_loaded(), "klass must be loaded");
+  ciEnv* env = ciEnv::current();
+  assert(env != nullptr && env->oop_recorder() != nullptr,
+         "Klass constants require an active compilation");
+
+  Metadata* encoding = klass->constant_encoding();
+  // LLVM embeds this Klass* as an integer-backed pointer constant. Keep it in
+  // the nmethod metadata table so class unloading can discover the dependency
+  // even if the oop load that exposed the Klass is later eliminated.
+  int metadata_index = env->oop_recorder()->find_index(encoding);
+  assert(env->oop_recorder()->metadata_at(metadata_index) == encoding,
+         "recorded Klass metadata must be recoverable");
+  (void)metadata_index;
+  return reinterpret_cast<uintptr_t>(encoding);
+}
+
 bool constant_field(int oop_id, int offset, ciField** field, ciConstant* con) {
   ciObject* base_oop = oop_by_id(oop_id);
   if (base_oop == nullptr || base_oop->is_null_object()) {
@@ -426,7 +443,51 @@ uintptr_t JeandleVMCallback::get_oop_klass(int oop_id) {
   // The constant oop is a single, compile-time-known object instance, so its
   // klass is the value's exact dynamic type. Mirrors the encoding used by the
   // frontend when attaching !java-klass metadata (jeandleAbstractInterpreter.cpp).
-  return (uintptr_t)(Klass*)(klass->constant_encoding());
+  return record_klass_metadata(klass);
+}
+
+uintptr_t JeandleVMCallback::get_mirror_klass(int oop_id) {
+  ciObject* oop = oop_by_id(oop_id);
+  if (oop == nullptr || oop->is_null_object() || !oop->is_instance()) {
+    return llvm::jeandle::MirrorKlassUnavailable;
+  }
+
+  ciType* mirror_type = oop->as_instance()->java_mirror_type();
+  if (mirror_type == nullptr) {
+    return llvm::jeandle::MirrorKlassUnavailable;
+  }
+  if (!mirror_type->is_klass()) {
+    // Primitive Class mirrors have a known-null hidden Klass field.
+    return 0;
+  }
+
+  ciKlass* klass = mirror_type->as_klass();
+  if (!klass->is_loaded()) {
+    return llvm::jeandle::MirrorKlassUnavailable;
+  }
+  return record_klass_metadata(klass);
+}
+
+int JeandleVMCallback::get_klass_layout_helper(uintptr_t klass_ptr) {
+  if (klass_ptr == 0) {
+    return 0;
+  }
+  Klass* klass = reinterpret_cast<Klass*>(klass_ptr);
+  return klass->layout_helper();
+}
+
+bool JeandleVMCallback::is_klass_initialized(uintptr_t klass_ptr) {
+  // Query through CI so the answer is a compilation-stable snapshot, matching
+  // C2's klass_needs_init_guard. Only a true answer is folded by LLVM.
+  VM_ENTRY_MARK;
+  Klass* klass = reinterpret_cast<Klass*>(klass_ptr);
+  if (klass == nullptr || !klass->is_instance_klass()) {
+    return false;
+  }
+  ciMetadata* metadata =
+      ciEnv::current()->get_metadata(reinterpret_cast<Metadata*>(klass));
+  return metadata != nullptr && metadata->is_instance_klass() &&
+         metadata->as_instance_klass()->is_initialized();
 }
 
 int JeandleVMCallback::get_java_mirror(uintptr_t klass_ptr) {
@@ -859,6 +920,9 @@ void JeandleVMCallback::register_callbacks() {
   callbacks.GetConstantField = &JeandleVMCallback::get_constant_field;
   callbacks.GetOopHandleName = &JeandleVMCallback::get_oop_handle_name;
   callbacks.GetOopKlass = &JeandleVMCallback::get_oop_klass;
+  callbacks.GetMirrorKlass = &JeandleVMCallback::get_mirror_klass;
+  callbacks.GetKlassLayoutHelper = &JeandleVMCallback::get_klass_layout_helper;
+  callbacks.IsKlassInitialized = &JeandleVMCallback::is_klass_initialized;
   callbacks.GetJavaMirror = &JeandleVMCallback::get_java_mirror;
   callbacks.GetInlineCalleeIR = &JeandleVMCallback::get_inline_callee_ir;
   callbacks.GetNewStatepointID = &JeandleVMCallback::get_new_statepoint_id;

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -446,6 +446,19 @@ uintptr_t JeandleVMCallback::get_oop_klass(int oop_id) {
   return record_klass_metadata(klass);
 }
 
+uintptr_t JeandleVMCallback::get_klass_constant(uintptr_t klass_ptr) {
+  if (klass_ptr == 0) {
+    return 0;
+  }
+  VM_ENTRY_MARK;
+  Klass* klass = reinterpret_cast<Klass*>(klass_ptr);
+  ciKlass* ci_klass = ciEnv::current()->get_klass(klass);
+  if (ci_klass == nullptr || !ci_klass->is_loaded()) {
+    return 0;
+  }
+  return record_klass_metadata(ci_klass);
+}
+
 uintptr_t JeandleVMCallback::get_mirror_klass(int oop_id) {
   ciObject* oop = oop_by_id(oop_id);
   if (oop == nullptr || oop->is_null_object() || !oop->is_instance()) {
@@ -920,6 +933,7 @@ void JeandleVMCallback::register_callbacks() {
   callbacks.GetConstantField = &JeandleVMCallback::get_constant_field;
   callbacks.GetOopHandleName = &JeandleVMCallback::get_oop_handle_name;
   callbacks.GetOopKlass = &JeandleVMCallback::get_oop_klass;
+  callbacks.GetKlassConstant = &JeandleVMCallback::get_klass_constant;
   callbacks.GetMirrorKlass = &JeandleVMCallback::get_mirror_klass;
   callbacks.GetKlassLayoutHelper = &JeandleVMCallback::get_klass_layout_helper;
   callbacks.IsKlassInitialized = &JeandleVMCallback::is_klass_initialized;

--- a/src/hotspot/share/jeandle/jeandleVMCallback.hpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.hpp
@@ -68,6 +68,9 @@ class JeandleVMCallback : public AllStatic {
   // Oop handles.
   static std::string get_oop_handle_name(int oop_id);
   static uintptr_t   get_oop_klass(int oop_id);
+  static uintptr_t   get_mirror_klass(int oop_id);
+  static int         get_klass_layout_helper(uintptr_t klass_ptr);
+  static bool        is_klass_initialized(uintptr_t klass_ptr);
 
   // Returns the oop id of the java.lang.Class mirror for a VM Klass pointer,
   // or -1 if unavailable. Used by PEA's foldGetClass.

--- a/src/hotspot/share/jeandle/jeandleVMCallback.hpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.hpp
@@ -68,6 +68,7 @@ class JeandleVMCallback : public AllStatic {
   // Oop handles.
   static std::string get_oop_handle_name(int oop_id);
   static uintptr_t   get_oop_klass(int oop_id);
+  static uintptr_t   get_klass_constant(uintptr_t klass_ptr);
   static uintptr_t   get_mirror_klass(int oop_id);
   static int         get_klass_layout_helper(uintptr_t klass_ptr);
   static bool        is_klass_initialized(uintptr_t klass_ptr);

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -39,6 +39,7 @@
 #include "oops/arrayOop.hpp"
 #include "oops/array.hpp"
 #include "oops/compressedOops.inline.hpp"
+#include "oops/instanceKlass.hpp"
 #include "classfile/javaClasses.hpp"
 #include "oops/klass.hpp"
 #include "oops/objArrayKlass.hpp"
@@ -605,13 +606,17 @@ void RuntimeDefinedJavaOps::define_global_variables(llvm::Module& template_modul
   define_global("arrayOopDesc.element_size.object",                 int32_type, static_cast<uint64_t>(type2aelembytes(T_OBJECT)));
   define_global("Klass.access_flags_offset",                        int32_type, static_cast<uint64_t>(Klass::access_flags_offset()));
   define_global("Klass.java_mirror_offset",                         int32_type, static_cast<uint64_t>(in_bytes(Klass::java_mirror_offset())));
+  define_global("Klass.layout_helper_offset",                       int32_type, static_cast<uint64_t>(in_bytes(Klass::layout_helper_offset())));
   define_global("Klass.secondary_super_cache_offset",               int32_type, static_cast<uint64_t>(Klass::secondary_super_cache_offset()));
   define_global("Klass.secondary_supers_offset",                    int32_type, static_cast<uint64_t>(Klass::secondary_supers_offset()));
   define_global("Klass.super_check_offset_offset",                  int32_type, static_cast<uint64_t>(Klass::super_check_offset_offset()));
   define_global("ObjArrayKlass.element_klass_offset",               int32_type, static_cast<uint64_t>(ObjArrayKlass::element_klass_offset()));
+  define_global("InstanceKlass.init_state_offset",                  int32_type, static_cast<uint64_t>(in_bytes(InstanceKlass::init_state_offset())));
+  define_global("InstanceKlass.fully_initialized",                  int8_type,  static_cast<uint64_t>(InstanceKlass::fully_initialized));
   define_global("oopDesc.klass_offset_in_bytes",                    int32_type, static_cast<uint64_t>(oopDesc::klass_offset_in_bytes()));
   define_global("oopDesc.mark_offset_in_bytes",                     int32_type, static_cast<uint64_t>(oopDesc::mark_offset_in_bytes()));
   define_global("java_lang_ref_Reference.referent_offset",          int32_type, static_cast<uint64_t>(java_lang_ref_Reference::referent_offset()));
+  define_global("java_lang_Class.klass_offset",                     int32_type, static_cast<uint64_t>(java_lang_Class::klass_offset()));
   define_global("java_lang_Class.array_klass_offset",               int32_type, static_cast<uint64_t>(java_lang_Class::array_klass_offset()));
   define_global("BasicLock.displaced_header_offset_in_bytes",       int32_type, static_cast<uint64_t>(BasicLock::displaced_header_offset_in_bytes()));
   define_global("JavaThread.held_monitor_count_offset",             int32_type, static_cast<uint64_t>(JavaThread::held_monitor_count_offset()));

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -234,8 +234,9 @@ JAVA_OP_END
 //   3. Dereference the OopHandle to get the actual mirror oop in the Java heap.
 // The mirror is always reachable (a GC root inside the Klass), so no null check is needed.
 //
-// TODO: When the receiver's Klass is known at compile time (via `java-klass` attribute),
-// Step 1 (jeandle.load_klass) can be skipped.
+// Exact receiver types are folded by LLVM ConstantFieldFolding before this
+// JavaOp is expanded. This body remains the dynamic fallback for receivers
+// whose exact Klass is unavailable.
 DEF_JAVA_OP(get_class, 1, llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),
             llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace))  // obj (receiver)
   llvm::Value* obj = func->getArg(0);

--- a/src/hotspot/share/jeandle/templatemodule/template.ll
+++ b/src/hotspot/share/jeandle/templatemodule/template.ll
@@ -68,10 +68,15 @@
 ; Byte offsets for Klass structure fields.
 @Klass.access_flags_offset = external global i32
 @Klass.java_mirror_offset = external global i32
+@Klass.layout_helper_offset = external global i32
 @Klass.secondary_super_cache_offset = external global i32
 @Klass.secondary_supers_offset = external global i32
 @Klass.super_check_offset_offset = external global i32
 @ObjArrayKlass.element_klass_offset = external global i32
+
+; InstanceKlass initialization state used by klass_is_initialized.
+@InstanceKlass.init_state_offset = external global i32
+@InstanceKlass.fully_initialized = external global i8
 
 ; Byte offsets for oopDesc structure fields.
 @oopDesc.klass_offset_in_bytes = external global i32
@@ -94,6 +99,9 @@
 
 ; Byte offsets for java.lang.ref.Reference instance fields.
 @java_lang_ref_Reference.referent_offset = external global i32
+
+; Byte offset of the represented Klass* in java.lang.Class.
+@java_lang_Class.klass_offset = external global i32
 
 ; Byte offset of the cached array klass in java.lang.Class (injected field).
 ; Stores the array Klass* for this component type once the array type has been loaded.
@@ -193,6 +201,43 @@ compressed:
 uncompressed:
   %wide = load atomic ptr addrspace(0), ptr addrspace(1) %klass_addr unordered, align 8
   ret ptr addrspace(0) %wide
+}
+
+; Load the reference Klass represented by a java.lang.Class mirror. Primitive
+; mirrors contain a null Klass*. Keeping this as a phase-1 JavaOp lets
+; ConstantFieldFolding answer the query from a constant mirror before exposing
+; the VM-injected field load.
+define hotspotcc ptr addrspace(0) @jeandle.load_mirror_klass(ptr addrspace(1) nocapture readonly %mirror) noinline "lower-phase"="1" #0 {
+entry:
+  %klass_offset = load i32, ptr @java_lang_Class.klass_offset
+  %klass_addr = getelementptr inbounds i8, ptr addrspace(1) %mirror, i32 %klass_offset
+  %klass = load atomic ptr addrspace(0), ptr addrspace(1) %klass_addr unordered, align 8
+  ret ptr addrspace(0) %klass
+}
+
+; Load Klass::layout_helper from a Klass pointer. Keeping this as a phase-1
+; JavaOp lets ConstantFieldFolding answer the query while the Klass is still a
+; compile-time constant; unresolved queries lower to the ordinary VM load.
+define hotspotcc i32 @jeandle.layout_helper(ptr addrspace(0) nocapture readonly %klass) noinline "lower-phase"="1" #0 {
+entry:
+  %layout_helper_offset = load i32, ptr @Klass.layout_helper_offset
+  %layout_helper_addr = getelementptr inbounds i8, ptr addrspace(0) %klass, i32 %layout_helper_offset
+  %layout_helper = load atomic i32, ptr addrspace(0) %layout_helper_addr unordered, align 4
+  ret i32 %layout_helper
+}
+
+; Query a Klass' current initialization state. Keeping this opaque through
+; phase 0 lets ConstantFieldFolding replace the query with true for a constant
+; Klass already known by the VM to be initialized. Otherwise phase 1 lowers it
+; to the runtime state load, preserving later class initialization.
+define hotspotcc i1 @jeandle.klass_is_initialized(ptr addrspace(0) nocapture readonly %klass) noinline "lower-phase"="1" #0 {
+entry:
+  %init_state_offset = load i32, ptr @InstanceKlass.init_state_offset
+  %init_state_addr = getelementptr inbounds i8, ptr addrspace(0) %klass, i32 %init_state_offset
+  %init_state = load volatile i8, ptr addrspace(0) %init_state_addr, align 1
+  %fully_initialized = load i8, ptr @InstanceKlass.fully_initialized
+  %is_initialized = icmp eq i8 %init_state, %fully_initialized
+  ret i1 %is_initialized
 }
 
 ; This is the slow path for subtype checking when the fast path fails.

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestGetClass.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestGetClass.java
@@ -22,7 +22,7 @@
  * @test
  * @summary Test the intrinsic implementation of Object.getClass()
  * @library /test/lib /
- * @build jdk.test.lib.Asserts
+ * @build jdk.test.lib.Asserts compiler.jeandle.fileCheck.FileCheck
  * @run main/othervm compiler.jeandle.intrinsic.TestGetClass
  */
 
@@ -46,7 +46,8 @@ public class TestGetClass {
                 "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
                 "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
                 "-XX:JeandleDumpDirectory=" + dumpPath,
-                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::getClass_of",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::getClass_of_object",
+                "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::getClass_of_exact",
                 TestWrapper.class.getName()));
 
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(commandArgs);
@@ -57,48 +58,73 @@ public class TestGetClass {
 
         // Verify the jeandle.get_class JavaOp is present in the IR
         FileCheck checker = new FileCheck(dumpPath,
-                TestWrapper.class.getMethod("getClass_of", Object.class), false);
-        checker.checkPattern("jeandle\\.get_class");
+                TestWrapper.class.getMethod("getClass_of_object", Object.class), false);
+        checker.checkPattern("call hotspotcc .*@jeandle\\.get_class");
+
+        // The object is allocated outside this compiled method, so PEA has no
+        // virtual allocation to eliminate. CFF can still use its exact Klass
+        // and fold getClass to the mirror handle.
+        FileCheck exactInitial = new FileCheck(dumpPath,
+                TestWrapper.class.getMethod("getClass_of_exact"), false);
+        exactInitial.checkPattern("jeandle\\.get_class");
+
+        FileCheck exactChecker = new FileCheck(dumpPath,
+                TestWrapper.class.getMethod("getClass_of_exact"), true);
+        exactChecker.checkNotPattern("call hotspotcc .*@jeandle\\.get_class");
+        exactChecker.checkPattern("%folded\\.oop = load ptr addrspace\\(1\\), ptr .*oop_handle_");
     }
 
     static class TestWrapper {
+        // This object is allocated during class initialization, outside the
+        // method compiled by Jeandle. It is therefore not a PEA candidate.
+        static final ExactObject exactObject = new ExactObject();
+
         public static void main(String[] args) {
             // Different object types
-            Asserts.assertEquals(getClass_of(new Object()), Object.class,
+            Asserts.assertEquals(getClass_of_object(new Object()), Object.class,
                     "Object.getClass() should return Object.class");
-            Asserts.assertEquals(getClass_of("hello"), String.class,
+            Asserts.assertEquals(getClass_of_object("hello"), String.class,
                     "String.getClass() should return String.class");
-            Asserts.assertEquals(getClass_of(Integer.valueOf(42)), Integer.class,
+            Asserts.assertEquals(getClass_of_object(Integer.valueOf(42)), Integer.class,
                     "Integer.getClass() should return Integer.class");
 
             // Array types
-            Asserts.assertEquals(getClass_of(new int[0]), int[].class,
+            Asserts.assertEquals(getClass_of_object(new int[0]), int[].class,
                     "int[].getClass() should return int[].class");
-            Asserts.assertEquals(getClass_of(new Object[0]), Object[].class,
+            Asserts.assertEquals(getClass_of_object(new Object[0]), Object[].class,
                     "Object[].getClass() should return Object[].class");
-            Asserts.assertEquals(getClass_of(new String[0]), String[].class,
+            Asserts.assertEquals(getClass_of_object(new String[0]), String[].class,
                     "String[].getClass() should return String[].class");
 
             // Subclass — getClass() returns the actual runtime class, not the declared type
-            Asserts.assertEquals(getClass_of(new HashMap<String, String>()), HashMap.class,
+            Asserts.assertEquals(getClass_of_object(new HashMap<String, String>()), HashMap.class,
                     "HashMap.getClass() should return HashMap.class, not Map.class");
-            Asserts.assertEquals(getClass_of(new ArrayList<String>()), ArrayList.class,
+            Asserts.assertEquals(getClass_of_object(new ArrayList<String>()), ArrayList.class,
                     "ArrayList.getClass() should return ArrayList.class, not List.class");
 
             // NullPointerException on null receiver
             boolean gotNPE = false;
             try {
-                getClass_of(null);
+                getClass_of_object(null);
             } catch (NullPointerException e) {
                 gotNPE = true;
             }
             Asserts.assertTrue(gotNPE, "getClass(null) should throw NullPointerException");
 
+            Asserts.assertEquals(getClass_of_exact(), ExactObject.class,
+                    "CFF should fold getClass for an exact external object");
+
             System.out.println("TestGetClass PASSED");
         }
 
-        public static Class<?> getClass_of(Object obj) {
+        public static Class<?> getClass_of_object(Object obj) {
             return obj.getClass();
         }
+
+        public static Class<?> getClass_of_exact() {
+            return exactObject.getClass();
+        }
+
+        static final class ExactObject { }
     }
 }

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestUnsafeAllocateInstanceConstantFolding.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestUnsafeAllocateInstanceConstantFolding.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ */
+
+/*
+ * @test
+ * @summary Verify Unsafe.allocateInstance constant mirror, Klass metadata,
+ *          and initialization queries are folded by Jeandle
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @build compiler.jeandle.fileCheck.FileCheck
+ * @run driver compiler.jeandle.intrinsic.TestUnsafeAllocateInstanceConstantFolding
+ */
+
+package compiler.jeandle.intrinsic;
+
+import compiler.jeandle.fileCheck.FileCheck;
+import jdk.internal.misc.Unsafe;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class TestUnsafeAllocateInstanceConstantFolding {
+    public static void main(String[] args) throws Exception {
+        Path dumpPath = Files.createTempDirectory("jeandle_unsafe_allocate_instance");
+        String wrapper = TestWrapper.class.getName();
+
+        ArrayList<String> command = new ArrayList<>(List.of(
+                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                "-Xbatch", "-XX:-TieredCompilation", "-XX:-BackgroundCompilation",
+                "-XX:CompileThreshold=100",
+                "-XX:+UseJeandleCompiler", "-Xlog:jeandle=debug,jit+compilation=debug",
+                "-XX:+JeandleDumpIR", "-XX:+JeandleRecordVMCallbacks",
+                "-XX:JeandleDumpDirectory=" + dumpPath,
+                "-XX:CompileCommand=compileonly," + wrapper + "::allocate*",
+                wrapper));
+
+        OutputAnalyzer output = ProcessTools.executeCommand(
+                ProcessTools.createLimitedTestJavaProcessBuilder(command));
+        output.shouldHaveExitValue(0)
+              .shouldContain("TestUnsafeAllocateInstanceConstantFolding PASSED")
+              .shouldContain("allocateInstance")
+              .shouldContain("is parsed as intrinsic");
+
+        Method constantMethod = TestWrapper.class.getMethod("allocateConstant");
+        FileCheck unoptimized = new FileCheck(dumpPath.toString(), constantMethod, false);
+        unoptimized.checkPattern(
+                "define hotspotcc .*TestUnsafeAllocateInstanceConstantFolding\\$TestWrapper_allocateConstant");
+        unoptimized.checkPattern("jeandle\\.load_mirror_klass");
+        unoptimized.checkPattern("jeandle\\.layout_helper");
+        unoptimized.checkPattern("jeandle\\.klass_is_initialized");
+
+        String callbackLog = Files.readString(findLatestDump(
+                dumpPath, TestWrapper.class, "allocateConstant", ".cblog"));
+        assertMatches(callbackLog, "(?m)^GetMirrorKlass [0-9]+ = [0-9]+$",
+                "constant mirror should fold to its represented Klass");
+        assertMatches(callbackLog, "(?m)^GetKlassLayoutHelper [0-9]+ = [1-9][0-9]*$",
+                "constant Klass layout helper should be queried");
+        assertMatches(callbackLog, "(?m)^IsKlassInitialized [0-9]+ = true$",
+                "initialized constant Klass should remove the initialization test");
+    }
+
+    private static Path findLatestDump(Path directory, Class<?> holder,
+                                       String methodName, String suffix) throws Exception {
+        String prefix = holder.getName().replace('.', '_') + "_" + methodName;
+        try (Stream<Path> files = Files.list(directory)) {
+            return files.filter(Files::isRegularFile)
+                        .filter(path -> path.getFileName().toString().startsWith(prefix))
+                        .filter(path -> path.getFileName().toString().endsWith(suffix))
+                        .max(Comparator.comparing(path -> path.getFileName().toString()))
+                        .orElseThrow(() -> new AssertionError(
+                                "No " + suffix + " dump found for " + prefix));
+        }
+    }
+
+    private static void assertMatches(String text, String regex, String message) {
+        Asserts.assertTrue(Pattern.compile(regex).matcher(text).find(),
+                message + "; callback log:\n" + text);
+    }
+
+    public static class TestWrapper {
+        private static final Unsafe U = Unsafe.getUnsafe();
+        private static int constructorCalls;
+        private static int lazyClassInitializations;
+
+        public static class Payload {
+            int value = 42;
+
+            public Payload() {
+                constructorCalls++;
+            }
+        }
+
+        public abstract static class AbstractPayload { }
+
+        public interface PayloadInterface { }
+
+        public static class LazyPayload {
+            static {
+                lazyClassInitializations++;
+            }
+        }
+
+        public static Payload allocateConstant() throws InstantiationException {
+            return (Payload) U.allocateInstance(Payload.class);
+        }
+
+        public static Object allocateDynamic(Class<?> klass) throws InstantiationException {
+            return U.allocateInstance(klass);
+        }
+
+        private static void expectInstantiationException(Class<?> klass) {
+            try {
+                allocateDynamic(klass);
+                throw new AssertionError("Expected InstantiationException for " + klass);
+            } catch (InstantiationException expected) {
+                // Expected.
+            }
+        }
+
+        public static void main(String[] args) throws Exception {
+            // The initialization callback may fold only a class already initialized
+            // when allocateConstant is compiled.
+            Class.forName(Payload.class.getName(), true, Payload.class.getClassLoader());
+
+            for (int i = 0; i < 20_000; i++) {
+                Payload constant = allocateConstant();
+                Asserts.assertEquals(constant.value, 0,
+                        "Unsafe.allocateInstance must skip field initializers");
+                Object dynamic = allocateDynamic(Payload.class);
+                Asserts.assertTrue(dynamic instanceof Payload);
+            }
+            Asserts.assertEquals(constructorCalls, 0,
+                    "Unsafe.allocateInstance must not invoke constructors");
+
+            Asserts.assertEquals(lazyClassInitializations, 0,
+                    "class literal must not initialize LazyPayload");
+            Asserts.assertTrue(allocateDynamic(LazyPayload.class) instanceof LazyPayload);
+            Asserts.assertEquals(lazyClassInitializations, 1,
+                    "dynamic initialization check must route an uninitialized class to runtime");
+
+            expectInstantiationException(AbstractPayload.class);
+            expectInstantiationException(PayloadInterface.class);
+            expectInstantiationException(Object[].class);
+            expectInstantiationException(int.class);
+
+            System.out.println("TestUnsafeAllocateInstanceConstantFolding PASSED");
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/pea/TestPEAArrayLengthBoundsAndTypes.java
+++ b/test/hotspot/jtreg/compiler/jeandle/pea/TestPEAArrayLengthBoundsAndTypes.java
@@ -41,7 +41,6 @@ public class TestPEAArrayLengthBoundsAndTypes {
             "compiler.jeandle.pea.TestPEAArrayLengthBoundsAndTypes$TestWrapper";
     private static final int ARRAY_CAP = 128;
     private static final String ARRAY_LENGTH = "@jeandle.arraylength";
-    private static final String GET_CLASS = "@jeandle.get_class";
     private static final String DEOPTIMIZE = "@llvm.experimental.deoptimize";
     private static final String DEOPTIMIZE_I64 = "llvm.experimental.deoptimize.i64";
     private static final String DEOPTIMIZE_I64_CALL = "@" + DEOPTIMIZE_I64;
@@ -101,8 +100,6 @@ public class TestPEAArrayLengthBoundsAndTypes {
             assertConstantOutOfBounds(run, constantUpperOutOfBounds, 14);
             assertDynamicBoundsFallbacks(run, dynamicBounds);
             assertMultiArrayConservative(run, multi);
-            assertGetClassFolded(run, primitiveTypes);
-            assertGetClassFolded(run, objectTypes);
             assertFailedCheckcast(run, failedCheckcast);
         }
     }
@@ -260,19 +257,6 @@ public class TestPEAArrayLengthBoundsAndTypes {
         firstSuccess.assertOccurrenceCount("store atomic i32", 4);
         secondSuccess.assertAbsent(DEOPTIMIZE);
         secondSuccess.assertOccurrenceCount("store atomic i32", 1);
-    }
-
-    private static void assertGetClassFolded(
-            PEATestUtils.RunResult run, Method target) throws Exception {
-        PEATestUtils.PEAReport report = run.report(target);
-        PEATestUtils.PEARound first = report.round(0);
-        first.before().assertOccurrenceCount(GET_CLASS, 1);
-        Asserts.assertEquals(first.effectCount("ReplaceCall", GET_CLASS), 1L,
-                target + ": exact getClass call is replaced");
-        Asserts.assertEquals(first.effectCount("Materialize"), 0L,
-                target + ": getClass folding does not materialize the array");
-        report.finalAfter().assertAbsent(GET_CLASS);
-        run.finalIR(target).assertAbsent(GET_CLASS);
     }
 
     private static void assertFailedCheckcast(PEATestUtils.RunResult run, Method target)

--- a/test/hotspot/jtreg/compiler/jeandle/pea/TestPEAGetClassAndArrayTypes.java
+++ b/test/hotspot/jtreg/compiler/jeandle/pea/TestPEAGetClassAndArrayTypes.java
@@ -22,8 +22,8 @@
  * @summary PEA getClass folding: Object.getClass() on a virtual object folds to
  *          the exact Class mirror (ReplaceCall) without materializing, for
  *          instances, subclasses and arrays; field access around getClass still
- *          folds. A published receiver keeps the real jeandle.get_class. The
- *          Class-mirror identity and array-class exactness match Java semantics.
+ *          folds. The Class-mirror identity and array-class exactness match
+ *          Java semantics.
  *          (foldLoadKlass is not Java-reachable: only phase-1 template bodies and
  *          the unloaded-catch path emit jeandle.load_klass, so it is lit-only.)
  * @library /test/lib /
@@ -53,14 +53,12 @@ public class TestPEAGetClassAndArrayTypes {
         Method objArr = TestWrapper.class.getMethod("getClassObjectArray");
         Method ifaceArr = TestWrapper.class.getMethod("getClassInterfaceArray");
         Method fields = TestWrapper.class.getMethod("fieldsAroundGetClass", boolean.class);
-        Method mat = TestWrapper.class.getMethod("getClassMaterializedReceiver");
-        Method consume = TestWrapper.class.getMethod("consume", Object.class);
-        Method[] targets = {exact, sub, iface, primArr, objArr, ifaceArr, fields, mat};
+        Method[] targets = {exact, sub, iface, primArr, objArr, ifaceArr, fields};
 
-        PEATestUtils.behaviorRun(WRAPPER, targets).dontinline(consume).runPEAOnOffEquivalent();
+        PEATestUtils.behaviorRun(WRAPPER, targets).runPEAOnOffEquivalent();
 
         try (PEATestUtils.RunResult run =
-                PEATestUtils.shapeRun(WRAPPER, targets).dontinline(consume).run()) {
+                PEATestUtils.shapeRun(WRAPPER, targets).run()) {
             assertGetClassFolded(run, exact, 1);
             assertGetClassFolded(run, sub, 1);
             assertGetClassFolded(run, iface, 2);
@@ -68,7 +66,6 @@ public class TestPEAGetClassAndArrayTypes {
             assertGetClassFolded(run, objArr, 1);
             assertGetClassFolded(run, ifaceArr, 2);
             assertGetClassFolded(run, fields, 1);
-            assertGetClassPublished(run, mat);
         }
     }
 
@@ -93,20 +90,6 @@ public class TestPEAGetClassAndArrayTypes {
         assertVerifierShape(run, report, target);
     }
 
-    private static void assertGetClassPublished(PEATestUtils.RunResult run, Method target)
-            throws Exception {
-        PEATestUtils.PEAReport report = run.report(target);
-        PEATestUtils.IRBody after = report.finalAfter();
-        // A published receiver is materialized, so getClass does not fold and the
-        // jeandle.get_class call survives to its phase-1 expansion.
-        after.assertPresent("jeandle.get_class");
-        Asserts.assertTrue(report.maxPartiallyEscapes() >= 1,
-                target + ": published receiver classified PartiallyEscapes");
-        after.assertAbsent("poison");
-        report.assertFinalTransformIdle();
-        assertVerifierShape(run, report, target);
-    }
-
     private static void assertVerifierShape(PEATestUtils.RunResult run,
                                             PEATestUtils.PEAReport report,
                                             Method target) throws Exception {
@@ -120,14 +103,12 @@ public class TestPEAGetClassAndArrayTypes {
     }
 
     public static class TestWrapper {
-        private static final String EXPECTED_DIGEST = "591d28229bc7c09f";
+        private static final String EXPECTED_DIGEST = "228c3dd1ad46d1f2";
 
         public static class Pojo { int x; }
         public static class SubPojo extends Pojo { int y; }
         public interface Iface2 { }
         public static class Iface2Impl implements Iface2 { }
-
-        private static Object consumed;
 
         public static void main(String[] args) throws Exception {
             new Pojo(); new SubPojo(); new Iface2Impl();
@@ -140,7 +121,6 @@ public class TestPEAGetClassAndArrayTypes {
             digest = mix(digest, getClassPrimitiveArray());
             digest = mix(digest, getClassObjectArray());
             digest = mix(digest, getClassInterfaceArray());
-            digest = mix(digest, getClassMaterializedReceiver());
             for (boolean mutate : new boolean[] {false, true}) {
                 digest = mix(digest, fieldsAroundGetClass(mutate));
             }
@@ -224,17 +204,6 @@ public class TestPEAGetClassAndArrayTypes {
                 p.x = 9;
             }
             return (c == Pojo.class ? 100 : 0) + p.x;
-        }
-
-        public static int getClassMaterializedReceiver() {
-            Pojo p = new Pojo();
-            p.x = 1;
-            consume(p);
-            return (p.getClass() == Pojo.class) ? 1 : 0;
-        }
-
-        public static void consume(Object o) {
-            consumed = o;
         }
 
         private static long mix(long digest, int value) {


### PR DESCRIPTION
CO_REPO: https://github.com/rcjhd/jeandle-llvm.git
CO_BRANCH: CFF-enhance

## Related issue(s):

issue #574 

## What this PR does / why we need it:
Enhances LLVM constant field folding to resolve:

    Constant oop to Klass
    Constant Class mirror to Klass
    Constant Klass to layout_helper

This enables further constant propagation and downstream optimizations that depend on precise HotSpot type metadata.
