### PR TITLE
feat: add unsigned divide and remainder intrinsics

### DIFF
--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -301,6 +301,11 @@ bool JeandleIntrinsicLowering::is_supported(vmIntrinsics::ID id) {
     case vmIntrinsics::_reverseBytes_s:
     case vmIntrinsics::_reverseBytes_c:
 
+    case vmIntrinsics::_divideUnsigned_i:
+    case vmIntrinsics::_divideUnsigned_l:
+    case vmIntrinsics::_remainderUnsigned_i:
+    case vmIntrinsics::_remainderUnsigned_l:
+
     // Math.{add,subtract,multiply,increment,decrement,negate}Exact:
     // UseMathExactIntrinsics and InlineMathNatives are enforced by
     // vmIntrinsics::is_disabled_by_flags(), which the caller
@@ -351,6 +356,11 @@ JeandleTrapReasonMask JeandleIntrinsicLowering::trap_throttle_mask(vmIntrinsics:
 
     case vmIntrinsics::_allocateInstance:
       return trap_reason_mask_val(Deoptimization::Reason_null_check);
+    case vmIntrinsics::_divideUnsigned_i:
+    case vmIntrinsics::_divideUnsigned_l:
+    case vmIntrinsics::_remainderUnsigned_i:
+    case vmIntrinsics::_remainderUnsigned_l:
+      return trap_reason_mask_val(Deoptimization::Reason_div0_check);
     case vmIntrinsics::_Preconditions_checkIndex:
     case vmIntrinsics::_Preconditions_checkLongIndex:
       return trap_reason_mask_val(Deoptimization::Reason_intrinsic) |
@@ -454,6 +464,12 @@ bool JeandleIntrinsicLowering::lower(vmIntrinsics::ID id, const ciMethod* target
     case vmIntrinsics::_reverseBytes_c:
     case vmIntrinsics::_reverseBytes_s:
       return lower_reverse_bytes_narrow(id);
+
+    case vmIntrinsics::_divideUnsigned_i:
+    case vmIntrinsics::_divideUnsigned_l:
+    case vmIntrinsics::_remainderUnsigned_i:
+    case vmIntrinsics::_remainderUnsigned_l:
+      return lower_unsigned_divmod(id);
 
     // Dual-path libm (JeandleUseHotspotIntrinsics selects the path)
     // TODO/FIXME: LLVM's `llvm.sin`, `llvm.cos`, etc. do **not** guarantee
@@ -1732,6 +1748,36 @@ bool JeandleIntrinsicLowering::lower_reverse_bytes_narrow(vmIntrinsics::ID id) {
   llvm::Value* result = is_char ? builder.CreateZExt(swapped, builder.getInt32Ty())
                                 : builder.CreateSExt(swapped, builder.getInt32Ty());
   _interp->_jvm->ipush(result);
+  return true;
+}
+
+// Java unsigned div/rem maps directly to LLVM udiv/urem except that division
+// by zero must deopt before operands are consumed to preserve ArithmeticException.
+bool JeandleIntrinsicLowering::lower_unsigned_divmod(vmIntrinsics::ID id) {
+  const bool is_long = id == vmIntrinsics::_divideUnsigned_l ||
+                       id == vmIntrinsics::_remainderUnsigned_l;
+  const bool is_remainder = id == vmIntrinsics::_remainderUnsigned_i ||
+                            id == vmIntrinsics::_remainderUnsigned_l;
+  // Logical peeks skip long category-2 placeholders and preserve the stack for zero_check.
+  llvm::Value* divisor = _interp->_jvm->peek_value(0).value();
+  llvm::Value* dividend = _interp->_jvm->peek_value(1).value();
+  _interp->zero_check(divisor);
+
+  llvm::IRBuilder<>& builder = _interp->_ir_builder;
+  // TODO: For long inputs, use PGO to select the divisor < 0 compare/subtract
+  // fast path only when the sign is strongly biased; a per-operation branch
+  // regresses mixed-sign workloads.
+  llvm::Value* result = is_remainder ? builder.CreateURem(dividend, divisor)
+                                      : builder.CreateUDiv(dividend, divisor);
+  if (is_long) {
+    _interp->_jvm->lpop();
+    _interp->_jvm->lpop();
+    _interp->_jvm->lpush(result);
+  } else {
+    _interp->_jvm->ipop();
+    _interp->_jvm->ipop();
+    _interp->_jvm->ipush(result);
+  }
   return true;
 }
 

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
@@ -178,6 +178,7 @@ class JeandleIntrinsicLowering : public StackObj {
   bool lower_bit_count(vmIntrinsics::ID id);
   bool lower_count_zeros(vmIntrinsics::ID id, llvm::Intrinsic::ID llvm_id);
   bool lower_reverse_bytes_narrow(vmIntrinsics::ID id);
+  bool lower_unsigned_divmod(vmIntrinsics::ID id);
   bool lower_llvm_bitcast();
   bool lower_fp_to_bits_canonical(vmIntrinsics::ID id);
   bool lower_float16_convert(vmIntrinsics::ID id);

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestUnsignedDivModIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestUnsignedDivModIntrinsic.java
@@ -108,6 +108,7 @@ public class TestUnsignedDivModIntrinsic {
                 + " \\(\\.\\.\\.\\) @llvm\\.experimental\\.deoptimize\\." + width
                 + "\\(i32 -122\\) \\[ \\\"deopt\\\"\\(.*";
         if (type == long.class) {
+            // Category-2 placeholder slots are serialized as i32 T_ILLEGAL values.
             deopt += "i64 8589934691, i32 0, i64 12884901987, i32 0, "
                     + "i64 65547, i64 %0, i64 8590000139, i64 %1,";
         } else {

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestUnsignedDivModIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestUnsignedDivModIntrinsic.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/*
+ * @test
+ * @key randomness
+ * @summary Test Jeandle lowering of Integer/Long unsigned divide and remainder
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @library /test/lib /
+ * @run main/othervm compiler.jeandle.intrinsic.TestUnsignedDivModIntrinsic
+ */
+
+package compiler.jeandle.intrinsic;
+
+import compiler.jeandle.fileCheck.FileCheck;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestUnsignedDivModIntrinsic {
+    private static final String[] LOGS = {
+            "Method `static jint java.lang.Integer.divideUnsigned(jint, jint)` is parsed as intrinsic",
+            "Method `static jint java.lang.Integer.remainderUnsigned(jint, jint)` is parsed as intrinsic",
+            "Method `static jlong java.lang.Long.divideUnsigned(jlong, jlong)` is parsed as intrinsic",
+            "Method `static jlong java.lang.Long.remainderUnsigned(jlong, jlong)` is parsed as intrinsic"
+    };
+
+    private static final String DISABLE = String.join(",",
+            "-_divideUnsigned_i", "-_divideUnsigned_l",
+            "-_remainderUnsigned_i", "-_remainderUnsigned_l");
+
+    public static void main(String[] args) throws Exception {
+        String enabledDump = Files.createTempDirectory("jeandle_unsigned_divmod_enabled").toString();
+        OutputAnalyzer enabled = runChild(enabledDump, true);
+        enabled.shouldHaveExitValue(0);
+        for (String log : LOGS) {
+            enabled.shouldContain(log);
+        }
+
+        checkEnabledIR(enabledDump, "divideInt", int.class, "udiv", "i32");
+        checkEnabledIR(enabledDump, "remainderInt", int.class, "urem", "i32");
+        checkEnabledIR(enabledDump, "divideLong", long.class, "udiv", "i64");
+        checkEnabledIR(enabledDump, "remainderLong", long.class, "urem", "i64");
+
+        String disabledDump = Files.createTempDirectory("jeandle_unsigned_divmod_disabled").toString();
+        OutputAnalyzer disabled = runChild(disabledDump, false);
+        disabled.shouldHaveExitValue(0);
+        for (String log : LOGS) {
+            disabled.shouldNotContain(log);
+        }
+
+        checkDisabledIR(disabledDump, "divideInt", int.class, "udiv", "i32");
+        checkDisabledIR(disabledDump, "remainderInt", int.class, "urem", "i32");
+        checkDisabledIR(disabledDump, "divideLong", long.class, "udiv", "i64");
+        checkDisabledIR(disabledDump, "remainderLong", long.class, "urem", "i64");
+    }
+
+    private static OutputAnalyzer runChild(String dumpPath, boolean enabled) throws Exception {
+        ArrayList<String> command = new ArrayList<>(List.of(
+                "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
+                "-XX:+UnlockDiagnosticVMOptions", "-Xlog:jeandle=debug",
+                "-XX:+JeandleDumpIR", "-XX:+JeandleDumpObjects",
+                "-XX:JeandleDumpDirectory=" + dumpPath,
+                "-XX:CompileCommand=compileonly," + Workload.class.getName() + "::divideInt",
+                "-XX:CompileCommand=compileonly," + Workload.class.getName() + "::remainderInt",
+                "-XX:CompileCommand=compileonly," + Workload.class.getName() + "::divideLong",
+                "-XX:CompileCommand=compileonly," + Workload.class.getName() + "::remainderLong"));
+        if (!enabled) {
+            command.add("-XX:ControlIntrinsic=" + DISABLE);
+        }
+        command.add(Workload.class.getName());
+        return ProcessTools.executeCommand(ProcessTools.createLimitedTestJavaProcessBuilder(command));
+    }
+
+    private static void checkEnabledIR(String dumpPath, String methodName, Class<?> type,
+                                       String operation, String width) throws Exception {
+        FileCheck check = new FileCheck(dumpPath,
+                Workload.class.getMethod(methodName, type, type), false);
+        check.checkPattern("%[0-9]+ = icmp eq " + width + " %1, 0");
+        check.checkNextPattern("br i1 %[0-9]+, label %bci_.*_zero_check_fail, "
+                + "label %bci_.*_zero_check_pass");
+        check.checkNextPattern("bci_.*_zero_check_pass:");
+        check.checkNextPattern("%[0-9]+ = " + operation + " " + width + " %0, %1");
+        check.checkPattern("bci_.*_zero_check_fail:");
+        String deopt = "%[0-9]+ = call hotspotcc " + width
+                + " \\(\\.\\.\\.\\) @llvm\\.experimental\\.deoptimize\\." + width
+                + "\\(i32 -122\\) \\[ \\\"deopt\\\"\\(.*";
+        if (type == long.class) {
+            deopt += "i64 8589934691, i32 0, i64 12884901987, i32 0, "
+                    + "i64 65547, i64 %0, i64 8590000139, i64 %1,";
+        } else {
+            deopt += "i64 65546, i32 %0, i64 4295032842, i32 %1,";
+        }
+        check.checkNextPattern(deopt);
+    }
+
+    private static void checkDisabledIR(String dumpPath, String methodName, Class<?> type,
+                                        String operation, String width) throws Exception {
+        FileCheck check = new FileCheck(dumpPath,
+                Workload.class.getMethod(methodName, type, type), false);
+        check.checkNotPattern(operation + " " + width);
+        check.checkNotPattern("llvm\\.experimental\\.deoptimize\\." + width);
+    }
+
+    public static class Workload {
+        private static final BigInteger MASK_64 = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+        private static final int[] INT_VALUES = {
+                0, 1, -1, Integer.MIN_VALUE, Integer.MAX_VALUE,
+                0x80000001, 0x7ffffffe, 0x55555555, 0xaaaaaaaa
+        };
+        private static final long[] LONG_VALUES = {
+                0L, 1L, -1L, Long.MIN_VALUE, Long.MAX_VALUE,
+                0x8000000000000001L, 0x7ffffffffffffffeL,
+                0x5555555555555555L, 0xaaaaaaaaaaaaaaaaL
+        };
+
+        static final int INT_DUMMY = Integer.divideUnsigned(1, 1);
+        static final long LONG_DUMMY = Long.remainderUnsigned(1L, 1L);
+
+        public static void main(String[] args) {
+            checkBoundaries();
+            checkRandomValues();
+            checkDivisionByZero();
+            Asserts.assertEquals(divideInt(-1, 3), refDivideInt(-1, 3));
+            Asserts.assertEquals(remainderLong(-1L, 7L), refRemainderLong(-1L, 7L));
+        }
+
+        private static void checkBoundaries() {
+            for (int dividend : INT_VALUES) {
+                for (int divisor : INT_VALUES) {
+                    if (divisor != 0) {
+                        checkInt(dividend, divisor);
+                    }
+                }
+            }
+            for (long dividend : LONG_VALUES) {
+                for (long divisor : LONG_VALUES) {
+                    if (divisor != 0) {
+                        checkLong(dividend, divisor);
+                    }
+                }
+            }
+        }
+
+        private static void checkRandomValues() {
+            Random random = Utils.getRandomInstance();
+            for (int i = 0; i < 1_000; i++) {
+                int intDivisor = random.nextInt();
+                if (intDivisor == 0) {
+                    intDivisor = 1;
+                }
+                checkInt(random.nextInt(), intDivisor);
+
+                long longDivisor = random.nextLong();
+                if (longDivisor == 0) {
+                    longDivisor = 1;
+                }
+                checkLong(random.nextLong(), longDivisor);
+            }
+        }
+
+        private static void checkDivisionByZero() {
+            expectArithmetic(() -> divideInt(1, 0));
+            expectArithmetic(() -> remainderInt(1, 0));
+            expectArithmetic(() -> divideLong(1L, 0L));
+            expectArithmetic(() -> remainderLong(1L, 0L));
+        }
+
+        private static void checkInt(int dividend, int divisor) {
+            Asserts.assertEquals(divideInt(dividend, divisor), refDivideInt(dividend, divisor));
+            Asserts.assertEquals(remainderInt(dividend, divisor), refRemainderInt(dividend, divisor));
+        }
+
+        private static void checkLong(long dividend, long divisor) {
+            Asserts.assertEquals(divideLong(dividend, divisor), refDivideLong(dividend, divisor));
+            Asserts.assertEquals(remainderLong(dividend, divisor), refRemainderLong(dividend, divisor));
+        }
+
+        private static int refDivideInt(int dividend, int divisor) {
+            return (int) (Integer.toUnsignedLong(dividend) / Integer.toUnsignedLong(divisor));
+        }
+
+        private static int refRemainderInt(int dividend, int divisor) {
+            return (int) (Integer.toUnsignedLong(dividend) % Integer.toUnsignedLong(divisor));
+        }
+
+        private static long refDivideLong(long dividend, long divisor) {
+            return unsigned(dividend).divide(unsigned(divisor)).longValue();
+        }
+
+        private static long refRemainderLong(long dividend, long divisor) {
+            return unsigned(dividend).remainder(unsigned(divisor)).longValue();
+        }
+
+        private static BigInteger unsigned(long value) {
+            return BigInteger.valueOf(value).and(MASK_64);
+        }
+
+        private static void expectArithmetic(Runnable action) {
+            try {
+                action.run();
+                Asserts.fail("expected ArithmeticException");
+            } catch (ArithmeticException expected) {
+                // Expected.
+            }
+        }
+
+        public static int divideInt(int dividend, int divisor) {
+            return Integer.divideUnsigned(dividend, divisor);
+        }
+
+        public static int remainderInt(int dividend, int divisor) {
+            return Integer.remainderUnsigned(dividend, divisor);
+        }
+
+        public static long divideLong(long dividend, long divisor) {
+            return Long.divideUnsigned(dividend, divisor);
+        }
+
+        public static long remainderLong(long dividend, long divisor) {
+            return Long.remainderUnsigned(dividend, divisor);
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/UnsignedDivModIntrinsics.java
+++ b/test/micro/org/openjdk/bench/java/lang/UnsignedDivModIntrinsics.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.openjdk.bench.java.lang;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+public class UnsignedDivModIntrinsics {
+    private static final int OPERATIONS = 16;
+
+    @Param({"small", "high"})
+    public String divisorKind;
+
+    private int intSeed;
+    private int intDivisor;
+    private long longSeed;
+    private long longDivisor;
+
+    @Setup
+    public void setup() {
+        intSeed = 0x89abcdef;
+        longSeed = 0x89abcdef01234567L;
+        if (divisorKind.equals("small")) {
+            intDivisor = 3;
+            longDivisor = 3L;
+        } else {
+            intDivisor = -3;
+            longDivisor = -3L;
+        }
+    }
+
+    // Keep a loop-free dependency chain so every invocation has the same 16 operations.
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(OPERATIONS)
+    public int divideUnsignedInt() {
+        int salt = intSeed += 0x9e3779b9;
+        int value = salt;
+        int divisor = intDivisor;
+        value = Integer.divideUnsigned((value + salt) ^ 0x9e3779b9, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0x7f4a7c15, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0x94d049bb, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0x2545f491, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0x369dea0f, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0x85ebca6b, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0xc2b2ae35, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0x27d4eb2f, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0x165667b1, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0xd3a2646c, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0xfd7046c5, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0xb55a4f09, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0x1b873593, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0xcc9e2d51, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0xe6546b64, divisor);
+        value = Integer.divideUnsigned((value + salt) ^ 0x9e3779b1, divisor);
+        return value;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(OPERATIONS)
+    public int remainderUnsignedInt() {
+        int salt = intSeed += 0x9e3779b9;
+        int value = salt;
+        int divisor = intDivisor;
+        value = Integer.remainderUnsigned((value + salt) ^ 0x9e3779b9, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0x7f4a7c15, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0x94d049bb, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0x2545f491, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0x369dea0f, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0x85ebca6b, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0xc2b2ae35, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0x27d4eb2f, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0x165667b1, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0xd3a2646c, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0xfd7046c5, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0xb55a4f09, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0x1b873593, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0xcc9e2d51, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0xe6546b64, divisor);
+        value = Integer.remainderUnsigned((value + salt) ^ 0x9e3779b1, divisor);
+        return value;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(OPERATIONS)
+    public long divideUnsignedLong() {
+        long salt = longSeed += 0x9e3779b97f4a7c15L;
+        long value = salt;
+        long divisor = longDivisor;
+        value = Long.divideUnsigned((value + salt) ^ 0x9e3779b97f4a7c15L, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0xbf58476d1ce4e5b9L, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0x94d049bb133111ebL, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0xd6e8feb86659fd93L, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0xa0761d6478bd642fL, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0xe7037ed1a0b428dbL, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0x8ebc6af09c88c6e3L, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0x589965cc75374cc3L, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0x1d8e4e27c47d124fL, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0xeb44accab455d165L, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0xc6bc279692b5c323L, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0xd3833e804f4c574bL, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0x9e6c63d0676a9a99L, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0x9e3779b185ebca87L, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0xc2b2ae3d27d4eb4fL, divisor);
+        value = Long.divideUnsigned((value + salt) ^ 0x165667b19e3779f9L, divisor);
+        return value;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(OPERATIONS)
+    public long remainderUnsignedLong() {
+        long salt = longSeed += 0x9e3779b97f4a7c15L;
+        long value = salt;
+        long divisor = longDivisor;
+        value = Long.remainderUnsigned((value + salt) ^ 0x9e3779b97f4a7c15L, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0xbf58476d1ce4e5b9L, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0x94d049bb133111ebL, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0xd6e8feb86659fd93L, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0xa0761d6478bd642fL, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0xe7037ed1a0b428dbL, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0x8ebc6af09c88c6e3L, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0x589965cc75374cc3L, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0x1d8e4e27c47d124fL, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0xeb44accab455d165L, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0xc6bc279692b5c323L, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0xd3833e804f4c574bL, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0x9e6c63d0676a9a99L, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0x9e3779b185ebca87L, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0xc2b2ae3d27d4eb4fL, divisor);
+        value = Long.remainderUnsigned((value + salt) ^ 0x165667b19e3779f9L, divisor);
+        return value;
+    }
+}


### PR DESCRIPTION
### Problem

Jeandle does not currently lower `Integer/Long.divideUnsigned` or `remainderUnsigned` as intrinsics. These calls fall back to their Java implementations, where the `Long` algorithms introduce additional arithmetic and control flow and rely on later inlining and optimization to recover efficient machine code.

### Approach

- Add intrinsic admission and lowering dispatch for `_divideUnsigned_i/l` and `_remainderUnsigned_i/l`.
- Perform the divide-by-zero check before consuming the JVM operand stack, preserving the original dividend and divisor in the deoptimization state while maintaining `ArithmeticException` semantics.
- Lower int and long operations to LLVM `udiv`/`urem`. On AArch64, these select `udiv` for division and `udiv + msub` for remainder.
- Preserve the Java fallback and add enabled/disabled semantic, IR, and divide-by-zero coverage.
- Add loop-free JMH dependency chains with exactly 16 target operations per invocation.
- Keep a PGO TODO for the long `divisor < 0` fast path. A per-operation runtime branch is intentionally not added because it regresses mixed-sign workloads.

### Verification

- AArch64 fastdebug and release `images` builds pass.
- `TestUnsignedDivModIntrinsic.java` passes under fastdebug jtreg and with the release image, covering boundary values, randomized values, divide-by-zero exceptions, intrinsic enabled/disabled paths, and deoptimization operands.
- Release object inspection confirms a single `udiv` for int/long division and `udiv + msub` for int/long remainder.
- JMH method-level object inspection confirms that all four methods retain exactly 16 target operations; disabling the intrinsics produces zero intrinsic-lowering log entries.

Performance environment: AArch64 HiSilicon, pinned to CPU 32, performance governor, the same release JDK for every mode, JMH 1.37, 3 forks, 5 x 1 s warmup iterations, and 5 x 1 s measurement iterations. Results are in ns/op; lower is better.

| Benchmark | Divisor | Jeandle on | Jeandle off | on/off | C2 |
| --- | --- | ---: | ---: | ---: | ---: |
| divideUnsignedInt | small | 4.133 +/- 0.023 | 4.152 +/- 0.025 | -0.5% | 4.170 +/- 0.012 |
| divideUnsignedInt | high | 2.122 +/- 0.018 | 2.132 +/- 0.022 | -0.5% | 2.208 +/- 0.027 |
| remainderUnsignedInt | small | 4.214 +/- 0.025 | 4.211 +/- 0.017 | +0.1% | 4.278 +/- 0.027 |
| remainderUnsignedInt | high | 2.284 +/- 0.017 | 2.281 +/- 0.023 | +0.1% | 2.759 +/- 0.305 |
| divideUnsignedLong | small | 6.900 +/- 0.002 | 7.698 +/- 0.088 | -10.4% | 6.920 +/- 0.002 |
| divideUnsignedLong | high | 2.207 +/- 0.012 | 1.243 +/- 0.003 | +77.5% | 2.269 +/- 0.008 |
| remainderUnsignedLong | small | 7.032 +/- 0.033 | 7.416 +/- 0.052 | -5.2% | 7.058 +/- 0.046 |
| remainderUnsignedLong | high | 2.472 +/- 0.007 | 1.933 +/- 0.012 | +27.9% | 2.927 +/- 0.395 |

The four int cases are effectively neutral on average (`-0.19%`). The long small-divisor cases improve by `7.82%` on average, while the long unsigned-high-divisor cases regress by `47.28%`. Across all eight equally weighted cases, the arithmetic mean regresses by `0.95%`, so the practical impact depends on the divisor distribution. Jeandle with the intrinsics enabled improves the eight-case arithmetic mean by `3.76%` relative to C2, although the C2 high-remainder results show noticeable fork-to-fork variance.

x86_64 hardware validation was not completed in this run because the dedicated validation host timed out.
