### PR TITLE
fix: correct some typos

### DIFF
--- a/src/hotspot/cpu/riscv/jeandleCompiledCode_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jeandleCompiledCode_riscv.cpp
@@ -43,13 +43,13 @@ void JeandleCompiledCode::setup_frame_size() {
 }
 
 bool JeandleCompiledCode::pd_build_exception_handler_table() {
-  SectionInfo excpet_table_section(".gcc_except_table");
-  if (ReadELF::findSection(*_elf, excpet_table_section)) {
+  SectionInfo except_table_section(".gcc_except_table");
+  if (ReadELF::findSection(*_elf, except_table_section)) {
     // Start of the exception handler table.
-    const char* except_table_pointer = object_start() + excpet_table_section._offset;
+    const char* except_table_pointer = object_start() + except_table_section._offset;
 
     // Utilize DataExtractor to decode exception handler table.
-    llvm::DataExtractor data_extractor(llvm::StringRef(except_table_pointer, excpet_table_section._size),
+    llvm::DataExtractor data_extractor(llvm::StringRef(except_table_pointer, except_table_section._size),
                                        ELFT::Endianness == llvm::endianness::little, /* IsLittleEndian */
                                        BytesPerWord/* AddressSize */);
     llvm::DataExtractor::Cursor data_cursor(0 /* Offset */);

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -602,8 +602,8 @@ void BasicBlockBuilder::setup_exception_handlers() {
     int bci = codes.cur_bci();
     JeandleBasicBlock* block = _bci2block[bci];
     if (block->is_exception_handler()) {
-      int covered_bci = block->exeption_range_start_bci();
-      while (covered_bci < block->exeption_range_limit_bci()) {
+      int covered_bci = block->exception_range_start_bci();
+      while (covered_bci < block->exception_range_limit_bci()) {
         JeandleBasicBlock* covered_block = _bci2block[covered_bci];
 
         // Connect each exception handler block only once.

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -221,8 +221,8 @@ class JeandleBasicBlock : public JeandleCompilationResourceObj {
   void set_tail_llvm_block(llvm::BasicBlock* block) { _tail_llvm_block = block; }
 
   bool is_exception_handler() { return _ci_block->is_handler(); }
-  int exeption_range_start_bci() { return _ci_block->ex_start_bci(); }
-  int exeption_range_limit_bci() { return _ci_block->ex_limit_bci(); }
+  int exception_range_start_bci() { return _ci_block->ex_start_bci(); }
+  int exception_range_limit_bci() { return _ci_block->ex_limit_bci(); }
 
   void set_initial_jvm(JeandleVMState* initial_jvm) { _initial_jvm = initial_jvm; }
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -1129,13 +1129,13 @@ JeandleStackMap* JeandleCompiledCode::parse_stackmap(StackMapParser& stackmaps,
 }
 
 void JeandleCompiledCode::build_exception_handler_table() {
-  SectionInfo excpet_table_section(".gcc_except_table");
-  if (ReadELF::findSection(*_elf, excpet_table_section)) {
+  SectionInfo except_table_section(".gcc_except_table");
+  if (ReadELF::findSection(*_elf, except_table_section)) {
     // Start of the exception handler table.
-    const char* except_table_pointer = object_start() + excpet_table_section._offset;
+    const char* except_table_pointer = object_start() + except_table_section._offset;
 
     // Utilize DataExtractor to decode exception handler table.
-    llvm::DataExtractor data_extractor(llvm::StringRef(except_table_pointer, excpet_table_section._size),
+    llvm::DataExtractor data_extractor(llvm::StringRef(except_table_pointer, except_table_section._size),
                                        ELFT::Endianness == llvm::endianness::little, /* IsLittleEndian */
                                        BytesPerWord/* AddressSize */);
     llvm::DataExtractor::Cursor data_cursor(0 /* Offset */);

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -422,10 +422,10 @@ class JeandleRuntimeRoutine : public AllStatic {
 
   // Assembly routine implementations:
 
-#define DEF_GENERETE_ASSEMBLY_ROUTINE(name) \
+#define DEF_GENERATE_ASSEMBLY_ROUTINE(name) \
   static void generate_##name();
 
-  ALL_JEANDLE_ASSEMBLY_ROUTINES(DEF_GENERETE_ASSEMBLY_ROUTINE);
+  ALL_JEANDLE_ASSEMBLY_ROUTINES(DEF_GENERATE_ASSEMBLY_ROUTINE);
 };
 
 #endif // SHARE_JEANDLE_RUNTIME_ROUTINE_HPP

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -774,7 +774,7 @@ llvm::jeandle::CHAOptResult JeandleVMCallback::get_cha_opt_info(uintptr_t caller
 }
 
 // Returns true if the call site was updated
-bool JeandleVMCallback::update_call_site(int64_t id, int dest, bool need_attched, uintptr_t method) {
+bool JeandleVMCallback::update_call_site(int64_t id, int dest, bool need_attached, uintptr_t method) {
   JeandleCompilation* compilation = JeandleCompilation::current();
   assert(compilation != nullptr, "no active compilation");
   JeandleCompiledCode* cc = compilation->compiled_code();
@@ -803,7 +803,7 @@ bool JeandleVMCallback::update_call_site(int64_t id, int dest, bool need_attched
                                          ci_method->is_compiled_lambda_form());
   // False means this update does not provide a new attached method.
   // Preserve an existing one from an earlier MethodHandle intrinsic rewrite.
-  if (need_attched) {
+  if (need_attached) {
     Method* method = reinterpret_cast<Method*>(ci_method->constant_encoding());
     call_site->set_attached_method(method);
   }

--- a/src/hotspot/share/jeandle/templatemodule/template.ll
+++ b/src/hotspot/share/jeandle/templatemodule/template.ll
@@ -116,7 +116,7 @@
 @ObjectMonitor.succ_offset_no_monitor_value = external global i32
 @ObjectMonitor.ANONYMOUS_OWNER = external global i64
 
-; Staic constants in markWord
+; Static constants in markWord
 @markWord.clear_lock_mask = external global i64
 @markWord.monitor_value = external global i64
 @markWord.unlocked_value = external global i64


### PR DESCRIPTION
## What this PR does / why we need it:
fix some typos

- `DEF_GENERETE_ASSEMBLY_ROUTINE` → `DEF_GENERATE_ASSEMBLY_ROUTINE`
- `exeption_range_start_bci` → `exception_range_start_bci`
- `exeption_range_limit_bci` → `exception_range_limit_bci`
- `excpet_table_section` → `except_table_section`
- `need_attched` → `need_attached`
- `Staic constants` → `Static constants`
