### PR TITLE
fix: support Jeandle-only compiler

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -40,7 +40,10 @@ ifeq ($(call check-jvm-feature, compiler2), true)
   JVM_SRC_DIRS += $(JVM_VARIANT_OUTPUTDIR)/gensrc/adfiles
 else
   JVM_EXCLUDES += opto libadt
-  JVM_EXCLUDE_FILES += bcEscapeAnalyzer.cpp ciTypeFlow.cpp
+  JVM_EXCLUDE_FILES += bcEscapeAnalyzer.cpp
+  ifneq ($(call check-jvm-feature, jeandle), true)
+    JVM_EXCLUDE_FILES += ciTypeFlow.cpp
+  endif
   JVM_EXCLUDE_PATTERNS += c2_ runtime_ /c2/
 endif
 

--- a/src/hotspot/cpu/aarch64/c1_globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_globals_aarch64.hpp
@@ -32,7 +32,7 @@
 // Sets the default values for platform dependent flags used by the client compiler.
 // (see c1_globals.hpp)
 
-#ifndef COMPILER2
+#if !defined(COMPILER2) && !defined(JEANDLE)
 define_pd_global(bool, BackgroundCompilation,        true );
 define_pd_global(bool, InlineIntrinsics,             true );
 define_pd_global(bool, PreferInterpreterNativeStubs, false);
@@ -55,7 +55,7 @@ define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
 define_pd_global(bool, NeverActAsServerClassMachine, true );
 define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
 define_pd_global(bool, CICompileOSR,                 true );
-#endif // !COMPILER2
+#endif // !COMPILER2 && !JEANDLE
 define_pd_global(bool, UseTypeProfile,               false);
 
 define_pd_global(bool, OptimizeSinglePrecision,      true );

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2572,7 +2572,7 @@ uint SharedRuntime::out_preserve_stack_slots() {
   return 0;
 }
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
 //------------------------------generate_uncommon_trap_blob--------------------
 void SharedRuntime::generate_uncommon_trap_blob() {
   // Allocate space for the code
@@ -2761,7 +2761,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   _uncommon_trap_blob =  UncommonTrapBlob::create(&buffer, oop_maps,
                                                  SimpleRuntimeFrame::framesize >> 1);
 }
-#endif // COMPILER2
+#endif // COMPILER2_OR_JEANDLE
 
 
 //------------------------------generate_handler_blob------

--- a/src/hotspot/cpu/riscv/c1_globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_globals_riscv.hpp
@@ -32,7 +32,7 @@
 // Sets the default values for platform dependent flags used by the client compiler.
 // (see c1_globals.hpp)
 
-#ifndef COMPILER2
+#if !defined(COMPILER2) && !defined(JEANDLE)
 define_pd_global(bool, BackgroundCompilation,        true );
 define_pd_global(bool, InlineIntrinsics,             true );
 define_pd_global(bool, PreferInterpreterNativeStubs, false);
@@ -55,7 +55,7 @@ define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
 define_pd_global(bool, NeverActAsServerClassMachine, true );
 define_pd_global(uint64_t, MaxRAM,                  1ULL*G);
 define_pd_global(bool, CICompileOSR,                 true );
-#endif // !COMPILER2
+#endif // !COMPILER2 && !JEANDLE
 define_pd_global(bool, UseTypeProfile,               false);
 
 define_pd_global(bool, OptimizeSinglePrecision,      true );

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2457,7 +2457,7 @@ uint SharedRuntime::out_preserve_stack_slots() {
   return 0;
 }
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
 //------------------------------generate_uncommon_trap_blob--------------------
 void SharedRuntime::generate_uncommon_trap_blob() {
   // Allocate space for the code
@@ -2654,7 +2654,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   _uncommon_trap_blob =  UncommonTrapBlob::create(&buffer, oop_maps,
                                                   SimpleRuntimeFrame::framesize >> 1);
 }
-#endif // COMPILER2
+#endif // COMPILER2_OR_JEANDLE
 
 //------------------------------generate_handler_blob------
 //

--- a/src/hotspot/cpu/x86/c1_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_globals_x86.hpp
@@ -31,7 +31,7 @@
 // Sets the default values for platform dependent flags used by the client compiler.
 // (see c1_globals.hpp)
 
-#ifndef COMPILER2
+#if !defined(COMPILER2) && !defined(JEANDLE)
 define_pd_global(bool, BackgroundCompilation,          true );
 define_pd_global(bool, InlineIntrinsics,               true );
 define_pd_global(bool, PreferInterpreterNativeStubs,   false);
@@ -54,7 +54,7 @@ define_pd_global(uintx,  CodeCacheMinimumUseSpace,     400*K);
 define_pd_global(bool,   NeverActAsServerClassMachine, true );
 define_pd_global(uint64_t, MaxRAM,                    1ULL*G);
 define_pd_global(bool,   CICompileOSR,                 true );
-#endif // !COMPILER2
+#endif // !COMPILER2 && !JEANDLE
 define_pd_global(bool, UseTypeProfile,                 false);
 
 define_pd_global(bool, OptimizeSinglePrecision,        true );

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2423,7 +2423,7 @@ void SharedRuntime::generate_deopt_blob() {
 }
 
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
 //------------------------------generate_uncommon_trap_blob--------------------
 void SharedRuntime::generate_uncommon_trap_blob() {
   // allocate space for the code
@@ -2602,7 +2602,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
 
    _uncommon_trap_blob = UncommonTrapBlob::create(&buffer, oop_maps, framesize);
 }
-#endif // COMPILER2
+#endif // COMPILER2_OR_JEANDLE
 
 //------------------------------generate_handler_blob------
 //

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2894,7 +2894,7 @@ void SharedRuntime::generate_deopt_blob() {
 #endif
 }
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
 //------------------------------generate_uncommon_trap_blob--------------------
 void SharedRuntime::generate_uncommon_trap_blob() {
   // Allocate space for the code
@@ -3073,7 +3073,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   _uncommon_trap_blob =  UncommonTrapBlob::create(&buffer, oop_maps,
                                                  SimpleRuntimeFrame::framesize >> 1);
 }
-#endif // COMPILER2
+#endif // COMPILER2_OR_JEANDLE
 
 //------------------------------generate_handler_blob------
 //
@@ -3721,4 +3721,3 @@ void OptoRuntime::generate_exception_blob() {
   _exception_blob =  ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
 }
 #endif // COMPILER2
-

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -52,9 +52,11 @@
 #include "runtime/handles.inline.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/xmlstream.hpp"
+#if defined(COMPILER2) || defined(JEANDLE)
+#include "ci/ciTypeFlow.hpp"
+#endif
 #ifdef COMPILER2
 #include "ci/bcEscapeAnalyzer.hpp"
-#include "ci/ciTypeFlow.hpp"
 #include "oops/method.hpp"
 #endif
 
@@ -96,8 +98,10 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   _exception_handlers = nullptr;
   _liveness           = nullptr;
   _method_blocks = nullptr;
-#if defined(COMPILER2)
+#if defined(COMPILER2) || defined(JEANDLE)
   _flow               = nullptr;
+#endif // COMPILER2 || JEANDLE
+#ifdef COMPILER2
   _bcea               = nullptr;
 #endif // COMPILER2
 
