### PR TITLE
feat: support profile-guided virtual call devirtualization

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -1075,9 +1075,7 @@ void JeandleAbstractInterpreter::interpret() {
   initialize_VM_state();
   RETURN_VOID_ON_JEANDLE_ERROR();
 
-  if (_parse_context.is_root()) {
-    JeandleCompilation::current()->accumulate_trap_counts_from_mdo(_method);
-  }
+  accumulate_trap_counts_from_mdo(_method);
 
   if (!is_osr()) {
     if (_method->is_synchronized()) {
@@ -3926,4 +3924,26 @@ bool JeandleAbstractInterpreter::too_many_traps(Deoptimization::DeoptReason reas
     return true;
   }
   return false;
+}
+
+void JeandleAbstractInterpreter::accumulate_trap_counts_from_mdo(ciMethod* method) {
+  ciMethodData* md = method->method_data();
+
+  for (uint reason = 0; reason < md->trap_reason_limit(); reason++) {
+    uint md_count = md->trap_count(reason);
+    if (md_count != 0) {
+      if (md_count >= md->trap_count_limit()) {
+        md_count = md->trap_count_limit() + md->overflow_trap_count();
+      }
+      uint total_count = trap_count(reason);
+      uint old_count = total_count;
+      total_count += md_count;
+      // Saturate the add if it overflows.
+      if (total_count < old_count || total_count < md_count) {
+        total_count = uint(-1);
+      }
+      set_trap_count(reason, total_count);
+    }
+  }
+  JeandleCompilation::current()->add_decompile_count(md->decompile_count());
 }

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -3936,4 +3936,5 @@ void JeandleAbstractInterpreter::accumulate_trap_counts_from_mdo(ciMethod* metho
       set_trap_count(reason, total_count);
     }
   }
+  JeandleCompilation::current()->add_decompile_count(md->decompile_count());
 }

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -1075,7 +1075,9 @@ void JeandleAbstractInterpreter::interpret() {
   initialize_VM_state();
   RETURN_VOID_ON_JEANDLE_ERROR();
 
-  accumulate_trap_counts_from_mdo(_method);
+  if (_parse_context.is_root()) {
+    JeandleCompilation::current()->accumulate_trap_counts_from_mdo(_method);
+  }
 
   if (!is_osr()) {
     if (_method->is_synchronized()) {
@@ -3915,26 +3917,4 @@ bool JeandleAbstractInterpreter::too_many_traps(Deoptimization::DeoptReason reas
     return true;
   }
   return false;
-}
-
-void JeandleAbstractInterpreter::accumulate_trap_counts_from_mdo(ciMethod* method) {
-  ciMethodData* md = method->method_data();
-
-  for (uint reason = 0; reason < md->trap_reason_limit(); reason++) {
-    uint md_count = md->trap_count(reason);
-    if (md_count != 0) {
-      if (md_count >= md->trap_count_limit()) {
-        md_count = md->trap_count_limit() + md->overflow_trap_count();
-      }
-      uint total_count = trap_count(reason);
-      uint old_count = total_count;
-      total_count += md_count;
-      // Saturate the add if it overflows.
-      if (total_count < old_count || total_count < md_count) {
-        total_count = uint(-1);
-      }
-      set_trap_count(reason, total_count);
-    }
-  }
-  JeandleCompilation::current()->add_decompile_count(md->decompile_count());
 }

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -522,14 +522,9 @@ class JeandleAbstractInterpreter : public StackObj {
   void guard_klass_being_initialized(llvm::Value* klass);
   void guard_init_thread(llvm::Value* klass);
 
-  void accumulate_trap_counts_from_mdo(ciMethod *method);
   uint trap_count(uint r) const {
     assert(r < MethodData::_trap_hist_limit, "trap reason overflow");
     return _trap_hist[r];
-  }
-  void set_trap_count(uint r, uint c) {
-    assert(r < MethodData::_trap_hist_limit, "trap reason overflow");
-    _trap_hist[r] = c;
   }
   bool too_many_traps(ciMethod *method, int bci, Deoptimization::DeoptReason reason);
   bool too_many_traps(Deoptimization::DeoptReason reason);

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -519,9 +519,14 @@ class JeandleAbstractInterpreter : public StackObj {
   void guard_klass_being_initialized(llvm::Value* klass);
   void guard_init_thread(llvm::Value* klass);
 
+  void accumulate_trap_counts_from_mdo(ciMethod *method);
   uint trap_count(uint r) const {
     assert(r < MethodData::_trap_hist_limit, "trap reason overflow");
     return _trap_hist[r];
+  }
+  void set_trap_count(uint r, uint c) {
+    assert(r < MethodData::_trap_hist_limit, "trap reason overflow");
+    _trap_hist[r] = c;
   }
   bool too_many_traps(ciMethod *method, int bci, Deoptimization::DeoptReason reason);
   bool too_many_traps(Deoptimization::DeoptReason reason);

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -1305,6 +1305,7 @@ void JeandleCompilation::initialize() {
   _env->set_dependencies(new Dependencies(_env));
 
   Copy::zero_to_bytes(_trap_hist, sizeof(_trap_hist));
+  _decompile_count = 0;
 
   set_has_monitors(false);
 

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -64,7 +64,6 @@
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciCallProfile.hpp"
 #include "ci/ciKlass.hpp"
-#include "ci/ciMethodData.hpp"
 #include "ci/ciObject.hpp"
 #include "ci/ciReplay.hpp"
 #include "ci/ciMethodBlocks.hpp"
@@ -1314,28 +1313,6 @@ void JeandleCompilation::initialize() {
   auto now = std::chrono::system_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
   _comp_start_time = std::to_string(duration.count());
-}
-
-void JeandleCompilation::accumulate_trap_counts_from_mdo(ciMethod* method) {
-  ciMethodData* md = method->method_data();
-
-  for (uint reason = 0; reason < md->trap_reason_limit(); reason++) {
-    uint md_count = md->trap_count(reason);
-    if (md_count != 0) {
-      if (md_count >= md->trap_count_limit()) {
-        md_count = md->trap_count_limit() + md->overflow_trap_count();
-      }
-      uint total_count = trap_count(reason);
-      uint old_count = total_count;
-      total_count += md_count;
-      // Saturate the add if it overflows.
-      if (total_count < old_count || total_count < md_count) {
-        total_count = uint(-1);
-      }
-      _trap_hist[reason] = total_count;
-    }
-  }
-  add_decompile_count(md->decompile_count());
 }
 
 void JeandleCompilation::setup_llvm_module(llvm::MemoryBuffer* template_buffer) {

--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -64,6 +64,7 @@
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciCallProfile.hpp"
 #include "ci/ciKlass.hpp"
+#include "ci/ciMethodData.hpp"
 #include "ci/ciObject.hpp"
 #include "ci/ciReplay.hpp"
 #include "ci/ciMethodBlocks.hpp"
@@ -1313,6 +1314,28 @@ void JeandleCompilation::initialize() {
   auto now = std::chrono::system_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
   _comp_start_time = std::to_string(duration.count());
+}
+
+void JeandleCompilation::accumulate_trap_counts_from_mdo(ciMethod* method) {
+  ciMethodData* md = method->method_data();
+
+  for (uint reason = 0; reason < md->trap_reason_limit(); reason++) {
+    uint md_count = md->trap_count(reason);
+    if (md_count != 0) {
+      if (md_count >= md->trap_count_limit()) {
+        md_count = md->trap_count_limit() + md->overflow_trap_count();
+      }
+      uint total_count = trap_count(reason);
+      uint old_count = total_count;
+      total_count += md_count;
+      // Saturate the add if it overflows.
+      if (total_count < old_count || total_count < md_count) {
+        total_count = uint(-1);
+      }
+      _trap_hist[reason] = total_count;
+    }
+  }
+  add_decompile_count(md->decompile_count());
 }
 
 void JeandleCompilation::setup_llvm_module(llvm::MemoryBuffer* template_buffer) {

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -284,6 +284,18 @@ class JeandleCompilation : public StackObj {
   JeandleCompiledCode* compiled_code() { return &_code; }
 
   uint* trap_hist() { return _trap_hist; }
+  uint trap_count(uint reason) const {
+    assert(reason < MethodData::_trap_hist_limit, "trap reason overflow");
+    return _trap_hist[reason];
+  }
+  uint decompile_count() const { return _decompile_count; }
+  void add_decompile_count(uint count) {
+    uint old_count = _decompile_count;
+    _decompile_count += count;
+    if (_decompile_count < old_count || _decompile_count < count) {
+      _decompile_count = uint(-1);
+    }
+  }
 
   Arena* arena() { return _arena; }
 
@@ -309,6 +321,7 @@ class JeandleCompilation : public StackObj {
   std::unique_ptr<llvm::Module> _llvm_module;
   std::string _comp_start_time;
   uint _trap_hist[MethodData::_trap_hist_limit];
+  uint _decompile_count;
   void* _replay_inline_data;
 
   // LLVM uses -1 for the root Java method scope. Non-negative scope ids are

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -288,6 +288,7 @@ class JeandleCompilation : public StackObj {
     assert(reason < MethodData::_trap_hist_limit, "trap reason overflow");
     return _trap_hist[reason];
   }
+  void accumulate_trap_counts_from_mdo(ciMethod* method);
   uint decompile_count() const { return _decompile_count; }
   void add_decompile_count(uint count) {
     uint old_count = _decompile_count;

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -288,7 +288,6 @@ class JeandleCompilation : public StackObj {
     assert(reason < MethodData::_trap_hist_limit, "trap reason overflow");
     return _trap_hist[reason];
   }
-  void accumulate_trap_counts_from_mdo(ciMethod* method);
   uint decompile_count() const { return _decompile_count; }
   void add_decompile_count(uint count) {
     uint old_count = _decompile_count;

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -77,7 +77,7 @@ bool JeandleProfile::has_too_many_recompiles(
   uint method_cutoff = static_cast<uint>(PerMethodRecompilationCutoff) / 2 + 1;
   Deoptimization::DeoptReason per_bc_reason =
       Deoptimization::reason_recorded_per_bytecode_if_any(reason);
-  ciMethod *trap_method =
+  ciMethod* trap_method =
       Deoptimization::reason_is_speculate(reason) ? _method : nullptr;
 
   if ((per_bc_reason == Deoptimization::Reason_none ||
@@ -92,10 +92,10 @@ bool JeandleProfile::has_too_many_recompiles(
          compilation->decompile_count() >= method_cutoff;
 }
 
-static ciMethod *resolve_profile_virtual_target(ciMethod *caller,
-                                                ciMethod *callee,
-                                                ciInstanceKlass *holder,
-                                                ciKlass *receiver) {
+static ciMethod* resolve_profile_virtual_target(ciMethod* caller,
+                                                ciMethod* callee,
+                                                ciInstanceKlass* holder,
+                                                ciKlass* receiver) {
   if (receiver == nullptr) {
     return nullptr;
   }
@@ -112,7 +112,7 @@ static ciMethod *resolve_profile_virtual_target(ciMethod *caller,
     return nullptr;
   }
 
-  ciInstanceKlass *receiver_klass = receiver->as_instance_klass();
+  ciInstanceKlass* receiver_klass = receiver->as_instance_klass();
   if (!receiver_klass->is_loaded() || !receiver_klass->is_initialized() ||
       receiver_klass->is_interface() ||
       !receiver_klass->is_subtype_of(holder)) {
@@ -122,7 +122,7 @@ static ciMethod *resolve_profile_virtual_target(ciMethod *caller,
 }
 
 JeandleProfile::DevirtualizationInfo
-JeandleProfile::devirtualization_at(ciMethod *callee, ciInstanceKlass *holder,
+JeandleProfile::devirtualization_at(ciMethod* callee, ciInstanceKlass* holder,
                                     int bci) const {
   if (_method == nullptr || callee == nullptr || holder == nullptr ||
       callee->can_be_statically_bound() || !is_mature() ||
@@ -147,15 +147,15 @@ JeandleProfile::devirtualization_at(ciMethod *callee, ciInstanceKlass *holder,
     return {};
   }
 
-  ciKlass *receiver = call_profile.receiver(0);
-  ciMethod *target =
+  ciKlass* receiver = call_profile.receiver(0);
+  ciMethod* target =
       resolve_profile_virtual_target(_method, callee, holder, receiver);
   if (target == nullptr || target->is_abstract()) {
     return {};
   }
 
-  ciKlass *receiver2 = nullptr;
-  ciMethod *target2 = nullptr;
+  ciKlass* receiver2 = nullptr;
+  ciMethod* target2 = nullptr;
   int64_t receiver_count2 = 0;
   if (bimorphic_candidate) {
     if (!call_profile.has_receiver(1) || call_profile.receiver_count(1) <= 0) {

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -142,10 +142,15 @@ JeandleProfile::devirtualization_at(ciMethod* callee, ciInstanceKlass* holder,
     return {};
   }
 
+  auto resolve_target = [&](ciKlass* receiver) -> ciMethod* {
+    ciMethod* target =
+        resolve_profile_virtual_target(_method, callee, holder, receiver);
+    return target != nullptr && !target->is_abstract() ? target : nullptr;
+  };
+
   ciKlass* receiver = call_profile.receiver(0);
-  ciMethod* target =
-      resolve_profile_virtual_target(_method, callee, holder, receiver);
-  if (target == nullptr || target->is_abstract()) {
+  ciMethod* target = resolve_target(receiver);
+  if (target == nullptr) {
     return {};
   }
 
@@ -159,9 +164,8 @@ JeandleProfile::devirtualization_at(ciMethod* callee, ciInstanceKlass* holder,
       }
     } else {
       receiver2 = call_profile.receiver(1);
-      target2 =
-          resolve_profile_virtual_target(_method, callee, holder, receiver2);
-      if (target2 == nullptr || target2->is_abstract()) {
+      target2 = resolve_target(receiver2);
+      if (target2 == nullptr) {
         if (!has_major_receiver) {
           return {};
         }

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -56,7 +56,13 @@ bool JeandleProfile::has_trap_at(int bci,
   // Treat the conservative "maybe trapped here" answer as a real trap for
   // speculation gating. Metadata-only uses such as branch_weights do not need
   // this guard; uncommon-trap/speculative transforms do.
-  return _mdo->has_trap_at(bci, nullptr, reason) != 0;
+  JeandleCompilation* compilation = JeandleCompilation::current();
+  // Speculative trap data is keyed by the compilation root, not the inline
+  // method whose MDO is being queried.
+  ciMethod* trap_method =
+      Deoptimization::reason_is_speculate(reason) ? compilation->method()
+                                                  : nullptr;
+  return _mdo->has_trap_at(bci, trap_method, reason) != 0;
 }
 
 bool JeandleProfile::has_too_many_traps(
@@ -78,15 +84,20 @@ bool JeandleProfile::has_too_many_recompiles(
   uint method_cutoff = static_cast<uint>(PerMethodRecompilationCutoff) / 2 + 1;
   Deoptimization::DeoptReason per_bc_reason =
       Deoptimization::reason_recorded_per_bytecode_if_any(reason);
+  JeandleCompilation* compilation = JeandleCompilation::current();
+  // Match C2: speculative trap data is associated with the root compilation
+  // method, while _method identifies the MDO being queried.
+  ciMethod* trap_method =
+      Deoptimization::reason_is_speculate(reason) ? compilation->method()
+                                                  : nullptr;
 
   if ((per_bc_reason == Deoptimization::Reason_none ||
-       _mdo->has_trap_at(bci, nullptr, reason) != 0) &&
-      _mdo->trap_recompiled_at(bci, nullptr) &&
+       _mdo->has_trap_at(bci, trap_method, reason) != 0) &&
+      _mdo->trap_recompiled_at(bci, trap_method) &&
       _mdo->overflow_recompile_count() >= bc_cutoff) {
     return true;
   }
 
-  JeandleCompilation* compilation = JeandleCompilation::current();
   return compilation->trap_count(reason) != 0 &&
          compilation->decompile_count() >= method_cutoff;
 }

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -22,9 +22,17 @@
 #include "jeandle/jeandle_globals.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "ci/ciCallProfile.hpp"
+#include "ci/ciEnv.hpp"
+#include "ci/ciInstanceKlass.hpp"
+#include "ci/ciKlass.hpp"
 #include "ci/ciMethod.hpp"
 #include "ci/ciMethodData.hpp"
+#include "ci/ciSymbols.hpp"
+#include "logging/log.hpp"
 #include "oops/methodData.hpp"
+#include "opto/c2_globals.hpp"
+#include "runtime/globals.hpp"
 
 JeandleProfile::JeandleProfile(ciMethod* method)
   : _method(method),
@@ -36,6 +44,171 @@ bool JeandleProfile::has_profile() const {
 
 bool JeandleProfile::is_mature() const {
   return _mdo != nullptr && _mdo->is_mature();
+}
+
+bool JeandleProfile::has_trap_at(int bci,
+                                 Deoptimization::DeoptReason reason) const {
+  if (_mdo == nullptr) {
+    return false;
+  }
+  // Treat the conservative "maybe trapped here" answer as a real trap for
+  // speculation gating. Metadata-only uses such as branch_weights do not need
+  // this guard; uncommon-trap/speculative transforms do.
+  return _mdo->has_trap_at(bci, nullptr, reason) != 0;
+}
+
+bool JeandleProfile::has_too_many_traps(
+    Deoptimization::DeoptReason reason) const {
+  if (_mdo == nullptr || _mdo->is_empty()) {
+    return false;
+  }
+  return _mdo->trap_count(reason) >=
+         Deoptimization::per_method_trap_limit(reason);
+}
+
+bool JeandleProfile::has_too_many_recompiles(
+    int bci, Deoptimization::DeoptReason reason) const {
+  if (_mdo == nullptr || _mdo->is_empty()) {
+    return false;
+  }
+
+  uint bc_cutoff = static_cast<uint>(PerBytecodeRecompilationCutoff) / 8;
+  uint method_cutoff = static_cast<uint>(PerMethodRecompilationCutoff) / 2 + 1;
+  Deoptimization::DeoptReason per_bc_reason =
+      Deoptimization::reason_recorded_per_bytecode_if_any(reason);
+  ciMethod *trap_method =
+      Deoptimization::reason_is_speculate(reason) ? _method : nullptr;
+
+  if ((per_bc_reason == Deoptimization::Reason_none ||
+       _mdo->has_trap_at(bci, trap_method, reason) != 0) &&
+      _mdo->trap_recompiled_at(bci, trap_method) &&
+      _mdo->overflow_recompile_count() >= bc_cutoff) {
+    return true;
+  }
+
+  return _mdo->trap_count(reason) != 0 &&
+         _mdo->decompile_count() >= method_cutoff;
+}
+
+static ciMethod *resolve_profile_virtual_target(ciMethod *caller,
+                                                ciMethod *callee,
+                                                ciInstanceKlass *holder,
+                                                ciKlass *receiver) {
+  if (receiver == nullptr) {
+    return nullptr;
+  }
+
+  if (receiver->is_array_klass()) {
+    if (callee->holder() == ciEnv::current()->Object_klass() &&
+        callee->name() != ciSymbols::finalize_method_name()) {
+      return callee;
+    }
+    return nullptr;
+  }
+
+  if (!receiver->is_instance_klass()) {
+    return nullptr;
+  }
+
+  ciInstanceKlass *receiver_klass = receiver->as_instance_klass();
+  if (!receiver_klass->is_loaded() || !receiver_klass->is_initialized() ||
+      receiver_klass->is_interface() ||
+      !receiver_klass->is_subtype_of(holder)) {
+    return nullptr;
+  }
+  return callee->resolve_invoke(caller->holder(), receiver_klass);
+}
+
+JeandleProfile::DevirtualizationInfo
+JeandleProfile::devirtualization_at(ciMethod *callee, ciInstanceKlass *holder,
+                                    int bci) const {
+  if (_method == nullptr || callee == nullptr || holder == nullptr ||
+      !is_mature() || !UseTypeProfile || !UseJeandleCompiler ||
+      !JeandleUseProfiledVirtualCallDevirtualization) {
+    return {};
+  }
+
+  ciCallProfile call_profile = _method->call_profile_at_bci(bci);
+  if (!call_profile.has_receiver(0) || call_profile.count() <= 0 ||
+      call_profile.receiver_count(0) <= 0) {
+    return {};
+  }
+
+  int64_t receiver_count = call_profile.receiver_count(0);
+  int64_t total_count = call_profile.count();
+  int morphism = call_profile.morphism();
+  bool has_major_receiver = 100.0 * call_profile.receiver_prob(0) >=
+                            static_cast<float>(TypeProfileMajorReceiverPercent);
+  bool bimorphic_candidate = morphism == 2 && UseBimorphicInlining;
+  if (morphism != 1 && !has_major_receiver && !bimorphic_candidate) {
+    return {};
+  }
+
+  ciKlass *receiver = call_profile.receiver(0);
+  ciMethod *target =
+      resolve_profile_virtual_target(_method, callee, holder, receiver);
+  if (target == nullptr || target->is_abstract()) {
+    return {};
+  }
+
+  ciKlass *receiver2 = nullptr;
+  ciMethod *target2 = nullptr;
+  int64_t receiver_count2 = 0;
+  if (bimorphic_candidate) {
+    if (!call_profile.has_receiver(1) || call_profile.receiver_count(1) <= 0) {
+      if (!has_major_receiver) {
+        return {};
+      }
+    } else {
+      receiver2 = call_profile.receiver(1);
+      target2 =
+          resolve_profile_virtual_target(_method, callee, holder, receiver2);
+      if (target2 == nullptr || target2->is_abstract()) {
+        if (!has_major_receiver) {
+          return {};
+        }
+        receiver2 = nullptr;
+        target2 = nullptr;
+      } else {
+        receiver_count2 = call_profile.receiver_count(1);
+      }
+    }
+  }
+
+  Deoptimization::DeoptReason reason = receiver2 == nullptr
+                                           ? Deoptimization::Reason_class_check
+                                           : Deoptimization::Reason_bimorphic;
+  bool too_many_traps_or_recompiles = has_trap_at(bci, reason) ||
+                                      has_too_many_traps(reason) ||
+                                      has_too_many_recompiles(bci, reason);
+  // Match C2's hysteresis: an initial miss refreshes receiver profiling through
+  // deoptimization. Once the same BCI/reason has trapped, subsequent compiles
+  // keep the guarded fast path but select a dynamic virtual-call miss path.
+  bool deoptimize_on_miss =
+      (morphism == 1 || receiver2 != nullptr) && !too_many_traps_or_recompiles;
+
+  if (receiver2 == nullptr) {
+    log_debug(jeandle)("profile_devirt_candidate: caller=%s bci=%d receiver=%s "
+                       "target=%s count=" INT64_FORMAT " total=" INT64_FORMAT
+                       " morphism=%d miss=%s",
+                       _method->name()->as_utf8(), bci,
+                       receiver->name()->as_utf8(), target->name()->as_utf8(),
+                       receiver_count, total_count, morphism,
+                       deoptimize_on_miss ? "uncommon_trap" : "virtual_call");
+  } else {
+    log_debug(jeandle)(
+        "profile_devirt_candidate: caller=%s bci=%d receiver=%s "
+        "receiver2=%s target=%s target2=%s count=" INT64_FORMAT
+        " count2=" INT64_FORMAT " total=" INT64_FORMAT " morphism=%d miss=%s",
+        _method->name()->as_utf8(), bci, receiver->name()->as_utf8(),
+        receiver2->name()->as_utf8(), target->name()->as_utf8(),
+        target2->name()->as_utf8(), receiver_count, receiver_count2,
+        total_count, morphism,
+        deoptimize_on_miss ? "uncommon_trap" : "virtual_call");
+  }
+
+  return {receiver, target, receiver_count, total_count, reason,
+          deoptimize_on_miss, receiver2, target2, receiver_count2};
 }
 
 // A branch/case count too large to fit in a signed int is treated as

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -21,6 +21,7 @@
 #include "jeandle/jeandleProfile.hpp"
 #include "jeandle/jeandleCompilation.hpp"
 #include "jeandle/jeandle_globals.hpp"
+#include "jeandle/jeandleUtils.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciCallProfile.hpp"
@@ -108,17 +109,11 @@ static ciMethod* resolve_profile_virtual_target(ciMethod* caller,
     return nullptr;
   }
 
-  if (!receiver->is_instance_klass()) {
+  if (!is_valid_instance_receiver(receiver, holder)) {
     return nullptr;
   }
-
-  ciInstanceKlass* receiver_klass = receiver->as_instance_klass();
-  if (!receiver_klass->is_loaded() || !receiver_klass->is_initialized() ||
-      receiver_klass->is_interface() ||
-      !receiver_klass->is_subtype_of(holder)) {
-    return nullptr;
-  }
-  return callee->resolve_invoke(caller->holder(), receiver_klass);
+  return callee->resolve_invoke(caller->holder(),
+                                receiver->as_instance_klass());
 }
 
 JeandleProfile::DevirtualizationInfo

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "jeandle/jeandleProfile.hpp"
+#include "jeandle/jeandleCompilation.hpp"
 #include "jeandle/jeandle_globals.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
@@ -62,7 +63,7 @@ bool JeandleProfile::has_too_many_traps(
   if (_mdo == nullptr || _mdo->is_empty()) {
     return false;
   }
-  return _mdo->trap_count(reason) >=
+  return JeandleCompilation::current()->trap_count(reason) >=
          Deoptimization::per_method_trap_limit(reason);
 }
 
@@ -86,8 +87,9 @@ bool JeandleProfile::has_too_many_recompiles(
     return true;
   }
 
-  return _mdo->trap_count(reason) != 0 &&
-         _mdo->decompile_count() >= method_cutoff;
+  JeandleCompilation* compilation = JeandleCompilation::current();
+  return compilation->trap_count(reason) != 0 &&
+         compilation->decompile_count() >= method_cutoff;
 }
 
 static ciMethod *resolve_profile_virtual_target(ciMethod *caller,

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -78,12 +78,10 @@ bool JeandleProfile::has_too_many_recompiles(
   uint method_cutoff = static_cast<uint>(PerMethodRecompilationCutoff) / 2 + 1;
   Deoptimization::DeoptReason per_bc_reason =
       Deoptimization::reason_recorded_per_bytecode_if_any(reason);
-  ciMethod* trap_method =
-      Deoptimization::reason_is_speculate(reason) ? _method : nullptr;
 
   if ((per_bc_reason == Deoptimization::Reason_none ||
-       _mdo->has_trap_at(bci, trap_method, reason) != 0) &&
-      _mdo->trap_recompiled_at(bci, trap_method) &&
+       _mdo->has_trap_at(bci, nullptr, reason) != 0) &&
+      _mdo->trap_recompiled_at(bci, nullptr) &&
       _mdo->overflow_recompile_count() >= bc_cutoff) {
     return true;
   }
@@ -150,17 +148,10 @@ select_profile_targets(ciMethod* caller, ciMethod* callee,
   ciMethod* target2 = nullptr;
   int64_t receiver_count2 = 0;
   if (bimorphic_candidate) {
-    if (!call_profile.has_receiver(1) || call_profile.receiver_count(1) <= 0) {
-      if (!has_major_receiver) {
-        return {};
-      }
-    } else {
+    if (call_profile.has_receiver(1) && call_profile.receiver_count(1) > 0) {
       receiver2 = call_profile.receiver(1);
       target2 = resolve_target(receiver2);
       if (target2 == nullptr) {
-        if (!has_major_receiver) {
-          return {};
-        }
         receiver2 = nullptr;
       } else {
         receiver_count2 = call_profile.receiver_count(1);
@@ -196,17 +187,16 @@ JeandleProfile::devirtualization_at(ciMethod* callee, ciInstanceKlass* holder,
     return {};
   }
 
-  Deoptimization::DeoptReason reason = result.receiver2 == nullptr
-                                           ? Deoptimization::Reason_class_check
-                                           : Deoptimization::Reason_bimorphic;
-  bool too_many_traps_or_recompiles = has_trap_at(bci, reason) ||
-                                      has_too_many_traps(reason) ||
-                                      has_too_many_recompiles(bci, reason);
+  Deoptimization::DeoptReason reason = morphism == 2
+                                           ? Deoptimization::Reason_bimorphic
+                                           : Deoptimization::Reason_class_check;
   // Match C2's hysteresis: an initial miss refreshes receiver profiling through
   // deoptimization. Once the same BCI/reason has trapped, subsequent compiles
   // keep the guarded fast path but select a dynamic virtual-call miss path.
   bool deoptimize_on_miss = (morphism == 1 || result.receiver2 != nullptr) &&
-                            !too_many_traps_or_recompiles;
+                            !has_trap_at(bci, reason) &&
+                            !has_too_many_traps(reason) &&
+                            !has_too_many_recompiles(bci, reason);
 
   if (result.receiver2 == nullptr) {
     log_debug(jeandle)("profile_devirt_candidate: caller=%s bci=%d receiver=%s "

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -125,7 +125,8 @@ JeandleProfile::DevirtualizationInfo
 JeandleProfile::devirtualization_at(ciMethod *callee, ciInstanceKlass *holder,
                                     int bci) const {
   if (_method == nullptr || callee == nullptr || holder == nullptr ||
-      !is_mature() || !UseTypeProfile || !UseJeandleCompiler ||
+      callee->can_be_statically_bound() || !is_mature() ||
+      !UseTypeProfile || !UseJeandleCompiler ||
       !JeandleUseProfiledVirtualCallDevirtualization) {
     return {};
   }

--- a/src/hotspot/share/jeandle/jeandleProfile.cpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.cpp
@@ -116,17 +116,9 @@ static ciMethod* resolve_profile_virtual_target(ciMethod* caller,
                                 receiver->as_instance_klass());
 }
 
-JeandleProfile::DevirtualizationInfo
-JeandleProfile::devirtualization_at(ciMethod* callee, ciInstanceKlass* holder,
-                                    int bci) const {
-  if (_method == nullptr || callee == nullptr || holder == nullptr ||
-      callee->can_be_statically_bound() || !is_mature() ||
-      !UseTypeProfile || !UseJeandleCompiler ||
-      !JeandleUseProfiledVirtualCallDevirtualization) {
-    return {};
-  }
-
-  ciCallProfile call_profile = _method->call_profile_at_bci(bci);
+static JeandleProfile::DevirtualizationInfo
+select_profile_targets(ciMethod* caller, ciMethod* callee,
+                       ciInstanceKlass* holder, ciCallProfile& call_profile) {
   if (!call_profile.has_receiver(0) || call_profile.count() <= 0 ||
       call_profile.receiver_count(0) <= 0) {
     return {};
@@ -144,7 +136,7 @@ JeandleProfile::devirtualization_at(ciMethod* callee, ciInstanceKlass* holder,
 
   auto resolve_target = [&](ciKlass* receiver) -> ciMethod* {
     ciMethod* target =
-        resolve_profile_virtual_target(_method, callee, holder, receiver);
+        resolve_profile_virtual_target(caller, callee, holder, receiver);
     return target != nullptr && !target->is_abstract() ? target : nullptr;
   };
 
@@ -170,14 +162,41 @@ JeandleProfile::devirtualization_at(ciMethod* callee, ciInstanceKlass* holder,
           return {};
         }
         receiver2 = nullptr;
-        target2 = nullptr;
       } else {
         receiver_count2 = call_profile.receiver_count(1);
       }
     }
   }
 
-  Deoptimization::DeoptReason reason = receiver2 == nullptr
+  JeandleProfile::DevirtualizationInfo result;
+  result.receiver = receiver;
+  result.target = target;
+  result.receiver_count = receiver_count;
+  result.total_count = total_count;
+  result.receiver2 = receiver2;
+  result.target2 = target2;
+  result.receiver_count2 = receiver_count2;
+  return result;
+}
+
+JeandleProfile::DevirtualizationInfo
+JeandleProfile::devirtualization_at(ciMethod* callee, ciInstanceKlass* holder,
+                                    int bci) const {
+  if (_method == nullptr || callee == nullptr || holder == nullptr ||
+      callee->can_be_statically_bound() || !is_mature() || !UseTypeProfile ||
+      !UseJeandleCompiler || !JeandleUseProfiledVirtualCallDevirtualization) {
+    return {};
+  }
+
+  ciCallProfile call_profile = _method->call_profile_at_bci(bci);
+  int morphism = call_profile.morphism();
+  DevirtualizationInfo result =
+      select_profile_targets(_method, callee, holder, call_profile);
+  if (!result.is_valid()) {
+    return {};
+  }
+
+  Deoptimization::DeoptReason reason = result.receiver2 == nullptr
                                            ? Deoptimization::Reason_class_check
                                            : Deoptimization::Reason_bimorphic;
   bool too_many_traps_or_recompiles = has_trap_at(bci, reason) ||
@@ -186,31 +205,33 @@ JeandleProfile::devirtualization_at(ciMethod* callee, ciInstanceKlass* holder,
   // Match C2's hysteresis: an initial miss refreshes receiver profiling through
   // deoptimization. Once the same BCI/reason has trapped, subsequent compiles
   // keep the guarded fast path but select a dynamic virtual-call miss path.
-  bool deoptimize_on_miss =
-      (morphism == 1 || receiver2 != nullptr) && !too_many_traps_or_recompiles;
+  bool deoptimize_on_miss = (morphism == 1 || result.receiver2 != nullptr) &&
+                            !too_many_traps_or_recompiles;
 
-  if (receiver2 == nullptr) {
+  if (result.receiver2 == nullptr) {
     log_debug(jeandle)("profile_devirt_candidate: caller=%s bci=%d receiver=%s "
                        "target=%s count=" INT64_FORMAT " total=" INT64_FORMAT
                        " morphism=%d miss=%s",
                        _method->name()->as_utf8(), bci,
-                       receiver->name()->as_utf8(), target->name()->as_utf8(),
-                       receiver_count, total_count, morphism,
+                       result.receiver->name()->as_utf8(),
+                       result.target->name()->as_utf8(), result.receiver_count,
+                       result.total_count, morphism,
                        deoptimize_on_miss ? "uncommon_trap" : "virtual_call");
   } else {
     log_debug(jeandle)(
         "profile_devirt_candidate: caller=%s bci=%d receiver=%s "
         "receiver2=%s target=%s target2=%s count=" INT64_FORMAT
         " count2=" INT64_FORMAT " total=" INT64_FORMAT " morphism=%d miss=%s",
-        _method->name()->as_utf8(), bci, receiver->name()->as_utf8(),
-        receiver2->name()->as_utf8(), target->name()->as_utf8(),
-        target2->name()->as_utf8(), receiver_count, receiver_count2,
-        total_count, morphism,
+        _method->name()->as_utf8(), bci, result.receiver->name()->as_utf8(),
+        result.receiver2->name()->as_utf8(), result.target->name()->as_utf8(),
+        result.target2->name()->as_utf8(), result.receiver_count,
+        result.receiver_count2, result.total_count, morphism,
         deoptimize_on_miss ? "uncommon_trap" : "virtual_call");
   }
 
-  return {receiver, target, receiver_count, total_count, reason,
-          deoptimize_on_miss, receiver2, target2, receiver_count2};
+  result.deopt_reason = reason;
+  result.deoptimize_on_miss = deoptimize_on_miss;
+  return result;
 }
 
 // A branch/case count too large to fit in a signed int is treated as

--- a/src/hotspot/share/jeandle/jeandleProfile.hpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.hpp
@@ -28,6 +28,12 @@
 #include "ci/ciMethod.hpp"
 #include "ci/ciMethodData.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/deoptimization.hpp"
+
+#include <cstdint>
+
+class ciInstanceKlass;
+class ciKlass;
 
 // Read-only view of a method's MDO for the Jeandle JIT. Callers must treat
 // has_profile()==false as "emit the conservative shape", never as an error --
@@ -36,7 +42,29 @@ class JeandleProfile : public StackObj {
   ciMethod*     _method;
   ciMethodData* _mdo;
 
- public:
+  // C2-compatible speculation failure gates. Keep them private so callers use
+  // devirtualization_at() as the single receiver-profile policy entry point.
+  bool has_trap_at(int bci, Deoptimization::DeoptReason reason) const;
+  bool has_too_many_traps(Deoptimization::DeoptReason reason) const;
+  bool has_too_many_recompiles(int bci,
+                               Deoptimization::DeoptReason reason) const;
+
+public:
+  struct DevirtualizationInfo {
+    ciKlass* receiver = nullptr;
+    ciMethod* target = nullptr;
+    int64_t receiver_count = 0;
+    int64_t total_count = 0;
+    Deoptimization::DeoptReason deopt_reason = Deoptimization::Reason_none;
+    bool deoptimize_on_miss = false;
+    ciKlass* receiver2 = nullptr;
+    ciMethod* target2 = nullptr;
+    int64_t receiver_count2 = 0;
+
+    bool is_valid() const { return receiver != nullptr && target != nullptr; }
+    bool is_bimorphic() const { return receiver2 != nullptr; }
+  };
+
   explicit JeandleProfile(ciMethod* method);
 
   bool has_profile() const;
@@ -44,6 +72,11 @@ class JeandleProfile : public StackObj {
   // True when the MDO has enough samples to trust for speculation. Speculative
   // transforms (unstable-if prune, guarded devirt) must gate on this.
   bool is_mature() const;
+
+  // Single JDK-side entry point for receiver profile maturity, morphism,
+  // target resolution, and speculative trap gating.
+  DevirtualizationInfo
+  devirtualization_at(ciMethod *callee, ciInstanceKlass *holder, int bci) const;
 
   struct BranchCounts {
     uint taken;

--- a/src/hotspot/share/jeandle/jeandleProfile.hpp
+++ b/src/hotspot/share/jeandle/jeandleProfile.hpp
@@ -49,7 +49,7 @@ class JeandleProfile : public StackObj {
   bool has_too_many_recompiles(int bci,
                                Deoptimization::DeoptReason reason) const;
 
-public:
+ public:
   struct DevirtualizationInfo {
     ciKlass* receiver = nullptr;
     ciMethod* target = nullptr;
@@ -75,8 +75,9 @@ public:
 
   // Single JDK-side entry point for receiver profile maturity, morphism,
   // target resolution, and speculative trap gating.
-  DevirtualizationInfo
-  devirtualization_at(ciMethod *callee, ciInstanceKlass *holder, int bci) const;
+  DevirtualizationInfo devirtualization_at(ciMethod* callee,
+                                            ciInstanceKlass* holder,
+                                            int bci) const;
 
   struct BranchCounts {
     uint taken;

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -219,9 +219,16 @@ std::string JeandleFuncSig::method_name(ciMethod* method) {
 }
 
 std::string JeandleFuncSig::method_name_with_signature(ciMethod* method) {
-  std::string signature = std::string(method->signature()->as_symbol()->as_utf8());
-  return method_name(method) + signature;
-
+  std::string signature =
+      std::string(method->signature()->as_symbol()->as_utf8());
+  // A Java class is identified by both its defining class loader and its
+  // binary name. Dynamically generated classes from different loaders may
+  // therefore have the same class/method/signature spelling while denoting
+  // different Methods. Keep the readable spelling, but append the ciMethod
+  // identity used by the active compilation so every Java method gets a
+  // distinct LLVM symbol in the module.
+  return method_name(method) + signature + ".jeandle_method_" +
+         std::to_string(reinterpret_cast<uintptr_t>(method));
 }
 
 std::string JeandleFuncSig::root_method_name(ciMethod* method, bool is_osr_entry) {

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -30,6 +30,7 @@
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciInstanceKlass.hpp"
+#include "ci/ciKlass.hpp"
 #include "ci/ciObjArrayKlass.hpp"
 #include "ci/ciType.hpp"
 #include "compiler/abstractCompiler.hpp"
@@ -80,6 +81,18 @@ bool is_effectively_final(Klass* klass) {
   if (klass->is_objArray_klass())
     return is_effectively_final(ObjArrayKlass::cast(klass)->bottom_klass());
   return false;
+}
+
+bool is_valid_instance_receiver(ciKlass* receiver, ciInstanceKlass* holder) {
+  if (receiver == nullptr || holder == nullptr ||
+      !receiver->is_instance_klass()) {
+    return false;
+  }
+
+  ciInstanceKlass* receiver_klass = receiver->as_instance_klass();
+  return receiver_klass->is_loaded() && receiver_klass->is_initialized() &&
+         !receiver_klass->is_interface() &&
+         receiver_klass->is_subtype_of(holder);
 }
 
 void attach_java_klass_ret_attr(llvm::CallBase* call,

--- a/src/hotspot/share/jeandle/jeandleUtils.cpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.cpp
@@ -221,13 +221,9 @@ std::string JeandleFuncSig::method_name(ciMethod* method) {
 std::string JeandleFuncSig::method_name_with_signature(ciMethod* method) {
   std::string signature =
       std::string(method->signature()->as_symbol()->as_utf8());
-  // A Java class is identified by both its defining class loader and its
-  // binary name. Dynamically generated classes from different loaders may
-  // therefore have the same class/method/signature spelling while denoting
-  // different Methods. Keep the readable spelling, but append the ciMethod
-  // identity used by the active compilation so every Java method gets a
-  // distinct LLVM symbol in the module.
-  return method_name(method) + signature + ".jeandle_method_" +
+  // The binary name does not distinguish classes defined by different class
+  // loaders. Append the ciMethod identity so their LLVM symbols stay distinct.
+  return method_name(method) + signature + "." +
          std::to_string(reinterpret_cast<uintptr_t>(method));
 }
 

--- a/src/hotspot/share/jeandle/jeandleUtils.hpp
+++ b/src/hotspot/share/jeandle/jeandleUtils.hpp
@@ -29,6 +29,8 @@
 #include "ci/ciMethod.hpp"
 
 class Klass;
+class ciInstanceKlass;
+class ciKlass;
 class ciType;
 
 namespace llvm {
@@ -58,6 +60,9 @@ bool is_unverified_interface(Klass* klass);
 // A klass is effectively final if no subtype can exist at runtime.
 bool is_effectively_final(ciKlass* klass);
 bool is_effectively_final(Klass* klass);
+
+// Check whether a receiver is a loaded, initialized instance subtype of holder.
+bool is_valid_instance_receiver(ciKlass* receiver, ciInstanceKlass* holder);
 
 // Attach JavaKlass (and JavaKlassExact when applicable) return-value attributes
 // to a CallBase, based on the Java return type derived from the callee signature.

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -682,9 +682,7 @@ llvm::jeandle::CHAOptInfo optimize_virtual_call(ciMethod* caller,
       JeandleVMCallback::get_receiver_instance_klass(receiver_klass);
   ciInstanceKlass* actual_receiver = holder;
   bool actual_receiver_is_exact = false;
-  if (receiver_inst_klass->is_loaded() && receiver_inst_klass->is_initialized() &&
-      !receiver_inst_klass->is_interface() &&
-      (receiver_inst_klass == actual_receiver || receiver_inst_klass->is_subtype_of(actual_receiver))) {
+  if (is_valid_instance_receiver(receiver_inst_klass, actual_receiver)) {
     actual_receiver = receiver_inst_klass;
     actual_receiver_is_exact = is_exact;
   }

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -25,6 +25,7 @@
 #include "llvm/IR/Jeandle/VMCallbackLog.h"
 #include "llvm/IR/Jeandle/InvokeType.h"
 #include "llvm/Transforms/Jeandle/CHADevirtualization.h"
+#include "llvm/Transforms/Jeandle/ProfileDevirtualization.h"
 
 #include "jeandle/jeandleAbstractInterpreter.hpp"
 #include "jeandle/jeandleCompilation.hpp"
@@ -32,6 +33,7 @@
 #include "jeandle/jeandleVMCallback.hpp"
 #include "jeandle/jeandleCompiledCall.hpp"
 #include "jeandle/jeandleCompiledCode.hpp"
+#include "jeandle/jeandleProfile.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
 #include "ci/ciClassList.hpp"
@@ -48,6 +50,7 @@
 #include "ci/ciObject.hpp"
 #include "ci/ciType.hpp"
 #include "ci/ciUtilities.inline.hpp"
+#include "code/oopRecorder.hpp"
 #include "logging/log.hpp"
 #include "oops/fieldInfo.inline.hpp"
 #include "oops/fieldStreams.inline.hpp"
@@ -810,6 +813,91 @@ bool JeandleVMCallback::update_call_site(int64_t id, int dest, bool need_attache
   return true;
 }
 
+// ---------------------------------------------------------------------------
+// Profile-guided devirtualization
+// ---------------------------------------------------------------------------
+
+static void record_profile_receiver(ciKlass* receiver) {
+  assert(receiver != nullptr, "profile receiver must be present");
+  ciEnv* env = ciEnv::current();
+  assert(env != nullptr && env->oop_recorder() != nullptr,
+         "profile devirtualization must run in an active compilation");
+  // LLVM embeds the Klass* value in the exact-receiver guard. Recording it in
+  // the nmethod metadata table lets class unloading discover the dependency
+  // and invalidate the nmethod before that address can be reused.
+  env->oop_recorder()->find_index(receiver->constant_encoding());
+}
+
+llvm::jeandle::ProfileDevirtualizationResult
+JeandleVMCallback::get_profile_devirtualization_info(
+    uintptr_t caller_ptr, uintptr_t callee_ptr, uintptr_t holder_ptr, int bci,
+    int invoke_kind) {
+  if (caller_ptr == 0 || callee_ptr == 0 || holder_ptr == 0 || bci < 0 ||
+      (invoke_kind != llvm::jeandle::InvokeVirtual &&
+       invoke_kind != llvm::jeandle::InvokeInterface)) {
+    return {};
+  }
+
+  ciMethod* caller = reinterpret_cast<ciMethod*>(caller_ptr);
+  ciMethod* callee = reinterpret_cast<ciMethod*>(callee_ptr);
+  ciInstanceKlass* holder = reinterpret_cast<ciInstanceKlass*>(holder_ptr);
+  assert(!callee->can_be_statically_bound(),
+         "statically bound calls are handled by the bytecode parser");
+
+  JeandleProfile::DevirtualizationInfo opt_info =
+      JeandleProfile(caller).devirtualization_at(callee, holder, bci);
+  if (!opt_info.is_valid()) {
+    return {};
+  }
+
+  record_profile_receiver(opt_info.receiver);
+  if (opt_info.receiver2 != nullptr) {
+    record_profile_receiver(opt_info.receiver2);
+  }
+
+  llvm::jeandle::ProfileDevirtualizationTargetResult target{
+      reinterpret_cast<uintptr_t>(opt_info.receiver->constant_encoding()),
+      reinterpret_cast<uintptr_t>(opt_info.target), opt_info.receiver_count,
+      JeandleFuncSig::method_name_with_signature(opt_info.target)};
+  llvm::jeandle::ProfileDevirtualizationTargetResult target2;
+  if (opt_info.receiver2 != nullptr) {
+    target2 = {
+        reinterpret_cast<uintptr_t>(opt_info.receiver2->constant_encoding()),
+        reinterpret_cast<uintptr_t>(opt_info.target2), opt_info.receiver_count2,
+        JeandleFuncSig::method_name_with_signature(opt_info.target2)};
+  }
+  return {std::move(target), opt_info.total_count,
+          llvm::jeandle::ProfileDevirtualizationInfo::packDeoptInfo(
+              opt_info.target->is_accessor(),
+              opt_info.target2 != nullptr && opt_info.target2->is_accessor(),
+              static_cast<llvm::jeandle::Deoptimization::DeoptReason>(
+                  opt_info.deopt_reason)),
+          opt_info.deoptimize_on_miss, std::move(target2)};
+}
+
+// Change a virtual callsite to opt virtual call site.
+bool JeandleVMCallback::update_to_static_opt_virtual_call(int64_t id) {
+  JeandleCompilation* compilation = JeandleCompilation::current();
+  assert(compilation != nullptr, "no active compilation");
+  JeandleCompiledCode* cc = compilation->compiled_code();
+  if (id < 0) {
+    return false;
+  }
+  if (static_cast<size_t>(id) >= cc->non_routine_call_sites().size()) {
+    return false;
+  }
+  CallSiteInfo* call_site = cc->non_routine_call_sites()[id];
+  if (call_site == nullptr) {
+    return false;
+  }
+  // This callback updates only JDK installation metadata. LLVM owns the IR
+  // rewrite, while callback-log replay can reproduce it from the recorded
+  // return value without requiring a live CallSiteInfo.
+  call_site->set_type(JeandleCompiledCall::STATIC_CALL);
+  call_site->set_target(SharedRuntime::get_resolve_opt_virtual_call_stub());
+  return true;
+}
+
 uintptr_t JeandleVMCallback::get_signature_accessing_klass(uintptr_t method) {
   ciMethod* m = jeandle_callback_method(method);
   ciKlass* k = m->signature()->accessing_klass();
@@ -870,6 +958,10 @@ void JeandleVMCallback::register_callbacks() {
   callbacks.GetSignatureAccessingKlass = &JeandleVMCallback::get_signature_accessing_klass;
   callbacks.GetSignatureArgType = &JeandleVMCallback::get_signature_arg_type;
   callbacks.GetSignatureArgTypeKlass = &JeandleVMCallback::get_signature_arg_type_klass;
+  callbacks.GetProfileDevirtualizationInfo =
+      &JeandleVMCallback::get_profile_devirtualization_info;
+  callbacks.UpdateToStaticOptVirtualCall =
+      &JeandleVMCallback::update_to_static_opt_virtual_call;
   llvm::jeandle::registerVMCallbacks(callbacks);
 
   if (JeandleRecordVMCallbacks) {

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -827,6 +827,16 @@ static void record_profile_receiver(ciKlass* receiver) {
   env->oop_recorder()->find_index(receiver->constant_encoding());
 }
 
+static llvm::jeandle::ProfileDevirtualizationTargetResult
+make_profile_target_result(ciKlass* receiver, ciMethod* target,
+                           int64_t count) {
+  assert(receiver != nullptr && target != nullptr,
+         "profile target must be resolved");
+  return {reinterpret_cast<uintptr_t>(receiver->constant_encoding()),
+          reinterpret_cast<uintptr_t>(target), count,
+          JeandleFuncSig::method_name_with_signature(target)};
+}
+
 llvm::jeandle::ProfileDevirtualizationResult
 JeandleVMCallback::get_profile_devirtualization_info(
     uintptr_t caller_ptr, uintptr_t callee_ptr, uintptr_t holder_ptr, int bci,
@@ -854,16 +864,13 @@ JeandleVMCallback::get_profile_devirtualization_info(
     record_profile_receiver(opt_info.receiver2);
   }
 
-  llvm::jeandle::ProfileDevirtualizationTargetResult target{
-      reinterpret_cast<uintptr_t>(opt_info.receiver->constant_encoding()),
-      reinterpret_cast<uintptr_t>(opt_info.target), opt_info.receiver_count,
-      JeandleFuncSig::method_name_with_signature(opt_info.target)};
+  llvm::jeandle::ProfileDevirtualizationTargetResult target =
+      make_profile_target_result(opt_info.receiver, opt_info.target,
+                                 opt_info.receiver_count);
   llvm::jeandle::ProfileDevirtualizationTargetResult target2;
   if (opt_info.receiver2 != nullptr) {
-    target2 = {
-        reinterpret_cast<uintptr_t>(opt_info.receiver2->constant_encoding()),
-        reinterpret_cast<uintptr_t>(opt_info.target2), opt_info.receiver_count2,
-        JeandleFuncSig::method_name_with_signature(opt_info.target2)};
+    target2 = make_profile_target_result(opt_info.receiver2, opt_info.target2,
+                                         opt_info.receiver_count2);
   }
   return {std::move(target), opt_info.total_count,
           llvm::jeandle::ProfileDevirtualizationInfo::packDeoptInfo(

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -564,7 +564,6 @@ bool JeandleVMCallback::record_inline_result(int scope_id, int bci, uintptr_t ca
     // IsOkToInline has already prepared this tree, so a successful result only
     // commits metadata in the same successful-inline order as LLVM's InlineScopes.
     comp->commit_inline_tree_for_callee(scope_id, bci, callee);
-    comp->accumulate_trap_counts_from_mdo(callee);
   } else {
     comp->record_inline_failure(scope_id,
                                 bci,
@@ -890,25 +889,13 @@ bool JeandleVMCallback::update_call_site(int64_t id, int dest, bool need_attache
 // Profile-guided devirtualization
 // ---------------------------------------------------------------------------
 
-static void record_profile_receiver(ciKlass* receiver) {
-  assert(receiver != nullptr, "profile receiver must be present");
-  ciEnv* env = ciEnv::current();
-  assert(env != nullptr && env->oop_recorder() != nullptr,
-         "profile devirtualization must run in an active compilation");
-  // LLVM embeds the Klass* value in the exact-receiver guard. Recording it in
-  // the nmethod metadata table lets class unloading discover the dependency
-  // and invalidate the nmethod before that address can be reused.
-  env->oop_recorder()->find_index(receiver->constant_encoding());
-}
-
 static llvm::jeandle::ProfileDevirtualizationTargetResult
 make_profile_target_result(ciKlass* receiver, ciMethod* target,
                            int64_t count) {
   assert(receiver != nullptr && target != nullptr,
          "profile target must be resolved");
-  return {reinterpret_cast<uintptr_t>(receiver->constant_encoding()),
-          reinterpret_cast<uintptr_t>(target), count,
-          JeandleFuncSig::method_name_with_signature(target)};
+  return {record_klass_metadata(receiver), reinterpret_cast<uintptr_t>(target),
+          count, JeandleFuncSig::method_name_with_signature(target)};
 }
 
 llvm::jeandle::ProfileDevirtualizationResult
@@ -931,11 +918,6 @@ JeandleVMCallback::get_profile_devirtualization_info(
       JeandleProfile(caller).devirtualization_at(callee, holder, bci);
   if (!opt_info.is_valid()) {
     return {};
-  }
-
-  record_profile_receiver(opt_info.receiver);
-  if (opt_info.receiver2 != nullptr) {
-    record_profile_receiver(opt_info.receiver2);
   }
 
   llvm::jeandle::ProfileDevirtualizationTargetResult target =

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -490,6 +490,7 @@ bool JeandleVMCallback::record_inline_result(int scope_id, int bci, uintptr_t ca
     // IsOkToInline has already prepared this tree, so a successful result only
     // commits metadata in the same successful-inline order as LLVM's InlineScopes.
     comp->commit_inline_tree_for_callee(scope_id, bci, callee);
+    comp->accumulate_trap_counts_from_mdo(callee);
   } else {
     comp->record_inline_failure(scope_id,
                                 bci,

--- a/src/hotspot/share/jeandle/jeandleVMCallback.hpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.hpp
@@ -89,6 +89,15 @@ class JeandleVMCallback : public AllStatic {
   static int64_t get_signature_arg_type(uintptr_t method, int index);
   static uintptr_t get_signature_arg_type_klass(uintptr_t method, int index);
 
+  // Profile-guided devirtualization.
+  static llvm::jeandle::ProfileDevirtualizationResult
+  get_profile_devirtualization_info(uintptr_t caller_ptr, uintptr_t callee_ptr,
+                                    uintptr_t holder_ptr, int bci,
+                                    int invoke_kind);
+
+  // Compiled call-site metadata.
+  static bool update_to_static_opt_virtual_call(int64_t id);
+
   // Replaces the now-removed ciEnv::get_instance_klass_for_klass: maps a raw
   // receiver Klass* to a ciInstanceKlass*, preserving the null-check + assert +
   // VM_ENTRY_MARK the old public wrapper carried. Public because it is called

--- a/src/hotspot/share/jeandle/jeandle_globals.hpp
+++ b/src/hotspot/share/jeandle/jeandle_globals.hpp
@@ -63,6 +63,10 @@
           "Use interpreter/C1 profile (MDO) for branch/switch weights, "    \
           "unstable-if branch pruning")                                     \
                                                                             \
+  product(bool, JeandleUseProfiledVirtualCallDevirtualization, true,        \
+          "Use receiver type profile to devirtualize "                      \
+          "invokevirtual/invokeinterface calls in Jeandle")                 \
+                                                                            \
   product(intx, JeandleNodeCountInliningCutoff, 18000,                      \
           "If root LLVM IR instruction count exceeds limit stop inlining."  \
           "This value roughly follows C2's cutoff today; tune it later"     \

--- a/src/hotspot/share/jeandle/templatemodule/template.ll
+++ b/src/hotspot/share/jeandle/templatemodule/template.ll
@@ -195,6 +195,15 @@ uncompressed:
   ret ptr addrspace(0) %wide
 }
 
+; Test whether a previously loaded dynamic Klass is exactly the expected Klass.
+; Profile devirtualization shares one phase-1 load across all exact checks for
+; a receiver. JavaType traces actual_klass back to that load for path-sensitive
+; type propagation before JavaOperationLower(1) expands both operations.
+define hotspotcc i1 @jeandle.check_exact_klass(ptr addrspace(0) nocapture %expected_klass, ptr addrspace(0) nocapture %actual_klass) noinline "lower-phase"="1" #0 {
+  %is_exact = icmp eq ptr addrspace(0) %actual_klass, %expected_klass
+  ret i1 %is_exact
+}
+
 ; This is the slow path for subtype checking when the fast path fails.
 define hotspotcc i1 @jeandle.check_klass_subtype_slow_path(ptr addrspace(0) nocapture %sub_klass, ptr addrspace(0) nocapture %super_klass) "lower-phase"="0" #0 {
 entry:

--- a/test/hotspot/jtreg/compiler/jeandle/TestProfileDevirtualizationClassLoader.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestProfileDevirtualizationClassLoader.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @summary Profile devirtualization must distinguish same-named methods from
+ *          different class loaders
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UseJeandleCompiler
+ *                   -XX:+JeandleUseProfiledVirtualCallDevirtualization
+ *                   -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,compiler.jeandle.TestProfileDevirtualizationClassLoader::profiledCall
+ *                   compiler.jeandle.TestProfileDevirtualizationClassLoader
+ */
+
+package compiler.jeandle;
+
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_FINAL;
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.ALOAD;
+import static jdk.internal.org.objectweb.asm.Opcodes.ICONST_1;
+import static jdk.internal.org.objectweb.asm.Opcodes.ICONST_2;
+import static jdk.internal.org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static jdk.internal.org.objectweb.asm.Opcodes.IRETURN;
+import static jdk.internal.org.objectweb.asm.Opcodes.RETURN;
+import static jdk.internal.org.objectweb.asm.Opcodes.V17;
+
+public class TestProfileDevirtualizationClassLoader {
+    private static final String TARGET_NAME =
+            "compiler.jeandle.generated.ProfileTarget";
+    private static final String TARGET_INTERNAL_NAME =
+            TARGET_NAME.replace('.', '/');
+    private static final String VALUE_INTERNAL_NAME =
+            Value.class.getName().replace('.', '/');
+
+    public interface Value {
+        int value();
+    }
+
+    private static final class ByteArrayLoader extends ClassLoader {
+        private final byte[] targetBytes;
+
+        ByteArrayLoader(byte[] targetBytes) {
+            super(TestProfileDevirtualizationClassLoader.class.getClassLoader());
+            this.targetBytes = targetBytes;
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (!TARGET_NAME.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return defineClass(name, targetBytes, 0, targetBytes.length);
+        }
+    }
+
+    private static int profiledCall(Value receiver) {
+        return receiver.value();
+    }
+
+    public static void main(String[] args) throws Exception {
+        Value first = newTarget(1);
+        Value second = newTarget(2);
+
+        if (first.getClass() == second.getClass() ||
+                first.getClass().getClassLoader() ==
+                        second.getClass().getClassLoader()) {
+            throw new AssertionError("test requires two defining class loaders");
+        }
+
+        int iterations = 20_000_000;
+        long actual = 0;
+        for (int i = 0; i < iterations; i++) {
+            actual += profiledCall((i & 1) == 0 ? first : second);
+        }
+
+        long expected = (long) iterations / 2 * 3;
+        if (actual != expected) {
+            throw new AssertionError("wrong result: expected=" + expected +
+                    ", actual=" + actual);
+        }
+    }
+
+    private static Value newTarget(int result) throws Exception {
+        Class<?> target = Class.forName(TARGET_NAME, true,
+                new ByteArrayLoader(generateTarget(result)));
+        return (Value) target.getDeclaredConstructor().newInstance();
+    }
+
+    private static byte[] generateTarget(int result) {
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS |
+                                             ClassWriter.COMPUTE_FRAMES);
+        writer.visit(V17, ACC_PUBLIC | ACC_FINAL, TARGET_INTERNAL_NAME, null,
+                "java/lang/Object", new String[] { VALUE_INTERNAL_NAME });
+
+        MethodVisitor init = writer.visitMethod(ACC_PUBLIC, "<init>", "()V",
+                null, null);
+        init.visitCode();
+        init.visitVarInsn(ALOAD, 0);
+        init.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>",
+                "()V", false);
+        init.visitInsn(RETURN);
+        init.visitMaxs(0, 0);
+        init.visitEnd();
+
+        MethodVisitor value = writer.visitMethod(ACC_PUBLIC, "value", "()I",
+                null, null);
+        value.visitCode();
+        value.visitInsn(result == 1 ? ICONST_1 : ICONST_2);
+        value.visitInsn(IRETURN);
+        value.visitMaxs(0, 0);
+        value.visitEnd();
+
+        writer.visitEnd();
+        return writer.toByteArray();
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/TestProfileDevirtualizationClassLoader.java
+++ b/test/hotspot/jtreg/compiler/jeandle/TestProfileDevirtualizationClassLoader.java
@@ -22,9 +22,12 @@
  * @test
  * @summary Profile devirtualization must distinguish same-named methods from
  *          different class loaders
+ * @library /test/lib /
+ * @build compiler.jeandle.fileCheck.FileCheck
  * @modules java.base/jdk.internal.org.objectweb.asm
  * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UseJeandleCompiler
  *                   -XX:+JeandleUseProfiledVirtualCallDevirtualization
+ *                   -XX:-Inline -XX:+JeandleDumpIR
  *                   -XX:CompileCommand=quiet
  *                   -XX:CompileCommand=compileonly,compiler.jeandle.TestProfileDevirtualizationClassLoader::profiledCall
  *                   compiler.jeandle.TestProfileDevirtualizationClassLoader
@@ -32,6 +35,7 @@
 
 package compiler.jeandle;
 
+import compiler.jeandle.fileCheck.FileCheck;
 import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.MethodVisitor;
 
@@ -99,6 +103,15 @@ public class TestProfileDevirtualizationClassLoader {
             throw new AssertionError("wrong result: expected=" + expected +
                     ", actual=" + actual);
         }
+
+        FileCheck fileCheck = new FileCheck(System.getProperty("user.dir"),
+                TestProfileDevirtualizationClassLoader.class.getDeclaredMethod(
+                        "profiledCall", Value.class), true);
+        String targetPattern =
+                "declare hotspotcc i32 .*ProfileTarget_value.*\\.[0-9]+";
+        fileCheck.checkPattern(targetPattern);
+        fileCheck.checkPattern(targetPattern);
+        fileCheck.checkNot("__jeandle_dynamic_call.");
     }
 
     private static Value newTarget(int result) throws Exception {

--- a/test/hotspot/jtreg/compiler/jeandle/pea/PEATestUtils.java
+++ b/test/hotspot/jtreg/compiler/jeandle/pea/PEATestUtils.java
@@ -157,6 +157,36 @@ public final class PEATestUtils {
 
     private PEATestUtils() {}
 
+    // JDK-generated LLVM symbols append the ciMethod identity as a numeric
+    // suffix. Try the stable name first, then accept that runtime suffix.
+    private static boolean matchesRuntimeFunctionName(String actual,
+                                                       String expected) {
+        if (actual == null || expected == null) {
+            return false;
+        }
+        if (actual.equals(expected)) {
+            return true;
+        }
+        boolean actualRoot = actual.endsWith(".root");
+        boolean expectedRoot = expected.endsWith(".root");
+        if (actualRoot != expectedRoot) {
+            return false;
+        }
+        String actualBase = actualRoot
+                ? actual.substring(0, actual.length() - ".root".length())
+                : actual;
+        String expectedBase = expectedRoot
+                ? expected.substring(0, expected.length() - ".root".length())
+                : expected;
+        String identityPrefix = expectedBase + ".";
+        if (!actualBase.startsWith(identityPrefix)) {
+            return false;
+        }
+        String identity = actualBase.substring(identityPrefix.length());
+        return !identity.isEmpty()
+                && identity.chars().allMatch(Character::isDigit);
+    }
+
     /** Exact identity for one Java method in HotSpot commands and Jeandle IR. */
     public static final class MethodId {
         private final Method method;
@@ -1357,7 +1387,7 @@ public final class PEATestUtils {
                     if (!summary.matches()) {
                         throw malformed(method, "malformed PEA summary: " + line);
                     }
-                    if (!summary.group(1).equals(function)) {
+                    if (!matchesRuntimeFunctionName(summary.group(1), function)) {
                         if (current != null && !current.afterSeen) {
                             throw malformed(method,
                                     "interleaved summary before after marker");
@@ -1412,7 +1442,7 @@ public final class PEATestUtils {
                 Matcher marker = MARKER.matcher(line);
                 if (marker.matches()) {
                     String markerFunction = marker.group(3);
-                    boolean matches = markerFunction.equals(function);
+                    boolean matches = matchesRuntimeFunctionName(markerFunction, function);
                     if (!matches) {
                         if (current != null && !current.afterSeen) {
                             throw malformed(method, "interleaved marker before after marker");
@@ -1467,7 +1497,7 @@ public final class PEATestUtils {
                 Matcher stats = STATS.matcher(line);
                 if (stats.matches()) {
                     capture = Capture.NONE;
-                    if (!stats.group(1).equals(function)) {
+                    if (!matchesRuntimeFunctionName(stats.group(1), function)) {
                         continue;
                     }
                     if (current == null || current.afterSeen) {
@@ -1491,7 +1521,7 @@ public final class PEATestUtils {
                         throw malformed(method, "malformed LockReplay line: " + line);
                     }
                     String effectFunction = decodeLLVMOperand(lockReplay.group(1));
-                    if (!effectFunction.equals(function)) {
+                    if (!matchesRuntimeFunctionName(effectFunction, function)) {
                         continue;
                     }
                     if (current == null || current.afterSeen) {
@@ -1509,7 +1539,7 @@ public final class PEATestUtils {
                 if (effect.matches()) {
                     capture = Capture.NONE;
                     String effectFunction = decodeLLVMOperand(effect.group(2));
-                    if (!effectFunction.equals(function)) {
+                    if (!matchesRuntimeFunctionName(effectFunction, function)) {
                         continue;
                     }
                     if (current == null || current.afterSeen) {
@@ -1983,7 +2013,7 @@ public final class PEATestUtils {
             for (int i = 0; i < folded.size(); i++) {
                 String line = folded.get(i);
                 String defined = definedFunctionName(line);
-                if (!method.llvmFunctionName().equals(defined)) {
+                if (!matchesRuntimeFunctionName(defined, method.llvmFunctionName())) {
                     continue;
                 }
                 ArrayList<String> body = new ArrayList<>();
@@ -2378,7 +2408,7 @@ public final class PEATestUtils {
             for (CompleteCallInstruction call : callInstructions()) {
                 String instruction = call.text();
                 String callee = calledFunctionName(instruction);
-                if (exactCallee.equals(callee)) {
+                if (matchesRuntimeFunctionName(callee, exactCallee)) {
                     matches.add(instruction);
                 }
             }

--- a/test/hotspot/jtreg/compiler/jeandle/pea/PEATestUtils.java
+++ b/test/hotspot/jtreg/compiler/jeandle/pea/PEATestUtils.java
@@ -167,24 +167,80 @@ public final class PEATestUtils {
         if (actual.equals(expected)) {
             return true;
         }
-        boolean actualRoot = actual.endsWith(".root");
-        boolean expectedRoot = expected.endsWith(".root");
-        if (actualRoot != expectedRoot) {
-            return false;
+        return stableRuntimeFunctionName(actual).equals(expected);
+    }
+
+    private static String stableRuntimeFunctionName(String function) {
+        boolean root = function.endsWith(".root");
+        String candidate = root
+                ? function.substring(0, function.length() - ".root".length())
+                : function;
+        int identitySeparator = candidate.lastIndexOf('.');
+        if (identitySeparator < 0 || identitySeparator == candidate.length() - 1) {
+            return function;
         }
-        String actualBase = actualRoot
-                ? actual.substring(0, actual.length() - ".root".length())
-                : actual;
-        String expectedBase = expectedRoot
-                ? expected.substring(0, expected.length() - ".root".length())
-                : expected;
-        String identityPrefix = expectedBase + ".";
-        if (!actualBase.startsWith(identityPrefix)) {
-            return false;
+        String stable = candidate.substring(0, identitySeparator);
+        String identity = candidate.substring(identitySeparator + 1);
+        int closeDescriptor = stable.lastIndexOf(')');
+        if (stable.lastIndexOf('(', closeDescriptor) < 0
+                || closeDescriptor == stable.length() - 1
+                || !identity.chars().allMatch(Character::isDigit)) {
+            return function;
         }
-        String identity = actualBase.substring(identityPrefix.length());
-        return !identity.isEmpty()
-                && identity.chars().allMatch(Character::isDigit);
+        return stable + (root ? ".root" : "");
+    }
+
+    // PEA assertions use stable Java method names. Remove only the numeric
+    // identity after a JVM method descriptor; ordinary LLVM .1/.2 suffixes
+    // and unrelated numeric constants remain visible to the tests.
+    private static String normalizeRuntimeFunctionSymbols(String line) {
+        StringBuilder normalized = null;
+        int copiedThrough = 0;
+        int searchFrom = 0;
+        while (true) {
+            int at = line.indexOf('@', searchFrom);
+            if (at < 0) {
+                break;
+            }
+            ParsedOperand operand;
+            try {
+                operand = parseLLVMNamedOperand(line, at);
+            } catch (IllegalArgumentException malformed) {
+                searchFrom = at + 1;
+                continue;
+            }
+            searchFrom = operand.end;
+            String stable = stableRuntimeFunctionName(operand.value);
+            if (stable.equals(operand.value)) {
+                continue;
+            }
+
+            boolean root = operand.value.endsWith(".root");
+            int stableLengthWithoutRoot = stable.length()
+                    - (root ? ".root".length() : 0);
+            int identityEnd = operand.value.length()
+                    - (root ? ".root".length() : 0);
+            String identitySuffix = operand.value.substring(
+                    stableLengthWithoutRoot, identityEnd);
+            String rawOperand = line.substring(at, operand.end);
+            int suffixAt = rawOperand.lastIndexOf(identitySuffix);
+            if (suffixAt < 0) {
+                throw new IllegalStateException(
+                        "Runtime function identity is not present in LLVM operand: "
+                                + rawOperand);
+            }
+            if (normalized == null) {
+                normalized = new StringBuilder(line.length());
+            }
+            normalized.append(line, copiedThrough, at + suffixAt)
+                    .append(rawOperand, suffixAt + identitySuffix.length(),
+                            rawOperand.length());
+            copiedThrough = operand.end;
+        }
+        if (normalized == null) {
+            return line;
+        }
+        return normalized.append(line, copiedThrough, line.length()).toString();
     }
 
     /** Exact identity for one Java method in HotSpot commands and Jeandle IR. */
@@ -2002,8 +2058,10 @@ public final class PEATestUtils {
 
         private IRBody(MethodId method, List<String> lines) {
             this.method = method;
-            this.lines = List.copyOf(lines);
-            this.text = String.join("\n", lines);
+            this.lines = lines.stream()
+                    .map(PEATestUtils::normalizeRuntimeFunctionSymbols)
+                    .toList();
+            this.text = String.join("\n", this.lines);
         }
 
         private static IRBody fromModuleLines(List<String> rawLines, MethodId method) {
@@ -2074,6 +2132,9 @@ public final class PEATestUtils {
         }
 
         private static List<String> crossProcessExactLines(List<String> sourceLines) {
+            sourceLines = sourceLines.stream()
+                    .map(PEATestUtils::normalizeRuntimeFunctionSymbols)
+                    .toList();
             LinkedHashMap<String, String> klassReplacements = new LinkedHashMap<>();
             LinkedHashMap<String, String> methodReplacements = new LinkedHashMap<>();
             for (String line : sourceLines) {
@@ -4070,6 +4131,23 @@ public final class PEATestUtils {
     }
 
     private static void assertCrossProcessNormalizerContracts() {
+        List<String> runtimeFunctionsFirst = List.of(
+                "define void @\"pkg_Test_work()V.111111.root\"() {",
+                "call void @\"pkg_Test_helper(I)V.222222\"(i32 1)",
+                "}");
+        List<String> runtimeFunctionsSecond = List.of(
+                "define void @\"pkg_Test_work()V.333333.root\"() {",
+                "call void @\"pkg_Test_helper(I)V.444444\"(i32 1)",
+                "}");
+        Asserts.assertEquals(IRBody.crossProcessExactLines(runtimeFunctionsFirst),
+                IRBody.crossProcessExactLines(runtimeFunctionsSecond),
+                "cross-process normalizer handles runtime Java method identities");
+
+        String ordinarySuffixes = "call void @ordinary.1(i32 123456)";
+        Asserts.assertEquals(normalizeRuntimeFunctionSymbols(ordinarySuffixes),
+                ordinarySuffixes,
+                "runtime symbol normalizer preserves ordinary LLVM suffixes and constants");
+
         List<String> first = List.of(
                 "%object = call \"java-klass\"=\"101010101010\" ptr "
                         + "inttoptr (i64 101010101010 to ptr)",

--- a/test/hotspot/jtreg/compiler/jeandle/pea/TestPEADeadLoopFieldPhi.java
+++ b/test/hotspot/jtreg/compiler/jeandle/pea/TestPEADeadLoopFieldPhi.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/*
+ * @test
+ * @summary End-to-end coverage for a loop whose only forward edge is dead
+ *          only under PEA's identity tracking (two distinct fresh allocations
+ *          are never reference-equal — a fold no earlier pass can do), with a
+ *          field-PHI merge downstream: the method must compile, eliminate all
+ *          allocations, and keep every PHI complete for every structural
+ *          predecessor on every round. Note: the malformed-%pea.field.phi
+ *          crash itself ( EliminateUnreachableBlocks -> removePredecessor ->
+ *          removeIncomingValue(-1) ) is owned by lit tests 752/753/754,
+ *          because the pre-PEA pipeline masks this shape at the VM level
+ *          (LoopRotate preloads the merged field on the dead exit path, which
+ *          keeps the phi receiver real until round-1 canonicalization removes
+ *          the dead nest). `o == null` on a fresh allocation does not work
+ *          either: the implicit null check on the <init> receiver lets
+ *          pre-PEA GVN fold the guard before PEA ever sees the loop.
+ * @library /test/lib /
+ * @build jdk.test.lib.Asserts jdk.test.whitebox.WhiteBox compiler.jeandle.pea.PEATestUtils
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -XX:-UseJeandleCompiler
+ *      -XX:-UseCompressedOops -XX:-UseCompressedClassPointers
+ *      compiler.jeandle.pea.TestPEADeadLoopFieldPhi
+ */
+
+package compiler.jeandle.pea;
+
+import java.lang.reflect.Method;
+
+import jdk.test.lib.Asserts;
+
+public class TestPEADeadLoopFieldPhi {
+    private static final String WRAPPER =
+            "compiler.jeandle.pea.TestPEADeadLoopFieldPhi$TestWrapper";
+
+    public static void main(String[] args) throws Exception {
+        PEATestUtils.assertPhiParserContracts();
+        PEATestUtils.assertStructuralParserContracts();
+
+        Method deadLoop = TestWrapper.class.getMethod("deadLoopFieldPhi",
+                boolean.class, int.class, int.class, int.class);
+        Method sink = TestWrapper.class.getMethod("sink", int.class);
+        Method[] targets = {deadLoop};
+
+        PEATestUtils.behaviorRun(WRAPPER, targets).dontinline(sink)
+                .runPEAOnOffEquivalent();
+
+        try (PEATestUtils.RunResult run =
+                PEATestUtils.shapeRun(WRAPPER, targets).dontinline(sink)
+                        .peaIterations(3).run()) {
+            PEATestUtils.PEAReport report = run.report(deadLoop);
+            PEATestUtils.IRBody before = report.round0Before();
+            PEATestUtils.IRBody after = report.finalAfter();
+
+            Asserts.assertEquals(before.peaAllocCount(), 3,
+                    deadLoop + ": o, a, b source allocations");
+            // The guarded loop must survive the pre-PEA pipeline, otherwise
+            // the test exercises nothing.
+            before.assertPresent("sink(I)V");
+            Asserts.assertEquals(report.round(0).neverEscapes(), 2,
+                    deadLoop + ": the identity-compared a and b die first");
+            Asserts.assertEquals(
+                    report.round(0).effectCount("EliminateAllocation"), 2L,
+                    deadLoop + ": a and b are eliminated in round 0");
+            Asserts.assertTrue(
+                    report.round(1).effectCount("CreatePHI") == 1,
+                    deadLoop + ": the merge synthesizes the field PHI once "
+                            + "the dead nest is gone (round 1)");
+            Asserts.assertEquals(report.round(1).neverEscapes(), 1,
+                    deadLoop + ": o is eliminated once the dead nest is gone");
+            Asserts.assertEquals(report.effects("EliminateAllocation").size(), 3,
+                    deadLoop + ": all three allocations eliminated across rounds");
+
+            // The malformed-PHI oracle: every PHI's incoming blocks must
+            // match its block's structural predecessors on every round, even
+            // while the dead loop nest still occupies its (poison) slots.
+            // Poison itself is only required to be gone once CFG cleanup has
+            // caught up (final round / final IR).
+            for (PEATestUtils.PEARound round : report.rounds()) {
+                PEATestUtils.assertCompletePhis(round.after(), deadLoop.toString());
+            }
+            after.assertAbsent("jeandle.new_instance");
+            after.assertAbsent("poison");
+            PEATestUtils.assertCompletePhis(after, deadLoop.toString());
+            PEATestUtils.IRBody finalIR = run.finalIR(deadLoop);
+            finalIR.assertAbsent("poison");
+            PEATestUtils.assertCompletePhis(finalIR, deadLoop.toString());
+            report.assertFinalTransformIdle();
+            report.assertStoppedAtFixpoint();
+        }
+    }
+
+    public static class TestWrapper {
+        private static final String EXPECTED_DIGEST = "edd529ac19032d65";
+
+        public static class Acc {
+            int f;
+        }
+
+        static int lastSink;
+
+        public static void sink(int v) {
+            lastSink = v;
+        }
+
+        public static int deadLoopFieldPhi(boolean which, int x, int y, int n) {
+            Acc o = new Acc();
+            Acc a = new Acc();
+            Acc b = new Acc();
+            // PEA-only-provable dead: two distinct fresh allocations are never
+            // reference-equal, and only PEA's identity tracking can prove it
+            // (pre-PEA passes cannot, so the loop reaches PEA). The opaque
+            // sink call keeps the loop alive until PEA.
+            if (a == b) {
+                for (int i = 0; i < n; i++) {
+                    sink(i);
+                }
+            } else if (which) {
+                o.f = x;
+            } else {
+                o.f = y;
+            }
+            return o.f;
+        }
+
+        public static void main(String[] args) throws Exception {
+            new Acc();
+            PEATestUtils.compileConfiguredTargetsAtLevel4();
+
+            long digest = 0x254F0D7CDB10CBF1L;
+            for (int seed : new int[] {0, 9}) {
+                for (boolean which : new boolean[] {false, true}) {
+                    int x = seed + 3;
+                    int y = seed + 4;
+                    int n = seed + 5;
+                    int r = deadLoopFieldPhi(which, x, y, n);
+                    Asserts.assertEquals(r, which ? x : y, "deadLoopFieldPhi");
+                    digest = mix(digest, r);
+                }
+            }
+
+            String payload = Long.toUnsignedString(digest, 16);
+            Asserts.assertEquals(payload, EXPECTED_DIGEST, "behavior digest");
+            System.out.println("PEA-RESULT:" + payload);
+        }
+
+        private static long mix(long digest, int value) {
+            return Long.rotateLeft(digest ^ Integer.toUnsignedLong(value), 23)
+                    * 0x9E3779B97F4A7C15L;
+        }
+    }
+}


### PR DESCRIPTION
## Related issue(s):

issue #

## What this PR does / why we need it:

Adds profile-guided devirtualization for Jeandle `invokevirtual` and `invokeinterface` calls. HotSpot reads receiver profiles and resolves concrete targets, while LLVM emits receiver guards and rewrites the selected paths to direct calls.

```text
virtual call
  |
  v
Can CHA determine the target?
  | yes
  +------> CHA guard + direct call
  |
  no
  v
Read receiver profile
  |
  +------> monomorphic
  |           receiver0 -> direct call
  |           miss      -> uncommon trap or virtual call
  |
  +------> bimorphic
  |           receiver0 -> direct call target0
  |           receiver1 -> direct call target1
  |           miss      -> uncommon trap or virtual call
  |
  +------> major receiver
  |           receiver0 -> direct call
  |           other     -> virtual call
  |
  +------> no reliable prediction
              keep the virtual call
```

The miss path uses an uncommon trap until the C2-style trap or recompilation limit is reached, after which it falls back to the original virtual call.

## Main changes
- Select and validate monomorphic, bimorphic, and major-receiver targets from mature profiles.
- Recover the call-site context from LLVM IR and deopt scopes, following CHA; CallSiteInfo remains responsible only for runtime metadata and statepoint tracking.
- Preserve receiver type information after rewriting guarded calls so later type-based optimizations can still use it.
- Preserve class-unloading and accessor information, validate profile counts, and update JDK call-site metadata before rewriting LLVM IR.
- Add JeandleUseProfiledVirtualCallDevirtualization to control the optimization.

## Correctness
- Include `ciMethod` identity in LLVM symbols to distinguish same-named methods from different class loaders.

## Performance
Compared profile devirtualization ON and OFF on 25 Renaissance benchmarks using the release build. Each configuration ran five times on the same NUMA node, with the last three runs averaged. In the reported run, 21 benchmarks improved and four regressed; the geometric-mean improvement was 10.86% and total runtime decreased by 6.16%. The individual regressions were not stable across follow-up runs, and the earlier 8.42% regression reported for `philosophers` could not be reproduced.