@@ -178,9 +182,12 @@ ciMethod::ciMethod(ciInstanceKlass* holder,
   _can_be_statically_bound(false),
   _can_omit_stack_trace(true),
   _liveness(               nullptr)
-#if defined(COMPILER2)
+#if defined(COMPILER2) || defined(JEANDLE)
   ,
-  _flow(                   nullptr),
+  _flow(                   nullptr)
+#endif // COMPILER2 || JEANDLE
+#ifdef COMPILER2
+  ,
   _bcea(                   nullptr)
 #endif // COMPILER2
 {
@@ -321,34 +328,34 @@ bool ciMethod::has_balanced_monitors() {
 // ------------------------------------------------------------------
 // ciMethod::get_flow_analysis
 ciTypeFlow* ciMethod::get_flow_analysis() {
-#if defined(COMPILER2)
+#if defined(COMPILER2) || defined(JEANDLE)
   if (_flow == nullptr) {
     ciEnv* env = CURRENT_ENV;
     _flow = new (env->arena()) ciTypeFlow(env, this);
     _flow->do_flow();
   }
   return _flow;
-#else // COMPILER2
+#else // COMPILER2 || JEANDLE
   ShouldNotReachHere();
   return nullptr;
-#endif // COMPILER2
+#endif // COMPILER2 || JEANDLE
 }
 
 
 // ------------------------------------------------------------------
 // ciMethod::get_osr_flow_analysis
 ciTypeFlow* ciMethod::get_osr_flow_analysis(int osr_bci) {
-#if defined(COMPILER2)
+#if defined(COMPILER2) || defined(JEANDLE)
   // OSR entry points are always place after a call bytecode of some sort
   assert(osr_bci >= 0, "must supply valid OSR entry point");
   ciEnv* env = CURRENT_ENV;
   ciTypeFlow* flow = new (env->arena()) ciTypeFlow(env, this, osr_bci);
   flow->do_flow();
   return flow;
-#else // COMPILER2
+#else // COMPILER2 || JEANDLE
   ShouldNotReachHere();
   return nullptr;
-#endif // COMPILER2
+#endif // COMPILER2 || JEANDLE
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -101,8 +101,10 @@ class ciMethod : public ciMetadata {
 
   // Optional liveness analyzer.
   MethodLiveness* _liveness;
-#if defined(COMPILER2)
+#if defined(COMPILER2) || defined(JEANDLE)
   ciTypeFlow*         _flow;
+#endif // COMPILER2 || JEANDLE
+#ifdef COMPILER2
   BCEscapeAnalyzer*   _bcea;
 #endif
 

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -706,9 +706,9 @@ class CompileReplay : public StackObj {
     } else if (is_c1_compile(comp_level) && !CompilerConfig::is_c1_enabled()) {
       msg = NEW_RESOURCE_ARRAY(char, msg_len);
       jio_snprintf(msg, msg_len, "compilation level %d requires C1", comp_level);
-    } else if (is_c2_compile(comp_level) && !CompilerConfig::is_c2_enabled()) {
+    } else if (is_c2_compile(comp_level) && !CompilerConfig::is_high_tier_compiler_enabled()) {
       msg = NEW_RESOURCE_ARRAY(char, msg_len);
-      jio_snprintf(msg, msg_len, "compilation level %d requires C2", comp_level);
+      jio_snprintf(msg, msg_len, "compilation level %d requires a high-tier compiler", comp_level);
     }
     if (msg != nullptr) {
       report_error(msg);

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -37,8 +37,10 @@
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/oop.inline.hpp"
+#ifdef COMPILER2
 #include "opto/compile.hpp"
 #include "opto/node.hpp"
+#endif
 #include "runtime/deoptimization.hpp"
 #include "utilities/growableArray.hpp"
 
@@ -141,7 +143,7 @@ bool ciTypeFlow::JsrSet::is_compatible_with(JsrSet* other) {
   }
   // The two JsrSets agree.
   return true;
-#endif
+#endif // 0
 }
 
 // ------------------------------------------------------------------
@@ -2252,8 +2254,8 @@ bool ciTypeFlow::clone_loop_heads(StateVector* temp_vector, JsrSet* temp_set) {
         !head->is_clonable_exit(lp))
       continue;
 
-    // Avoid BoxLock merge.
-    if (EliminateNestedLocks && head->has_monitorenter())
+    // Avoid BoxLock merge when the C2 optimization is enabled.
+    if (COMPILER2_PRESENT(EliminateNestedLocks &&) head->has_monitorenter())
       continue;
 
     // check not already cloned
@@ -2832,7 +2834,7 @@ void ciTypeFlow::df_flow_types(Block* start,
       assert (!blk->has_pre_order(), "");
       blk->set_next_pre_order();
 
-      // TODO: Check bail out in Jeandle
+#ifdef COMPILER2
       if (!UseJeandleCompiler && _next_pre_order >= (int)Compile::current()->max_node_limit() / 2) {
         // Too many basic blocks.  Bail out.
         // This can happen when try/finally constructs are nested to depth N,
@@ -2842,6 +2844,7 @@ void ciTypeFlow::df_flow_types(Block* start,
         record_failure("too many basic blocks");
         return;
       }
+#endif
       if (do_flow) {
         flow_block(blk, temp_vector, temp_set);
         if (failing()) return; // Watch for bailouts.

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -25,11 +25,11 @@
 #ifndef SHARE_CI_CITYPEFLOW_HPP
 #define SHARE_CI_CITYPEFLOW_HPP
 
-#ifdef COMPILER2
+#if defined(COMPILER2) || defined(JEANDLE)
 #include "ci/ciEnv.hpp"
 #include "ci/ciKlass.hpp"
 #include "ci/ciMethodBlocks.hpp"
-#endif
+#endif // COMPILER2 || JEANDLE
 
 
 class ciTypeFlow : public ArenaObj {

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -498,7 +498,7 @@ DeoptimizationBlob* DeoptimizationBlob::create(
 //----------------------------------------------------------------------------------------------------
 // Implementation of UncommonTrapBlob
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
 UncommonTrapBlob::UncommonTrapBlob(
   CodeBuffer* cb,
   int         size,
@@ -528,7 +528,7 @@ UncommonTrapBlob* UncommonTrapBlob::create(
 }
 
 
-#endif // COMPILER2
+#endif // COMPILER2_OR_JEANDLE
 
 
 //----------------------------------------------------------------------------------------------------

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -635,9 +635,9 @@ class DeoptimizationBlob: public SingletonBlob {
 
 
 //----------------------------------------------------------------------------------------------------
-// UncommonTrapBlob (currently only used by Compiler 2)
+// UncommonTrapBlob: used by high-tier compilers for uncommon traps.
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
 
 class UncommonTrapBlob: public SingletonBlob {
   friend class VMStructs;
@@ -664,11 +664,13 @@ class UncommonTrapBlob: public SingletonBlob {
   // Typing
   bool is_uncommon_trap_stub() const             { return true; }
 };
+#endif // COMPILER2_OR_JEANDLE
 
 
 //----------------------------------------------------------------------------------------------------
 // ExceptionBlob: used for exception unwinding in compiled code (currently only used by Compiler 2)
 
+#ifdef COMPILER2
 class ExceptionBlob: public SingletonBlob {
   friend class VMStructs;
  private:

--- a/src/hotspot/share/code/scopeDesc.cpp
+++ b/src/hotspot/share/code/scopeDesc.cpp
@@ -233,8 +233,8 @@ void ScopeDesc::print_on(outputStream* st, PcDesc* pd) const {
     }
   }
 
-#if COMPILER2_OR_JVMCI
-  if (NOT_JVMCI(DoEscapeAnalysis &&) is_top() && _objects != nullptr) {
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
+  if (is_top() && _objects != nullptr) {
     st->print_cr("   Objects");
     for (int i = 0; i < _objects->length(); i++) {
       ObjectValue* sv = (ObjectValue*) _objects->at(i);
@@ -244,7 +244,7 @@ void ScopeDesc::print_on(outputStream* st, PcDesc* pd) const {
       st->cr();
     }
   }
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 }
 
 #endif

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -113,7 +113,7 @@ static inline CompLevel adjust_level_for_compilability_query(CompLevel comp_leve
   if (comp_level == CompLevel_any) {
      if (CompilerConfig::is_c1_only()) {
        comp_level = CompLevel_simple;
-     } else if (CompilerConfig::is_c2_or_jvmci_compiler_only()) {
+     } else if (CompilerConfig::is_high_tier_compiler_only()) {
        comp_level = CompLevel_full_optimization;
      }
   }
@@ -433,11 +433,12 @@ void CompilationPolicy::initialize() {
   if (!CompilerConfig::is_interpreter_only()) {
     int count = CICompilerCount;
     bool c1_only = CompilerConfig::is_c1_only();
-    bool c2_only = CompilerConfig::is_c2_or_jvmci_compiler_only();
+    bool c2_only = CompilerConfig::is_high_tier_compiler_only();
 
 #ifdef _LP64
     // Turn on ergonomic compiler count selection
-    if (FLAG_IS_DEFAULT(CICompilerCountPerCPU) && FLAG_IS_DEFAULT(CICompilerCount)) {
+    if (FLAG_IS_DEFAULT(CICompilerCountPerCPU) && FLAG_IS_DEFAULT(CICompilerCount) &&
+        (!CompilerConfig::has_jeandle() || CompilerConfig::has_c2())) {
       FLAG_SET_DEFAULT(CICompilerCountPerCPU, true);
     }
     if (CICompilerCountPerCPU) {
@@ -455,10 +456,12 @@ void CompilationPolicy::initialize() {
       c2_size = C2Compiler::initial_code_buffer_size();
 #endif
       size_t buffer_size = c1_only ? c1_size : (c1_size/3 + 2*c2_size/3);
-      int max_count = (ReservedCodeCacheSize - (CodeCacheMinimumUseSpace DEBUG_ONLY(* 3))) / (int)buffer_size;
-      if (count > max_count) {
-        // Lower the compiler count such that all buffers fit into the code cache
-        count = MAX2(max_count, c1_only ? 1 : 2);
+      if (buffer_size > 0) {
+        int max_count = (ReservedCodeCacheSize - (CodeCacheMinimumUseSpace DEBUG_ONLY(* 3))) / (int)buffer_size;
+        if (count > max_count) {
+          // Lower the compiler count such that all buffers fit into the code cache
+          count = MAX2(max_count, c1_only ? 1 : 2);
+        }
       }
       FLAG_SET_ERGO(CICompilerCount, count);
     }
@@ -511,7 +514,7 @@ bool CompilationPolicy::verify_level(CompLevel level) {
   if (!CompilerConfig::is_c1_enabled() && is_c1_compile(level)) {
     return false;
   }
-  if (!CompilerConfig::is_c2_or_jvmci_compiler_enabled() && is_c2_compile(level)) {
+  if (!CompilerConfig::is_high_tier_compiler_enabled() && is_c2_compile(level)) {
     return false;
   }
 
@@ -537,7 +540,7 @@ CompLevel CompilationPolicy::highest_compile_level() {
   CompLevel level = CompLevel_none;
   // Setup the maximum level available for the current compiler configuration.
   if (!CompilerConfig::is_interpreter_only()) {
-    if (CompilerConfig::is_c2_or_jvmci_compiler_enabled()) {
+    if (CompilerConfig::is_high_tier_compiler_enabled()) {
       level = CompLevel_full_optimization;
     } else if (CompilerConfig::is_c1_enabled()) {
       if (CompilerConfig::is_c1_simple_only()) {
@@ -1221,4 +1224,3 @@ void CompilationPolicy::method_back_branch_event(const methodHandle& mh, const m
     }
   }
 }
-

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -651,12 +651,20 @@ void CompileBroker::compilation_init_phase1(JavaThread* THREAD) {
         _compilers[1] = new JeandleCompiler();
       } else
 #endif // JEANDLE
+#ifdef COMPILER2
       {
         _compilers[1] = new C2Compiler();
       }
+#else
+      {
+        ShouldNotReachHere();
+      }
+#endif // COMPILER2
+#ifdef COMPILER2
       // Register c2 first as c2 CompilerPhaseType idToPhase mapping is explicit.
       // idToPhase mapping for c2 is in opto/phasetype.hpp
       JFR_ONLY(register_jfr_phasetype_serializer(compiler_c2);)
+#endif // COMPILER2
     }
   }
 #endif // COMPILER2_OR_JEANDLE

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -64,8 +64,8 @@ bool CompilationModeFlag::initialize() {
         _mode = Mode::QUICK_ONLY;
       }
     } else if (strcmp(CompilationMode, "high-only") == 0) {
-      if (!CompilerConfig::has_c2() && !CompilerConfig::is_jvmci_compiler()) {
-        print_mode_unavailable("high-only", "there is no c2 or jvmci compiler present");
+      if (!CompilerConfig::has_c2() && !CompilerConfig::is_jeandle_compiler() && !CompilerConfig::is_jvmci_compiler()) {
+        print_mode_unavailable("high-only", "there is no high-tier compiler present");
       } else {
         _mode = Mode::HIGH_ONLY;
       }
@@ -85,7 +85,7 @@ bool CompilationModeFlag::initialize() {
   if (normal()) {
     if (CompilerConfig::is_c1_simple_only()) {
       _mode = Mode::QUICK_ONLY;
-    } else if (CompilerConfig::is_c2_or_jvmci_compiler_only()) {
+    } else if (CompilerConfig::is_high_tier_compiler_only()) {
       _mode = Mode::HIGH_ONLY;
     } else if (CompilerConfig::is_jvmci_compiler_enabled() && CompilerConfig::is_c1_enabled() && !TieredCompilation) {
       warning("Disabling tiered compilation with non-native JVMCI compiler is not recommended, "
@@ -103,7 +103,7 @@ void CompilationModeFlag::print_error() {
     jio_fprintf(defaultStream::error_stream(), "%s quick-only", comma ? "," : "");
     comma = true;
   }
-  if (CompilerConfig::has_c2() || CompilerConfig::has_jvmci()) {
+  if (CompilerConfig::has_c2() || CompilerConfig::has_jeandle() || CompilerConfig::has_jvmci()) {
     jio_fprintf(defaultStream::error_stream(), "%s high-only", comma ? "," : "");
     comma = true;
   }
@@ -230,6 +230,7 @@ bool CompilerConfig::is_compilation_mode_selected() {
   return !FLAG_IS_DEFAULT(TieredCompilation) ||
          !FLAG_IS_DEFAULT(TieredStopAtLevel) ||
          !FLAG_IS_DEFAULT(CompilationMode)
+         JEANDLE_PRESENT(|| !FLAG_IS_DEFAULT(UseJeandleCompiler))
          JVMCI_ONLY(|| !FLAG_IS_DEFAULT(EnableJVMCI)
                     || !FLAG_IS_DEFAULT(UseJVMCICompiler));
 }
@@ -255,7 +256,7 @@ void CompilerConfig::set_legacy_emulation_flags() {
   if (!FLAG_IS_DEFAULT(CompileThreshold)         ||
       !FLAG_IS_DEFAULT(OnStackReplacePercentage) ||
       !FLAG_IS_DEFAULT(InterpreterProfilePercentage)) {
-    if (CompilerConfig::is_c1_only() || CompilerConfig::is_c2_or_jvmci_compiler_only()) {
+    if (CompilerConfig::is_c1_only() || CompilerConfig::is_high_tier_compiler_only()) {
       // This function is called before these flags are validated. In order to not confuse the user with extraneous
       // error messages, we check the validity of these flags here and bail out if any of them are invalid.
       if (!check_legacy_flags()) {
@@ -287,7 +288,7 @@ void CompilerConfig::set_legacy_emulation_flags() {
       FLAG_SET_ERGO(Tier3MinInvocationThreshold, threshold);
       FLAG_SET_ERGO(Tier3CompileThreshold, threshold);
       FLAG_SET_ERGO(Tier3BackEdgeThreshold, osr_threshold);
-      if (CompilerConfig::is_c2_or_jvmci_compiler_only()) {
+      if (CompilerConfig::is_high_tier_compiler_only()) {
         FLAG_SET_ERGO(Tier4InvocationThreshold, threshold);
         FLAG_SET_ERGO(Tier4MinInvocationThreshold, threshold);
         FLAG_SET_ERGO(Tier4CompileThreshold, threshold);
@@ -474,6 +475,14 @@ void CompilerConfig::set_jvmci_specific_flags() {
 #endif // INCLUDE_JVMCI
 
 bool CompilerConfig::check_args_consistency(bool status) {
+#if defined(JEANDLE) && !defined(COMPILER1) && !defined(COMPILER2) && !INCLUDE_JVMCI
+  if (!UseJeandleCompiler && UseCompiler && !is_interpreter_only()) {
+    jio_fprintf(defaultStream::error_stream(),
+                "UseJeandleCompiler cannot be disabled because no other compiler is present.\n");
+    status = false;
+  }
+#endif
+
   // Check lower bounds of the code cache
   // Template Interpreter code is approximately 3X larger in debug builds.
   uint min_code_cache_size = CodeCacheMinimumUseSpace DEBUG_ONLY(* 3);
@@ -583,7 +592,7 @@ void CompilerConfig::ergo_initialize() {
       if (NeverActAsServerClassMachine) {
         set_client_emulation_mode_flags();
       }
-    } else if (!has_c2() && !is_jvmci_compiler()) {
+    } else if (!has_c2() && !is_jeandle_compiler() && !is_jvmci_compiler()) {
       set_client_emulation_mode_flags();
     }
   }

--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -61,7 +61,7 @@ enum CompLevel : s1 {
   CompLevel_simple            = 1,         // C1
   CompLevel_limited_profile   = 2,         // C1, invocation & backedge counters
   CompLevel_full_profile      = 3,         // C1, invocation & backedge counters + mdo
-  CompLevel_full_optimization = 4          // C2 or JVMCI
+  CompLevel_full_optimization = 4          // C2, JVMCI, or Jeandle
 };
 
 class CompilationModeFlag : AllStatic {
@@ -135,10 +135,11 @@ public:
   static void ergo_initialize();
 
   // Which compilers are baked in?
-  constexpr static bool has_c1()     { return COMPILER1_PRESENT(true) NOT_COMPILER1(false); }
-  constexpr static bool has_c2()     { return COMPILER2_PRESENT(true) NOT_COMPILER2(false); }
-  constexpr static bool has_jvmci()  { return JVMCI_ONLY(true) NOT_JVMCI(false);            }
-  constexpr static bool has_tiered() { return has_c1() && (has_c2() || has_jvmci());        }
+  constexpr static bool has_c1()      { return COMPILER1_PRESENT(true) NOT_COMPILER1(false); }
+  constexpr static bool has_c2()      { return COMPILER2_PRESENT(true) NOT_COMPILER2(false); }
+  constexpr static bool has_jeandle() { return JEANDLE_PRESENT(true) NOT_JEANDLE(false);     }
+  constexpr static bool has_jvmci()   { return JVMCI_ONLY(true) NOT_JVMCI(false);            }
+  constexpr static bool has_tiered()  { return has_c1() && (has_c2() || has_jeandle() || has_jvmci()); }
 
   inline static bool is_jvmci_compiler();
   inline static bool is_jvmci();
@@ -162,10 +163,16 @@ public:
   inline static bool is_jvmci_compiler_enabled();
   inline static bool is_jvmci_compiler_only();
 
+  inline static bool is_jeandle_compiler();
+  inline static bool is_jeandle_compiler_enabled();
+  inline static bool is_jeandle_compiler_only();
+
   inline static bool is_c2_only();
   inline static bool is_c2_enabled();
   inline static bool is_c2_or_jvmci_compiler_only();
   inline static bool is_c2_or_jvmci_compiler_enabled();
+  inline static bool is_high_tier_compiler_only();
+  inline static bool is_high_tier_compiler_enabled();
 
 private:
   static bool is_compilation_mode_selected();

--- a/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
@@ -37,6 +37,7 @@ inline bool CompilerConfig::is_interpreter_only() {
 
 inline bool CompilerConfig::is_jvmci_compiler()    { return JVMCI_ONLY(has_jvmci() && UseJVMCICompiler) NOT_JVMCI(false); }
 inline bool CompilerConfig::is_jvmci()             { return JVMCI_ONLY(has_jvmci() && EnableJVMCI     ) NOT_JVMCI(false); }
+inline bool CompilerConfig::is_jeandle_compiler()  { return JEANDLE_PRESENT(has_jeandle() && UseJeandleCompiler && !is_jvmci_compiler()) NOT_JEANDLE(false); }
 
 // is_*_only() functions describe situations in which the JVM is in one way or another
 // forced to use a particular compiler or their combination. The constraint functions
@@ -48,7 +49,7 @@ inline bool CompilerConfig::is_jvmci()             { return JVMCI_ONLY(has_jvmci
 // Is the JVM in a configuration that permits only c1-compiled methods (level 1,2,3)?
 inline bool CompilerConfig::is_c1_only() {
   if (!is_interpreter_only() && has_c1()) {
-    const bool c1_only = !has_c2() && !is_jvmci_compiler();
+    const bool c1_only = !has_c2() && !is_jeandle_compiler() && !is_jvmci_compiler();
     const bool tiered_degraded_to_c1_only = TieredCompilation && TieredStopAtLevel >= CompLevel_simple && TieredStopAtLevel < CompLevel_full_optimization;
     const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
     return c1_only || tiered_degraded_to_c1_only || c1_only_compilation_mode;
@@ -83,6 +84,10 @@ inline bool CompilerConfig::is_c2_enabled() {
 inline bool CompilerConfig::is_jvmci_compiler_enabled() {
   return is_jvmci_compiler() && !is_interpreter_only() && !is_c1_only();
 }
+
+inline bool CompilerConfig::is_jeandle_compiler_enabled() {
+  return is_jeandle_compiler() && !is_interpreter_only() && !is_c1_only();
+}
 // Is the JVM in a configuration that permits only c2-compiled methods?
 inline bool CompilerConfig::is_c2_only() {
   if (is_c2_enabled()) {
@@ -108,18 +113,33 @@ inline bool CompilerConfig::is_jvmci_compiler_only() {
   return false;
 }
 
+// Is the JVM in a configuration that permits only Jeandle-compiled methods?
+inline bool CompilerConfig::is_jeandle_compiler_only() {
+  if (is_jeandle_compiler_enabled()) {
+    const bool jeandle_compiler_only = !has_c1();
+    const bool jeandle_only_compilation_mode = CompilationModeFlag::high_only();
+    const bool tiered_off = !TieredCompilation;
+    return jeandle_compiler_only || jeandle_only_compilation_mode || tiered_off;
+  }
+  return false;
+}
+
 inline bool CompilerConfig::is_c2_or_jvmci_compiler_only() {
   return is_c2_only() || is_jvmci_compiler_only();
 }
 
-// Tiered is basically C1 & (C2 | JVMCI) minus all the odd cases with restrictions.
+inline bool CompilerConfig::is_high_tier_compiler_only() {
+  return is_c2_or_jvmci_compiler_only() || is_jeandle_compiler_only();
+}
+
+// Tiered is basically C1 & (C2 | JVMCI | Jeandle) minus all the odd cases with restrictions.
 inline bool CompilerConfig::is_tiered() {
   assert(is_c1_simple_only() && is_c1_only() || !is_c1_simple_only(), "c1 simple mode must imply c1-only mode");
-  return has_tiered() && !is_interpreter_only() && !is_c1_only() && !is_c2_or_jvmci_compiler_only();
+  return has_tiered() && !is_interpreter_only() && !is_c1_only() && !is_high_tier_compiler_only();
 }
 
 inline bool CompilerConfig::is_c1_enabled() {
-  return has_c1() && !is_interpreter_only() && !is_c2_or_jvmci_compiler_only();
+  return has_c1() && !is_interpreter_only() && !is_high_tier_compiler_only();
 }
 
 inline bool CompilerConfig::is_c1_profiling() {
@@ -130,6 +150,10 @@ inline bool CompilerConfig::is_c1_profiling() {
 
 inline bool CompilerConfig::is_c2_or_jvmci_compiler_enabled() {
   return is_c2_enabled() || is_jvmci_compiler_enabled();
+}
+
+inline bool CompilerConfig::is_high_tier_compiler_enabled() {
+  return is_c2_or_jvmci_compiler_enabled() || is_jeandle_compiler_enabled();
 }
 
 #endif // SHARE_COMPILER_COMPILERDEFINITIONS_INLINE_HPP

--- a/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
@@ -78,7 +78,8 @@ inline bool CompilerConfig::is_c1_simple_only() {
 }
 
 inline bool CompilerConfig::is_c2_enabled() {
-  return has_c2() && !is_interpreter_only() && !is_c1_only() && !is_jvmci_compiler();
+  return has_c2() && !is_interpreter_only() && !is_c1_only() &&
+         !is_jvmci_compiler() && !is_jeandle_compiler();
 }
 
 inline bool CompilerConfig::is_jvmci_compiler_enabled() {

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -596,8 +596,8 @@ void DirectivesStack::init() {
 #if defined(COMPILER1) || INCLUDE_JVMCI
   _default_directives->_c1_store->EnableOption = true;
 #endif
-#ifdef COMPILER2
-  if (CompilerConfig::is_c2_enabled()) {
+#if COMPILER2_OR_JEANDLE
+  if (CompilerConfig::is_high_tier_compiler_enabled()) {
     _default_directives->_c2_store->EnableOption = true;
   }
 #endif

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -278,8 +278,8 @@
           "Compilation modes: "                                             \
           "default: normal tiered compilation; "                            \
           "quick-only: C1-only mode; "                                      \
-          "high-only: C2/JVMCI-only mode; "                                 \
-          "high-only-quick-internal: C2/JVMCI-only mode, "                  \
+          "high-only: high-tier compiler-only mode; "                       \
+          "high-only-quick-internal: high-tier compiler-only mode, "        \
           "with JVMCI compiler compiled with C1.")                          \
                                                                             \
   product(bool, PrintTieredEvents, false,                                   \

--- a/src/hotspot/share/compiler/compiler_globals_pd.hpp
+++ b/src/hotspot/share/compiler/compiler_globals_pd.hpp
@@ -35,16 +35,17 @@
 #ifdef COMPILER1
 #include "c1/c1_globals_pd.hpp"
 #endif // COMPILER1
-#ifdef COMPILER2
+#if defined(COMPILER2) || defined(JEANDLE)
+// Jeandle uses the server compiler defaults for shared compiler flags.
 #include "opto/c2_globals_pd.hpp"
-#endif // COMPILER2
+#endif // COMPILER2 || JEANDLE
 
 // JVMCI has no platform-specific global definitions
 //#if INCLUDE_JVMCI
 //#include "jvmci/jvmci_globals_pd.hpp"
 //#endif
 
-#if !defined(COMPILER1) && !defined(COMPILER2) && !INCLUDE_JVMCI
+#if !defined(COMPILER1) && !defined(COMPILER2) && !INCLUDE_JVMCI && !defined(JEANDLE)
 define_pd_global(bool, BackgroundCompilation,        false);
 define_pd_global(bool, CICompileOSR,                 false);
 define_pd_global(bool, UseTypeProfile,               false);
@@ -82,11 +83,11 @@ define_pd_global(uint64_t,MaxRAM,                    128ULL*G);
 #define CI_COMPILER_COUNT 0
 #else
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
 #define CI_COMPILER_COUNT 2
 #else
 #define CI_COMPILER_COUNT 1
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 
 #endif // no compilers
 

--- a/src/hotspot/share/compiler/oopMap.cpp
+++ b/src/hotspot/share/compiler/oopMap.cpp
@@ -393,9 +393,9 @@ class AddDerivedOop : public DerivedOopClosure {
   };
 
   virtual void do_derived_oop(derived_base* base, derived_pointer* derived) {
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
     DerivedPointerTable::add(derived, base);
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
   }
 };
 
@@ -877,7 +877,7 @@ void ImmutableOopMapSet::operator delete(void* p) {
 
 //------------------------------DerivedPointerTable---------------------------
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
 
 class DerivedPointerTable::Entry : public CHeapObj<mtCompiler> {
   derived_pointer* _location; // Location of derived pointer, also pointing to base
@@ -976,4 +976,4 @@ void DerivedPointerTable::update_pointers() {
   _active = false;
 }
 
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE

--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -480,7 +480,7 @@ private:
 // oops, it is filled in with references to all locations that contains a
 // derived oop (assumed to be very few).  When the GC is complete, the derived
 // pointers are updated based on their base pointers new value and an offset.
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
 class DerivedPointerTable : public AllStatic {
   friend class VMStructs;
  private:
@@ -517,6 +517,6 @@ class DerivedPointerTableDeactivate: public StackObj {
     }
   }
 };
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 
 #endif // SHARE_COMPILER_OOPMAP_HPP

--- a/src/hotspot/share/compiler/oopMap.inline.hpp
+++ b/src/hotspot/share/compiler/oopMap.inline.hpp
@@ -65,14 +65,14 @@ void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::iterate_oops_do(const frame 
       if (omv.type() != OopMapValue::derived_oop_value)
         continue;
 
-  #ifndef COMPILER2
+  #if !COMPILER2_OR_JEANDLE
       COMPILER1_PRESENT(ShouldNotReachHere();)
   #if INCLUDE_JVMCI
       if (UseJVMCICompiler) {
         ShouldNotReachHere();
       }
   #endif
-  #endif // !COMPILER2
+  #endif // !COMPILER2_OR_JEANDLE
 
       address loc = fr->oopmapreg_to_location(omv.reg(), reg_map);
 
@@ -158,4 +158,3 @@ void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::oops_do(const frame *fr, con
 }
 
 #endif // SHARE_VM_COMPILER_OOPMAP_INLINE_HPP
-

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2322,7 +2322,7 @@ void G1CollectedHeap::gc_epilogue(bool full) {
     increment_old_marking_cycles_completed(false /* concurrent */, true /* liveness_completed */);
   }
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   assert(DerivedPointerTable::is_empty(), "derived pointer present");
 #endif
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -48,19 +48,19 @@
 #include "utilities/debug.hpp"
 
 static void clear_and_activate_derived_pointers() {
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   DerivedPointerTable::clear();
 #endif
 }
 
 static void deactivate_derived_pointers() {
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   DerivedPointerTable::set_active(false);
 #endif
 }
 
 static void update_derived_pointers() {
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   DerivedPointerTable::update_pointers();
 #endif
 }
@@ -503,7 +503,7 @@ void G1FullCollector::verify_after_marking() {
     return;
   }
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   DerivedPointerTableDeactivate dpt_deact;
 #endif
   _heap->prepare_for_verify();

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -101,7 +101,7 @@ G1GCPhaseTimes::G1GCPhaseTimes(STWGCTimer* gc_timer, uint max_gc_threads) :
   _gc_par_phases[RemoveSelfForwards] = new WorkerDataArray<double>("RemoveSelfForwards", "Remove Self Forwards (ms):", max_gc_threads);
   _gc_par_phases[ClearCardTable] = new WorkerDataArray<double>("ClearLoggedCards", "Clear Logged Cards (ms):", max_gc_threads);
   _gc_par_phases[RecalculateUsed] = new WorkerDataArray<double>("RecalculateUsed", "Recalculate Used Memory (ms):", max_gc_threads);
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   _gc_par_phases[UpdateDerivedPointers] = new WorkerDataArray<double>("UpdateDerivedPointers", "Update Derived Pointers (ms):", max_gc_threads);
 #endif
   _gc_par_phases[EagerlyReclaimHumongousObjects] = new WorkerDataArray<double>("EagerlyReclaimHumongousObjects", "Eagerly Reclaim Humongous Objects (ms):", max_gc_threads);
@@ -511,7 +511,7 @@ double G1GCPhaseTimes::print_post_evacuate_collection_set(bool evacuation_failed
     debug_phase(_gc_par_phases[RestorePreservedMarks], 1);
     debug_phase(_gc_par_phases[ClearRetainedRegionBitmaps], 1);
   }
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   debug_phase(_gc_par_phases[UpdateDerivedPointers], 1);
 #endif
   debug_phase(_gc_par_phases[EagerlyReclaimHumongousObjects], 1);
@@ -641,4 +641,3 @@ G1EvacPhaseTimesTracker::~G1EvacPhaseTimesTracker() {
     _phase_times->record_or_add_time_secs(G1GCPhaseTimes::ObjCopy, _worker_id, _trim_time.seconds());
   }
 }
-

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -83,7 +83,7 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
     RemoveSelfForwards,
     ClearCardTable,
     RecalculateUsed,
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
     UpdateDerivedPointers,
 #endif
     EagerlyReclaimHumongousObjects,

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -504,7 +504,7 @@ void G1YoungCollector::pre_evacuate_collection_set(G1EvacInfo* evacuation_info) 
 
   assert(_g1h->verifier()->check_region_attr_table(), "Inconsistency in the region attributes table.");
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   DerivedPointerTable::clear();
 #endif
 

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -233,7 +233,7 @@ public:
   }
 };
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
 class G1PostEvacuateCollectionSetCleanupTask2::UpdateDerivedPointersTask : public G1AbstractSubTask {
 public:
   UpdateDerivedPointersTask() : G1AbstractSubTask(G1GCPhaseTimes::UpdateDerivedPointers) { }
@@ -717,7 +717,7 @@ G1PostEvacuateCollectionSetCleanupTask2::G1PostEvacuateCollectionSetCleanupTask2
                                                                                  G1EvacFailureRegions* evac_failure_regions) :
   G1BatchedTask("Post Evacuate Cleanup 2", G1CollectedHeap::heap()->phase_times())
 {
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   add_serial_task(new UpdateDerivedPointersTask());
 #endif
   if (G1CollectedHeap::heap()->has_humongous_reclaim_candidates()) {

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
@@ -62,7 +62,7 @@ public:
 // - Resize TLABs
 class G1PostEvacuateCollectionSetCleanupTask2 : public G1BatchedTask {
   class EagerlyReclaimHumongousObjectsTask;
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   class UpdateDerivedPointersTask;
 #endif
 

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -91,7 +91,7 @@ void GenMarkSweep::invoke_at_safepoint(bool clear_all_softrefs) {
   mark_sweep_phase2();
 
   // Don't add any more derived pointers during phase3
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   assert(DerivedPointerTable::is_active(), "Sanity");
   DerivedPointerTable::set_active(false);
 #endif

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -425,7 +425,9 @@ void GenCollectedHeap::collect_generation(Generation* gen, bool full, size_t siz
   if (run_verification && VerifyBeforeGC) {
     Universe::verify("Before GC");
   }
-  COMPILER2_OR_JVMCI_PRESENT(DerivedPointerTable::clear());
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
+  DerivedPointerTable::clear();
+#endif
 
   // Do collection work
   {
@@ -434,7 +436,9 @@ void GenCollectedHeap::collect_generation(Generation* gen, bool full, size_t siz
     gen->collect(full, clear_soft_refs, size, is_tlab);
   }
 
-  COMPILER2_OR_JVMCI_PRESENT(DerivedPointerTable::update_pointers());
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
+  DerivedPointerTable::update_pointers();
+#endif
 
   gen->stat_record()->accumulated_time.stop();
 
@@ -1116,9 +1120,9 @@ class GenGCEpilogueClosure: public GenCollectedHeap::GenClosure {
 };
 
 void GenCollectedHeap::gc_epilogue(bool full) {
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   assert(DerivedPointerTable::is_empty(), "derived pointer present");
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 
   resize_all_tlabs();
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -62,7 +62,7 @@ void ReferenceProcessor::init_statics() {
   java_lang_ref_SoftReference::set_clock(_soft_ref_timestamp_clock);
 
   _always_clear_soft_ref_policy = new AlwaysClearPolicy();
-  if (CompilerConfig::is_c2_or_jvmci_compiler_enabled()) {
+  if (CompilerConfig::is_high_tier_compiler_enabled()) {
     _default_soft_ref_policy = new LRUMaxHeapPolicy();
   } else {
     _default_soft_ref_policy = new LRUCurrentHeapPolicy();

--- a/src/hotspot/share/jeandle/jeandle_globals.hpp
+++ b/src/hotspot/share/jeandle/jeandle_globals.hpp
@@ -84,6 +84,62 @@
           "counted loops (0 disables strip mining).")                       \
           range(0, max_juint)                                               \
                                                                             \
+  NOT_COMPILER2(product(intx, ArrayOperationPartialInlineSize, 0,           \
+          DIAGNOSTIC,                                                       \
+          "Partial inline size used for small array operations"             \
+          "(e.g. copy,cmp) acceleration.")                                  \
+          range(0, 256))                                                    \
+                                                                            \
+  NOT_COMPILER2(product(bool, EliminateAutoBox, true,                       \
+          "Control optimizations for autobox elimination"))                \
+                                                                            \
+  NOT_COMPILER2(product(bool, DoEscapeAnalysis, true,                       \
+          "Perform escape analysis"))                                      \
+                                                                            \
+  NOT_COMPILER2(product(bool, EliminateAllocations, true,                   \
+          "Use escape analysis to eliminate allocations"))                 \
+                                                                            \
+  NOT_COMPILER2(develop(bool, InlineAccessors, true,                        \
+          "inline accessor methods (get/set)"))                            \
+                                                                            \
+  NOT_COMPILER2(product(intx, MaxInlineLevel, 15,                           \
+          "maximum number of nested calls that are inlined by high tier "   \
+          "compiler"                                                       \
+          range(0, max_jint)))                                              \
+                                                                            \
+  NOT_COMPILER2(product(intx, MaxRecursiveInlineLevel, 1,                   \
+          "maximum number of nested recursive calls that are inlined by "   \
+          "high tier compiler"                                             \
+          range(0, max_jint)))                                              \
+                                                                            \
+  NOT_COMPILER2(product(intx, InlineSmallCode, 1000,                        \
+          "Only inline already compiled methods if their code size is "     \
+          "less than this"                                                 \
+          range(0, max_jint)))                                              \
+                                                                            \
+  NOT_COMPILER2(product(intx, MaxInlineSize, 35,                            \
+          "The maximum bytecode size of a method to be inlined by high "    \
+          "tier compiler"                                                  \
+          range(0, max_jint)))                                              \
+                                                                            \
+  NOT_COMPILER2(product_pd(intx, FreqInlineSize,                            \
+          "The maximum bytecode size of a frequent method to be inlined"    \
+          range(0, max_jint)))                                              \
+                                                                            \
+  NOT_COMPILER2(product(intx, MaxTrivialSize, 6,                            \
+          "The maximum bytecode size of a trivial method to be inlined by " \
+          "high tier compiler"                                             \
+          range(0, max_jint)))                                              \
+                                                                            \
+  NOT_COMPILER2(product(bool, IncrementalInline, true,                      \
+          "do post parse inlining"))                                       \
+                                                                            \
+  NOT_COMPILER2(develop(bool, PoisonOSREntry, true,                         \
+          "Detect abnormal calls to OSR code"))                            \
+                                                                            \
+  NOT_COMPILER2(product(bool, InlineSecondarySupersTest, true, DIAGNOSTIC,  \
+          "Inline the secondary supers hash lookup."))                     \
+                                                                            \
 // end of JEANDLE_FLAGS
 
 DECLARE_FLAGS(JEANDLE_FLAGS)

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -1119,11 +1119,11 @@ bool Universe::should_verify_subset(uint subset) {
 }
 
 void Universe::verify(VerifyOption option, const char* prefix) {
-  COMPILER2_PRESENT(
+#if COMPILER2_OR_JEANDLE
     assert(!DerivedPointerTable::is_active(),
          "DPT should not be active during verification "
          "(of thread stacks below)");
-  )
+#endif
 
   Thread* thread = Thread::current();
   ResourceMark rm(thread);

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -95,16 +95,16 @@ int Abstract_VM_Version::_vm_build_number = VERSION_BUILD;
 #endif
 
 #ifndef VMTYPE
-  #if COMPILER1_AND_COMPILER2
+  #if COMPILER1_AND_COMPILER2 || defined(JEANDLE)
     #define VMTYPE "Server"
-  #else // COMPILER1_AND_COMPILER2
+  #else // COMPILER1_AND_COMPILER2 || JEANDLE
   #ifdef ZERO
     #define VMTYPE "Zero"
   #else // ZERO
      #define VMTYPE COMPILER1_PRESENT("Client")   \
                     COMPILER2_PRESENT("Server")
   #endif // ZERO
-  #endif // COMPILER1_AND_COMPILER2
+  #endif // COMPILER1_AND_COMPILER2 || JEANDLE
 #endif
 
 #ifndef HOTSPOT_VM_DISTRO

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3011,7 +3011,7 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
     FLAG_SET_ERGO(InitialTenuringThreshold, MaxTenuringThreshold);
   }
 
-#if !COMPILER2_OR_JVMCI
+#if !COMPILER2_OR_JVMCI_OR_JEANDLE
   // Don't degrade server performance for footprint
   if (FLAG_IS_DEFAULT(UseLargePages) &&
       MaxHeapSize < LargePageHeapSizeThreshold) {

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1892,7 +1892,7 @@ Deoptimization::get_method_data(JavaThread* thread, const methodHandle& m,
   return mdo;
 }
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
 void Deoptimization::load_class_by_index(const constantPoolHandle& constant_pool, int index, TRAPS) {
   // In case of an unresolved klass entry, load the class.
   // This path is exercised from case _ldc in Parse::do_one_bytecode,
@@ -2331,7 +2331,12 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
     // aggressive optimization.
     bool inc_recompile_count = false;
     ProfileData* pdata = nullptr;
-    if (ProfileTraps && CompilerConfig::is_c2_or_jvmci_compiler_enabled() && update_trap_state && trap_mdo != nullptr) {
+    const bool high_tier_compiled = nm->is_compiled_by_c2() || nm->is_compiled_by_jeandle()
+#if INCLUDE_JVMCI
+                                    || nm->is_compiled_by_jvmci()
+#endif
+                                    ;
+    if (ProfileTraps && high_tier_compiled && update_trap_state && trap_mdo != nullptr) {
       assert(trap_mdo == get_method_data(current, profiled_method, false), "sanity");
       uint this_trap_count = 0;
       bool maybe_prior_trap = false;
@@ -2884,7 +2889,7 @@ void Deoptimization::print_statistics() {
   }
 }
 
-#else // COMPILER2_OR_JVMCI
+#else // COMPILER2_OR_JVMCI_OR_JEANDLE
 
 
 // Stubs for C1 only system.
@@ -2928,4 +2933,4 @@ const char* Deoptimization::format_trap_state(char* buf, size_t buflen,
   return buf;
 }
 
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -289,7 +289,7 @@ JRT_BLOCK_ENTRY(Deoptimization::UnrollBlock*, Deoptimization::fetch_unroll_info(
   return fetch_unroll_info_helper(current, exec_mode);
 JRT_END
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
 // print information about reallocated objects
 static void print_objects(JavaThread* deoptee_thread,
                           GrowableArray<ScopeValue*>* objects, bool realloc_failures) {
@@ -439,14 +439,20 @@ bool Deoptimization::deoptimize_objects_internal(JavaThread* thread, GrowableArr
   frame deoptee = chunk->at(0)->fr();
   JavaThread* deoptee_thread = chunk->at(0)->thread();
   CompiledMethod* cm = deoptee.cb()->as_compiled_method_or_null();
+  const bool c2_compiled = COMPILER2_PRESENT(cm != nullptr && cm->is_compiled_by_c2())
+                           NOT_COMPILER2(false);
+  const bool jeandle_compiled = JEANDLE_PRESENT(cm != nullptr && cm->is_compiled_by_jeandle())
+                                NOT_JEANDLE(false);
   RegisterMap map(chunk->at(0)->register_map());
   bool deoptimized_objects = false;
 
   bool const jvmci_enabled = JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false);
 
   // Reallocate the non-escaping objects and restore their fields.
-  if (jvmci_enabled COMPILER2_PRESENT(|| (DoEscapeAnalysis && EliminateAllocations)
-                                      || EliminateAutoBox || EnableVectorAggressiveReboxing)) {
+  if (jvmci_enabled ||
+      (c2_compiled COMPILER2_PRESENT(&& ((DoEscapeAnalysis && EliminateAllocations)
+                                        || EliminateAutoBox || EnableVectorAggressiveReboxing))) ||
+      (jeandle_compiled JEANDLE_PRESENT(&& JeandleDoPEA))) {
     realloc_failures = rematerialize_objects(thread, Unpack_none, cm, deoptee, map, chunk, deoptimized_objects);
   }
 
@@ -454,12 +460,14 @@ bool Deoptimization::deoptimize_objects_internal(JavaThread* thread, GrowableArr
   NoSafepointVerifier no_safepoint;
 
   // Now relock objects if synchronization on them was eliminated.
-  if (jvmci_enabled COMPILER2_PRESENT(|| ((DoEscapeAnalysis || EliminateNestedLocks) && EliminateLocks))) {
+  if (jvmci_enabled ||
+      (c2_compiled COMPILER2_PRESENT(&& (DoEscapeAnalysis || EliminateNestedLocks) && EliminateLocks)) ||
+      (jeandle_compiled JEANDLE_PRESENT(&& JeandleDoPEA && JeandleEliminateLocks))) {
     restore_eliminated_locks(thread, chunk, realloc_failures, deoptee, Unpack_none, deoptimized_objects);
   }
   return deoptimized_objects;
 }
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 
 // This is factored, since it is both called from a JRT_LEAF (deoptimization) and a JRT_ENTRY (uncommon_trap)
 Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread* current, int exec_mode) {
@@ -492,6 +500,10 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   // Set the deoptee nmethod
   assert(current->deopt_compiled_method() == nullptr, "Pending deopt!");
   CompiledMethod* cm = deoptee.cb()->as_compiled_method_or_null();
+  const bool c2_compiled = COMPILER2_PRESENT(cm != nullptr && cm->is_compiled_by_c2())
+                           NOT_COMPILER2(false);
+  const bool jeandle_compiled = JEANDLE_PRESENT(cm != nullptr && cm->is_compiled_by_jeandle())
+                                NOT_JEANDLE(false);
   current->set_deopt_compiled_method(cm);
 
   if (VerifyStack) {
@@ -513,17 +525,19 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
 
   bool realloc_failures = false;
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   bool const jvmci_enabled = JVMCI_ONLY(EnableJVMCI) NOT_JVMCI(false);
 
   // Reallocate the non-escaping objects and restore their fields. Then
   // relock objects if synchronization on them was eliminated.
-  if (jvmci_enabled COMPILER2_PRESENT( || (DoEscapeAnalysis && EliminateAllocations)
-                                       || EliminateAutoBox || EnableVectorAggressiveReboxing )) {
+  if (jvmci_enabled ||
+      (c2_compiled COMPILER2_PRESENT(&& ((DoEscapeAnalysis && EliminateAllocations)
+                                        || EliminateAutoBox || EnableVectorAggressiveReboxing))) ||
+      (jeandle_compiled JEANDLE_PRESENT(&& JeandleDoPEA))) {
     bool unused;
     realloc_failures = rematerialize_objects(current, exec_mode, cm, deoptee, map, chunk, unused);
   }
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 
   // Ensure that no safepoint is taken after pointers have been stored
   // in fields of rematerialized objects.  If a safepoint occurs from here on
@@ -531,13 +545,15 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   // Locks may be rebaised in a safepoint.
   NoSafepointVerifier no_safepoint;
 
-#if COMPILER2_OR_JVMCI
-  if ((jvmci_enabled COMPILER2_PRESENT( || ((DoEscapeAnalysis || EliminateNestedLocks) && EliminateLocks) ))
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
+  if ((jvmci_enabled ||
+       (c2_compiled COMPILER2_PRESENT(&& (DoEscapeAnalysis || EliminateNestedLocks) && EliminateLocks)) ||
+       (jeandle_compiled JEANDLE_PRESENT(&& JeandleDoPEA && JeandleEliminateLocks)))
       && !EscapeBarrier::objs_are_deoptimized(current, deoptee.id())) {
     bool unused = false;
     restore_eliminated_locks(current, chunk, realloc_failures, deoptee, exec_mode, unused);
   }
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 
   ScopeDesc* trap_scope = chunk->at(0)->scope();
   Handle exceptionObject;
@@ -556,7 +572,7 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   }
 
   vframeArray* array = create_vframeArray(current, deoptee, &map, chunk, realloc_failures);
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   if (realloc_failures) {
     // This destroys all ScopedValue bindings.
     current->clear_scopedValueBindings();
@@ -1200,7 +1216,7 @@ oop Deoptimization::get_cached_box(AutoBoxObjectValue* bv, frame* fr, RegisterMa
 }
 #endif // INCLUDE_JVMCI
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
 bool Deoptimization::realloc_objects(JavaThread* thread, frame* fr, RegisterMap* reg_map, GrowableArray<ScopeValue*>* objects, TRAPS) {
   Handle pending_exception(THREAD, thread->pending_exception());
   const char* exception_file = thread->exception_file();
@@ -1672,7 +1688,7 @@ bool Deoptimization::relock_objects(JavaThread* thread, GrowableArray<MonitorInf
   }
   return relocked_objects;
 }
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 
 vframeArray* Deoptimization::create_vframeArray(JavaThread* thread, frame fr, RegisterMap *reg_map, GrowableArray<compiledVFrame*>* chunk, bool realloc_failures) {
   Events::log_deopt_message(thread, "DEOPT PACKING pc=" INTPTR_FORMAT " sp=" INTPTR_FORMAT, p2i(fr.pc()), p2i(fr.sp()));
@@ -1724,7 +1740,7 @@ vframeArray* Deoptimization::create_vframeArray(JavaThread* thread, frame fr, Re
   return array;
 }
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
 void Deoptimization::pop_frames_failed_reallocs(JavaThread* thread, vframeArray* array) {
   // Reallocation of some scalar replaced objects failed. Record
   // that we need to pop all the interpreter frames for the

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -192,7 +192,7 @@ class Deoptimization : AllStatic {
   // Does the actual work for deoptimizing a single frame
   static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   // Deoptimize objects, that is reallocate and relock them, just before they
   // escape through JVMTI.  The given vframes cover one physical frame.
   static bool deoptimize_objects_internal(JavaThread* thread, GrowableArray<compiledVFrame*>* chunk,
@@ -208,7 +208,7 @@ class Deoptimization : AllStatic {
   static bool relock_objects(JavaThread* thread, GrowableArray<MonitorInfo*>* monitors,
                              JavaThread* deoptee_thread, frame& fr, int exec_mode, bool realloc_failures);
   static void pop_frames_failed_reallocs(JavaThread* thread, vframeArray* array);
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 
   public:
   static vframeArray* create_vframeArray(JavaThread* thread, frame fr, RegisterMap *reg_map, GrowableArray<compiledVFrame*>* chunk, bool realloc_failures);

--- a/src/hotspot/share/runtime/escapeBarrier.cpp
+++ b/src/hotspot/share/runtime/escapeBarrier.cpp
@@ -47,7 +47,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
 
 // Returns true iff objects were reallocated and relocked because of access through JVMTI
 bool EscapeBarrier::objs_are_deoptimized(JavaThread* thread, intptr_t* fr_id) {
@@ -373,4 +373,4 @@ bool EscapeBarrier::deoptimize_objects_internal(JavaThread* deoptee, intptr_t* f
   return !realloc_failures;
 }
 
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE

--- a/src/hotspot/share/runtime/escapeBarrier.hpp
+++ b/src/hotspot/share/runtime/escapeBarrier.hpp
@@ -27,6 +27,7 @@
 #define SHARE_RUNTIME_ESCAPEBARRIER_HPP
 
 #include "compiler/compiler_globals.hpp"
+#include "compiler/compilerDefinitions.inline.hpp"
 #include "memory/allocation.hpp"
 #include "utilities/macros.hpp"
 
@@ -39,7 +40,7 @@ class JavaThread;
 
 class EscapeBarrier : StackObj {
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   JavaThread* const _calling_thread;
   JavaThread* const _deoptee_thread;
   bool        const _barrier_active;
@@ -72,7 +73,8 @@ public:
   EscapeBarrier(bool barrier_active, JavaThread* calling_thread, JavaThread* deoptee_thread)
     : _calling_thread(calling_thread), _deoptee_thread(deoptee_thread),
       _barrier_active(barrier_active && (JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false)
-                      COMPILER2_PRESENT(|| DoEscapeAnalysis)))
+                      COMPILER2_PRESENT(|| (CompilerConfig::is_c2_enabled() && DoEscapeAnalysis))
+                      JEANDLE_PRESENT(|| (CompilerConfig::is_jeandle_compiler_enabled() && JeandleDoPEA)))
   {
     if (_barrier_active) sync_and_suspend_one();
   }
@@ -81,7 +83,8 @@ public:
   EscapeBarrier(bool barrier_active, JavaThread* calling_thread)
     : _calling_thread(calling_thread), _deoptee_thread(nullptr),
       _barrier_active(barrier_active && (JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false)
-                      COMPILER2_PRESENT(|| DoEscapeAnalysis)))
+                      COMPILER2_PRESENT(|| (CompilerConfig::is_c2_enabled() && DoEscapeAnalysis))
+                      JEANDLE_PRESENT(|| (CompilerConfig::is_jeandle_compiler_enabled() && JeandleDoPEA)))
   {
     if (_barrier_active) sync_and_suspend_all();
   }
@@ -93,7 +96,7 @@ public:
   EscapeBarrier(bool barrier_active, JavaThread* calling_thread) { }
   static bool deoptimizing_objects_for_all_threads() { return false; }
   bool barrier_active() const                        { return false; }
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 
   // Deoptimize objects of frames of the target thread up to the given depth.
   // Deoptimize objects of caller frames if they passed references to ArgEscape objects as arguments.
@@ -105,18 +108,18 @@ public:
   // Deoptimize objects of frames of the target thread at depth >= d1 and depth <= d2.
   // Deoptimize objects of caller frames if they passed references to ArgEscape objects as arguments.
   // Return false in the case of a reallocation failure and true otherwise.
-  bool deoptimize_objects(int d1, int d2)                      NOT_COMPILER2_OR_JVMCI_RETURN_(true);
+  bool deoptimize_objects(int d1, int d2)                      NOT_COMPILER2_OR_JVMCI_OR_JEANDLE_RETURN_(true);
 
   // Find and deoptimize non escaping objects and the holding frames on all stacks.
-  bool deoptimize_objects_all_threads()                        NOT_COMPILER2_OR_JVMCI_RETURN_(true);
+  bool deoptimize_objects_all_threads()                        NOT_COMPILER2_OR_JVMCI_OR_JEANDLE_RETURN_(true);
 
   // A java thread was added to the list of threads.
-  static void thread_added(JavaThread* jt)                     NOT_COMPILER2_OR_JVMCI_RETURN;
+  static void thread_added(JavaThread* jt)                     NOT_COMPILER2_OR_JVMCI_OR_JEANDLE_RETURN;
 
   // A java thread was removed from the list of threads.
-  static void thread_removed(JavaThread* jt)                   NOT_COMPILER2_OR_JVMCI_RETURN;
+  static void thread_removed(JavaThread* jt)                   NOT_COMPILER2_OR_JVMCI_OR_JEANDLE_RETURN;
 
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   // Returns true iff objects were reallocated and relocked because of access through JVMTI.
   static bool objs_are_deoptimized(JavaThread* thread, intptr_t* fr_id);
 
@@ -141,7 +144,7 @@ public:
   // accessors
   JavaThread* calling_thread() const     { return _calling_thread; }
   JavaThread* deoptee_thread() const     { return _deoptee_thread; }
-#endif // COMPILER2_OR_JVMCI
+#endif // COMPILER2_OR_JVMCI_OR_JEANDLE
 };
 
 #endif // SHARE_RUNTIME_ESCAPEBARRIER_HPP

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -42,7 +42,7 @@
  */
 JVMFlag::Error CICompilerCountConstraintFunc(intx value, bool verbose) {
   int min_number_of_compiler_threads = 0;
-#if COMPILER1_OR_COMPILER2
+#if COMPILER1_OR_COMPILER2_OR_JEANDLE
   if (CompilerConfig::is_tiered()) {
     min_number_of_compiler_threads = 2;
   } else if (!CompilerConfig::is_interpreter_only()) {

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1194,7 +1194,7 @@ void frame::verify(const RegisterMap* map) const {
       // make sure we have the right receiver type
     }
   }
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
   assert(DerivedPointerTable::is_empty(), "must be empty before verify");
 #endif
 

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -454,7 +454,7 @@ class frame {
  public:
   // Memory management
   void oops_do(OopClosure* f, CodeBlobClosure* cf, const RegisterMap* map) {
-#if COMPILER2_OR_JVMCI
+#if COMPILER2_OR_JVMCI_OR_JEANDLE
     DerivedPointerIterationMode dpim = DerivedPointerTable::is_active() ?
                                        DerivedPointerIterationMode::_with_table :
                                        DerivedPointerIterationMode::_ignore;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -96,9 +96,9 @@ SafepointBlob*      SharedRuntime::_polling_page_vectors_safepoint_handler_blob;
 SafepointBlob*      SharedRuntime::_polling_page_safepoint_handler_blob;
 SafepointBlob*      SharedRuntime::_polling_page_return_handler_blob;
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
 UncommonTrapBlob*   SharedRuntime::_uncommon_trap_blob;
-#endif // COMPILER2
+#endif // COMPILER2_OR_JEANDLE
 
 nmethod*            SharedRuntime::_cont_doYield_stub;
 
@@ -126,9 +126,9 @@ void SharedRuntime::generate_stubs() {
 
   generate_deopt_blob();
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
   generate_uncommon_trap_blob();
-#endif // COMPILER2
+#endif // COMPILER2_OR_JEANDLE
 }
 
 #include <math.h>

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -67,9 +67,9 @@ class SharedRuntime: AllStatic {
   static SafepointBlob*      _polling_page_safepoint_handler_blob;
   static SafepointBlob*      _polling_page_return_handler_blob;
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
   static UncommonTrapBlob*   _uncommon_trap_blob;
-#endif // COMPILER2
+#endif // COMPILER2_OR_JEANDLE
 
   static nmethod*            _cont_doYield_stub;
 
@@ -228,10 +228,10 @@ class SharedRuntime: AllStatic {
     return _wrong_method_abstract_blob->entry_point();
   }
 
-#ifdef COMPILER2
+#if COMPILER2_OR_JEANDLE
   static void generate_uncommon_trap_blob(void);
   static UncommonTrapBlob* uncommon_trap_blob()                  { return _uncommon_trap_blob; }
-#endif // COMPILER2
+#endif // COMPILER2_OR_JEANDLE
 
   static address get_resolve_opt_virtual_call_stub() {
     assert(_resolve_opt_virtual_call_blob != nullptr, "oops");

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -692,7 +692,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   MonitorDeflationThread::initialize();
 
   // initialize compiler(s)
-#if defined(COMPILER1) || COMPILER2_OR_JVMCI
+#if defined(COMPILER1) || COMPILER2_OR_JVMCI_OR_JEANDLE
 #if INCLUDE_JVMCI
   bool force_JVMCI_intialization = false;
   if (EnableJVMCI) {

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -339,6 +339,20 @@
 #define NOT_JEANDLE(code) code
 #endif // JEANDLE
 
+// COMPILER1, COMPILER2, or JEANDLE
+#if defined(COMPILER1) || defined(COMPILER2) || defined(JEANDLE)
+#define COMPILER1_OR_COMPILER2_OR_JEANDLE 1
+#else
+#define COMPILER1_OR_COMPILER2_OR_JEANDLE 0
+#endif
+
+// COMPILER2, JVMCI, or JEANDLE
+#if defined(COMPILER2) || INCLUDE_JVMCI || defined(JEANDLE)
+#define COMPILER2_OR_JVMCI_OR_JEANDLE 1
+#else
+#define COMPILER2_OR_JVMCI_OR_JEANDLE 0
+#endif
+
 // COMPILER2 or JEANDLE
 #if defined(COMPILER2) || defined(JEANDLE)
 #define COMPILER2_OR_JEANDLE 1

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -360,6 +360,15 @@
 #define COMPILER2_OR_JEANDLE 0
 #endif // COMPILER2 || JEANDLE
 
+// COMPILER2, JVMCI, or JEANDLE
+#if defined(COMPILER2) || INCLUDE_JVMCI || defined(JEANDLE)
+#define NOT_COMPILER2_OR_JVMCI_OR_JEANDLE_RETURN        /* next token must be ; */
+#define NOT_COMPILER2_OR_JVMCI_OR_JEANDLE_RETURN_(code) /* next token must be ; */
+#else
+#define NOT_COMPILER2_OR_JVMCI_OR_JEANDLE_RETURN {}
+#define NOT_COMPILER2_OR_JVMCI_OR_JEANDLE_RETURN_(code) { return code; }
+#endif
+
 // PRODUCT variant
 #ifdef PRODUCT
 #define PRODUCT_ONLY(code) code

--- a/test/hotspot/jtreg/compiler/jeandle/deoptimize/TestUncommonTrapConvergence.java
+++ b/test/hotspot/jtreg/compiler/jeandle/deoptimize/TestUncommonTrapConvergence.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @summary Test that Jeandle uncommon traps converge after trap profiling records a recompile
+ * @requires vm.debug
+ * @library /test/lib
+ * @run driver compiler.jeandle.deoptimize.TestUncommonTrapConvergence
+ */
+
+package compiler.jeandle.deoptimize;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestUncommonTrapConvergence {
+    private static final int ROUNDS = 6;
+    private static final String CHECKED_INSTALL =
+            "(?m)^.*\\[nmethod,install\\].*Installing method \\(4\\) " +
+            Pattern.quote(TestUncommonTrapConvergence.class.getName()) +
+            "\\.checked\\(II\\)I\\s*$";
+    private static volatile int sink;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1 && args[0].equals("worker")) {
+            runWorker();
+            return;
+        }
+
+        OutputAnalyzer profiled = runChild("-XX:+ProfileTraps");
+        int profiledCompilations = countMatches(profiled.getOutput(),
+                "(?m)^.*Jeandle:\\s+\\d+\\s+b\\s+.*::checked \\(6 bytes\\)$");
+        int profiledInstalls = countMatches(profiled.getOutput(), CHECKED_INSTALL);
+        int profiledTraps = countMatches(profiled.getOutput(),
+                "(?m)^.*Jeandle:\\s+\\d+.*::checked \\(6 bytes\\)\\s+made not entrant$");
+        if (profiledCompilations < 2) {
+            throw new RuntimeException("Expected the Jeandle method to be compiled and recompiled, found " +
+                                       profiledCompilations + " compilations");
+        }
+        if (profiledInstalls < 2) {
+            throw new RuntimeException("Expected the Jeandle method to be installed and reinstalled, found " +
+                                       profiledInstalls + " installations");
+        }
+        if (profiledTraps != 1) {
+            throw new RuntimeException("Expected one profiled range-check trap, found " + profiledTraps);
+        }
+
+        OutputAnalyzer unprofiled = runChild("-XX:-ProfileTraps");
+        int unprofiledCompilations = countMatches(unprofiled.getOutput(),
+                "(?m)^.*Jeandle:\\s+\\d+\\s+b\\s+.*::checked \\(6 bytes\\)$");
+        int unprofiledInstalls = countMatches(unprofiled.getOutput(), CHECKED_INSTALL);
+        int unprofiledTraps = countMatches(unprofiled.getOutput(),
+                "(?m)^.*Jeandle:\\s+\\d+.*::checked \\(6 bytes\\)\\s+made not entrant$");
+        if (unprofiledCompilations < ROUNDS) {
+            throw new RuntimeException("Expected repeated Jeandle compilations without profiling, found " +
+                                       unprofiledCompilations + " compilations");
+        }
+        if (unprofiledInstalls < ROUNDS) {
+            throw new RuntimeException("Expected repeated Jeandle installations without profiling, found " +
+                                       unprofiledInstalls);
+        }
+        if (unprofiledTraps < ROUNDS - 1) {
+            throw new RuntimeException("Expected repeated range-check traps without profiling, found " +
+                                       unprofiledTraps);
+        }
+    }
+
+    private static OutputAnalyzer runChild(String profileTrapsOption) throws Exception {
+        ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(
+                "-Xbatch",
+                "-XX:-BackgroundCompilation",
+                "-XX:-TieredCompilation",
+                "-XX:+UseJeandleCompiler",
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+CIPrintCompilerName",
+                "-XX:CompileThreshold=100",
+                profileTrapsOption,
+                "-Xlog:deoptimization=debug,jit+compilation=debug,nmethod+install=info",
+                "-XX:CompileCommand=compileonly," + TestUncommonTrapConvergence.class.getName() + "::checked",
+                TestUncommonTrapConvergence.class.getName(),
+                "worker");
+        OutputAnalyzer output = ProcessTools.executeCommand(processBuilder);
+        output.shouldHaveExitValue(0);
+        return output;
+    }
+
+    private static int countMatches(String output, String regex) {
+        Matcher matcher = Pattern.compile(regex).matcher(output);
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
+    }
+
+    private static int checked(int index, int length) {
+        return Objects.checkIndex(index, length);
+    }
+
+    private static void runWorker() {
+        for (int round = 0; round < ROUNDS; round++) {
+            for (int i = 0; i < 20_000; i++) {
+                sink += checked(i & 7, 8);
+            }
+            try {
+                checked(-1, 8);
+                throw new RuntimeException("Expected IndexOutOfBoundsException");
+            } catch (IndexOutOfBoundsException expected) {
+            }
+        }
+        System.out.println("sink=" + sink);
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/pea/TestPEADeoptImplicitTrap.java
+++ b/test/hotspot/jtreg/compiler/jeandle/pea/TestPEADeoptImplicitTrap.java
@@ -27,6 +27,14 @@
  * @run main/othervm -XX:-UseJeandleCompiler
  *      -XX:-UseCompressedOops -XX:-UseCompressedClassPointers
  *      compiler.jeandle.pea.TestPEADeoptImplicitTrap
+ * @run main/othervm -XX:-UseJeandleCompiler
+ *      -XX:-UseCompressedOops -XX:-UseCompressedClassPointers
+ *      -Dcompiler.jeandle.pea.runtimeOnly=true
+ *      compiler.jeandle.pea.TestPEADeoptImplicitTrap
+ * @run main/othervm -XX:+UseJeandleCompiler
+ *      -XX:-UseCompressedOops -XX:-UseCompressedClassPointers
+ *      -Dcompiler.jeandle.pea.runtimeOnly=true
+ *      compiler.jeandle.pea.TestPEADeoptImplicitTrap
  */
 
 package compiler.jeandle.pea;
@@ -81,13 +89,16 @@ public class TestPEADeoptImplicitTrap {
 
     public static void main(String[] args) throws Exception {
         for (Scenario scenario : Scenario.values()) {
-            runScenario(scenario);
+            runScenario(scenario, Boolean.getBoolean("compiler.jeandle.pea.runtimeOnly"));
         }
     }
 
-    private static void runScenario(Scenario scenario) throws Exception {
+    private static void runScenario(Scenario scenario, boolean runtimeOnly) throws Exception {
         Method target = targetFor(scenario);
         builder(false, target, scenario).runPEAOnOffEquivalent();
+        if (runtimeOnly) {
+            return;
+        }
         try (PEATestUtils.RunResult run = builder(true, target, scenario).run()) {
             assertTrapShape(run, target, scenario);
         }


### PR DESCRIPTION
Problem:
Jeandle-only builds can emit uncommon traps and PEA virtual-object/lock state, but shared uncommon-trap and deoptimization recovery paths were still gated by C2/JVMCI-only conditions.

Approach:
- Enable high-tier uncommon-trap/deoptimization plumbing for Jeandle-only builds.
- Separate C2 and Jeandle predicates using the actual CompiledMethod identity.
- Restore Jeandle PEA virtual objects and eliminated locks during deoptimization, including failure rollback and EscapeBarrier handling.
- Add runtime and install-level jtreg coverage.

Verification:
- Base: jeandle/jeandle-jdk main at a2943078e03.
- All three commits carry Signed-off-by trailers.
- git diff --check passes.
- Jeandle-only preprocessor checks pass for deoptimization.cpp, escapeBarrier.cpp, and scopeDesc.cpp.
- Full AArch64 build/jtreg verification remains pending because the remote build host was unavailable and the local LLVM shared library was missing.