### PR TITLE
feat: support late inlining in Jeandle

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompilation.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.cpp
@@ -407,9 +407,13 @@ llvm::Value* JeandleCompilation::find_or_insert_oop(ciObject* oop) {
   return global_oop_handle;
 }
 
-bool JeandleCompilation::over_inlining_cutoff() const {
+bool JeandleCompilation::over_inlining_cutoff(bool is_late_inline) const {
   assert(_llvm_module != nullptr, "llvm module must exist");
-  if (JeandleNodeCountInliningCutoff == 0) {
+  intx cutoff = JeandleNodeCountInliningCutoff;
+  if (is_late_inline) {
+    cutoff = cutoff * 11 / 10;
+  }
+  if (cutoff == 0) {
     return true;
   }
 
@@ -421,7 +425,7 @@ bool JeandleCompilation::over_inlining_cutoff() const {
   intx instruction_count = 0;
   for (llvm::Instruction& inst : llvm::instructions(root)) {
     (void)inst;
-    if (++instruction_count > JeandleNodeCountInliningCutoff) {
+    if (++instruction_count > cutoff) {
       return true;
     }
   }
@@ -440,6 +444,7 @@ JeandleInlineTree::JeandleInlineTree(JeandleInlineTree* caller_tree,
                                      _max_inline_level(max_inline_level),
                                      _count_inline_bcs(method == nullptr ? 0 : method->code_size_for_inlining()),
                                      _reason(JeandleInlineReason::InlineHot),
+                                     _late_inline(false),
                                      _subtrees(arena, 2, 0, nullptr) {
 }
 
@@ -451,16 +456,77 @@ static bool jeandle_is_unboxing_method(ciMethod* callee) {
   return EliminateAutoBox && callee->is_unboxing_method();
 }
 
-static bool jeandle_exceeds_desired_method_limit(ciMethod* callee, int inline_bcs) {
+static bool jeandle_reject_or_delay_desired_method_limit(ciMethod* callee,
+                                                         int inline_bcs,
+                                                         bool is_late_inline,
+                                                         bool& should_delay) {
   if (!ClipInlining || inline_bcs < DesiredMethodLimit) {
     return false;
   }
 
-  // Match C2's DesiredMethodLimit gate: an annotated @ForceInline method may
-  // cross this limit only when IncrementalInline is enabled. C2 may then delay
-  // the inline; Jeandle currently has no late inline queue, so there is no
-  // should_delay state to record here.
-  return !callee->force_inline() || !IncrementalInline;
+  if (!callee->force_inline() || !JeandleIncrementalInline) {
+    return true;
+  }
+  if (!is_late_inline) {
+    should_delay = true;
+  }
+  return false;
+}
+
+static bool jeandle_should_delay_string_inline(ciMethod* callee,
+                                               ciMethod* caller) {
+  if (!OptimizeStringConcat) {
+    return false;
+  }
+
+  ciEnv* env = ciEnv::current();
+  bool callee_is_builder =
+      callee->holder() == env->StringBuilder_klass() ||
+      callee->holder() == env->StringBuffer_klass();
+  bool caller_is_builder =
+      caller->holder() == env->StringBuilder_klass() ||
+      caller->holder() == env->StringBuffer_klass();
+  if (callee_is_builder && caller_is_builder) {
+    return false;
+  }
+
+  switch (callee->intrinsic_id()) {
+    case vmIntrinsics::_StringBuilder_void:
+    case vmIntrinsics::_StringBuilder_int:
+    case vmIntrinsics::_StringBuilder_String:
+    case vmIntrinsics::_StringBuilder_append_char:
+    case vmIntrinsics::_StringBuilder_append_int:
+    case vmIntrinsics::_StringBuilder_append_String:
+    case vmIntrinsics::_StringBuilder_toString:
+    case vmIntrinsics::_StringBuffer_void:
+    case vmIntrinsics::_StringBuffer_int:
+    case vmIntrinsics::_StringBuffer_String:
+    case vmIntrinsics::_StringBuffer_append_char:
+    case vmIntrinsics::_StringBuffer_append_int:
+    case vmIntrinsics::_StringBuffer_append_String:
+    case vmIntrinsics::_StringBuffer_toString:
+    case vmIntrinsics::_Integer_toString:
+    case vmIntrinsics::_String_String:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool jeandle_should_delay_special_inline(ciMethod* callee,
+                                                ciMethod* caller) {
+  if (IncrementalInlineMH && callee->is_method_handle_intrinsic()) {
+    return true;
+  }
+  if (EliminateAutoBox && AggressiveUnboxing && callee->is_boxing_method()) {
+    return true;
+  }
+  if (EnableVectorSupport &&
+      (callee->is_vector_method() ||
+       callee->intrinsic_id() == vmIntrinsics::_VectorRebox)) {
+    return true;
+  }
+  return jeandle_should_delay_string_inline(callee, caller);
 }
 
 static bool jeandle_is_init_with_ea(ciMethod* callee,
@@ -610,6 +676,7 @@ bool JeandleInlineTree::should_inline(JeandleCompilation* comp,
                                       ciMethod* caller,
                                       int caller_bci,
                                       bool& forced_inline,
+                                      bool& should_delay,
                                       ciCallProfile& profile,
                                       JeandleInlineReason& reason) {
   if (CompilerOracle::should_inline(jeandle_method_handle(callee))) {
@@ -623,16 +690,12 @@ bool JeandleInlineTree::should_inline(JeandleCompilation* comp,
     return true;
   }
 
-  bool should_delay = false;
   int replay_inline_depth = inline_depth() + 1;
   if (ciReplay::should_inline(comp->replay_inline_data(),
                               callee,
                               caller_bci,
                               replay_inline_depth,
                               should_delay)) {
-    // TODO: Replay records can mark an inline as late/incremental. Jeandle has
-    // no late inline queue yet, so replay-forced inlines are performed
-    // immediately even when should_delay is true.
     forced_inline = true;
     reason = should_delay ? JeandleInlineReason::ForceIncrementalInlineByCiReplay :
                             JeandleInlineReason::ForceInlineByCiReplay;
@@ -675,6 +738,7 @@ bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,
                                           ciMethod* callee,
                                           ciMethod* caller,
                                           int caller_bci,
+                                          bool& should_delay,
                                           ciCallProfile& profile,
                                           JeandleInlineReason& reason) {
   if (callee->is_abstract()) {
@@ -717,15 +781,12 @@ bool JeandleInlineTree::should_not_inline(JeandleCompilation* comp,
     return true;
   }
 
-  bool should_delay = false;
   int replay_inline_depth = inline_depth() + 1;
   if (ciReplay::should_inline(comp->replay_inline_data(),
                               callee,
                               caller_bci,
                               replay_inline_depth,
                               should_delay)) {
-    // TODO: Jeandle currently ignores replay late-inline timing and treats this
-    // as an immediate replay-forced inline.
     reason = should_delay ? JeandleInlineReason::ForceIncrementalInlineByCiReplay :
                             JeandleInlineReason::ForceInlineByCiReplay;
     return false;
@@ -825,19 +886,34 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
                                       ciMethod* callee,
                                       ciMethod* caller,
                                       int caller_bci,
+                                      bool is_late_inline,
+                                      bool& should_delay,
                                       ciCallProfile& profile,
                                       JeandleInlineReason& reason) {
   bool forced_inline = false;
-  if (jeandle_exceeds_desired_method_limit(callee, (int)count_inline_bcs())) {
+  if (jeandle_reject_or_delay_desired_method_limit(
+          callee, (int)count_inline_bcs(), is_late_inline, should_delay)) {
     reason = JeandleInlineReason::SizeGreaterThanDesiredMethodLimit;
     return false;
   }
 
-  if (!should_inline(comp, callee, caller, caller_bci, forced_inline, profile, reason)) {
+  if (!should_inline(comp, callee, caller, caller_bci, forced_inline,
+                     should_delay, profile, reason)) {
     return false;
   }
-  if (should_not_inline(comp, callee, caller, caller_bci, profile, reason)) {
+  if (should_not_inline(comp, callee, caller, caller_bci, should_delay,
+                        profile, reason)) {
     return false;
+  }
+  if (is_late_inline) {
+    // A call whose late-inline marker survived a pre-late boundary must either
+    // inline now or be rejected. Unmarked calls newly exposed during the late
+    // phase use is_late_inline=false and may be delayed to the next round.
+    should_delay = false;
+  }
+
+  if (!is_late_inline && jeandle_should_delay_special_inline(callee, caller)) {
+    should_delay = true;
   }
 
   if (InlineAccessors && callee->is_accessor()) {
@@ -846,14 +922,6 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
   }
 
   if (callee->code_size() > MaxTrivialSize) {
-    // Match C2's parse-time node budget check with an LLVM IR instruction
-    // budget for the root Java method. Jeandle has no late inline queue yet,
-    // so non-forced inline candidates are rejected instead of delayed.
-    if (comp->over_inlining_cutoff() &&
-        (!callee->force_inline() || !IncrementalInline)) {
-      reason = JeandleInlineReason::NodeCountInliningCutoff;
-      return false;
-    }
     if (!forced_inline &&
         !(!UseInterpreter && jeandle_is_init_with_ea(callee, caller, comp->method())) &&
         is_not_reached(callee, caller, caller_bci, profile)) {
@@ -874,12 +942,13 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
     return false;
   }
   if (inline_depth() > max_inline_level()) {
-    if (!callee->force_inline() || !IncrementalInline) {
+    if (!callee->force_inline() || !JeandleIncrementalInline) {
       reason = JeandleInlineReason::InliningTooDeep;
       return false;
     }
-    // TODO: C2 delays this inline when not already in incremental inlining.
-    // Jeandle currently has no late inline queue, so forced inline continues.
+    if (!is_late_inline) {
+      should_delay = true;
+    }
   }
 
   int recursive_inline_level = 0;
@@ -897,21 +966,36 @@ bool JeandleInlineTree::try_to_inline(JeandleCompilation* comp,
   // map, so recursion is counted conservatively by method identity.
 
   int size = callee->code_size_for_inlining();
-  if (jeandle_exceeds_desired_method_limit(callee, (int)count_inline_bcs() + size)) {
+  if (jeandle_reject_or_delay_desired_method_limit(
+          callee, (int)count_inline_bcs() + size, is_late_inline,
+          should_delay)) {
     reason = JeandleInlineReason::SizeGreaterThanDesiredMethodLimit;
     return false;
   }
 
+  assert(!is_late_inline || !should_delay,
+         "a late inline decision must not be delayed again");
   return true;
 }
 
 bool JeandleInlineTree::ok_to_inline(JeandleCompilation* comp,
                                      ciMethod* callee,
                                      int caller_bci,
+                                     bool is_late_inline,
+                                     bool& should_delay,
+                                     bool& hit_node_count_cutoff,
                                      JeandleInlineReason& reason) {
   ciMethod* caller = method();
   assert(caller != nullptr, "caller method must exist");
   reason = JeandleInlineReason::InlineHot;
+  should_delay = false;
+  hit_node_count_cutoff = false;
+
+  if (comp->over_inlining_cutoff(is_late_inline)) {
+    reason = JeandleInlineReason::NodeCountInliningCutoff;
+    hit_node_count_cutoff = true;
+    return false;
+  }
 
   // Jeandle gets here only after LLVM has selected a monomorphic Java call
   // site. CHA/PGO monomorphization is represented in IR before this policy;
@@ -929,7 +1013,8 @@ bool JeandleInlineTree::ok_to_inline(JeandleCompilation* comp,
   }
 
   ciCallProfile profile = caller->call_profile_at_bci(caller_bci);
-  return try_to_inline(comp, callee, caller, caller_bci, profile, reason);
+  return try_to_inline(comp, callee, caller, caller_bci, is_late_inline,
+                       should_delay, profile, reason);
 }
 
 JeandleInlineTree* JeandleInlineTree::callee_at(int caller_bci, ciMethod* callee) const {
@@ -984,9 +1069,7 @@ int JeandleInlineTree::count() const {
 void JeandleInlineTree::dump_replay_data(outputStream* out, int depth_adjust) const {
   // Keep the replay inline record format identical to C2:
   //   <inline_depth> <caller_bci> <inline_late> <method>
-  // Jeandle currently lets LLVM perform inlining immediately, so there is no
-  // late inline queue equivalent to C2's late inlining CallGenerator.
-  const int inline_late = 0;
+  const int inline_late = is_late_inline() ? 1 : 0;
   out->print(" %d %d %d ", inline_depth() + depth_adjust, caller_bci(), inline_late);
   method()->dump_name_as_ascii(out);
   for (int i = 0; i < _subtrees.length(); i++) {

--- a/src/hotspot/share/jeandle/jeandleCompilation.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompilation.hpp
@@ -148,6 +148,7 @@ class JeandleInlineTree : public AnyObj {
   int _max_inline_level;
   uint _count_inline_bcs;
   JeandleInlineReason _reason;
+  bool _late_inline;
   GrowableArray<JeandleInlineTree*> _subtrees;
 
   bool pass_initial_checks(JeandleCompilation* comp,
@@ -161,12 +162,14 @@ class JeandleInlineTree : public AnyObj {
                      ciMethod* caller,
                      int caller_bci,
                      bool& forced_inline,
+                     bool& should_delay,
                      ciCallProfile& profile,
                      JeandleInlineReason& reason);
   bool should_not_inline(JeandleCompilation* comp,
                          ciMethod* callee,
                          ciMethod* caller,
                          int caller_bci,
+                         bool& should_delay,
                          ciCallProfile& profile,
                          JeandleInlineReason& reason);
   bool is_not_reached(ciMethod* callee,
@@ -177,6 +180,8 @@ class JeandleInlineTree : public AnyObj {
                      ciMethod* callee,
                      ciMethod* caller,
                      int caller_bci,
+                     bool is_late_inline,
+                     bool& should_delay,
                      ciCallProfile& profile,
                      JeandleInlineReason& reason);
 
@@ -195,11 +200,16 @@ class JeandleInlineTree : public AnyObj {
   uint count_inline_bcs() const { return _count_inline_bcs; }
   JeandleInlineReason reason() const { return _reason; }
   void set_reason(JeandleInlineReason reason) { _reason = reason; }
+  bool is_late_inline() const { return _late_inline; }
+  void set_late_inline(bool late_inline) { _late_inline = late_inline; }
   const GrowableArray<JeandleInlineTree*>& subtrees() const { return _subtrees; }
 
   bool ok_to_inline(JeandleCompilation* comp,
                     ciMethod* callee,
                     int caller_bci,
+                    bool is_late_inline,
+                    bool& should_delay,
+                    bool& hit_node_count_cutoff,
                     JeandleInlineReason& reason);
   JeandleInlineTree* callee_at(int caller_bci, ciMethod* callee) const;
   // Inline tree allocation is separated from commit so allocation happens before
@@ -302,7 +312,7 @@ class JeandleCompilation : public StackObj {
   const std::string name() { return _name; }
 
   bool is_osr_compilation() const { return _entry_bci != InvocationEntryBci; }
-  bool over_inlining_cutoff() const;
+  bool over_inlining_cutoff(bool is_late_inline) const;
   void* replay_inline_data() const { return _replay_inline_data; }
 
   void dump_inline_data(outputStream* out);

--- a/src/hotspot/share/jeandle/jeandleVMCallback.cpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.cpp
@@ -543,25 +543,41 @@ int JeandleVMCallback::get_java_mirror(uintptr_t klass_ptr) {
 // Inlining
 // ---------------------------------------------------------------------------
 
-bool JeandleVMCallback::is_ok_to_inline(int scope_id, int bci, uintptr_t callee_method) {
+int JeandleVMCallback::get_inline_decision(int scope_id,
+                                           int bci,
+                                           uintptr_t callee_method,
+                                           bool is_late_inline) {
+  using llvm::jeandle::JeandleInlineDecision;
+
   JeandleCompilation* comp = JeandleCompilation::current();
   assert(comp != nullptr, "Must be called in compile thread");
   JeandleInlineTree* caller_tree = comp->inline_tree_for_scope(scope_id);
   assert(caller_tree != nullptr, "caller inline tree must exist");
   ciMethod* callee = callback_method(callee_method);
   if (caller_tree->callee_at(bci, callee) != nullptr) {
-    return true;
+    return static_cast<int>(JeandleInlineDecision::InlineNow);
   }
+
   JeandleInlineReason reason = JeandleInlineReason::InlineHot;
-  if (!caller_tree->ok_to_inline(comp, callee, bci, reason)) {
+  bool should_delay = false;
+  bool hit_node_count_cutoff = false;
+  if (!caller_tree->ok_to_inline(comp, callee, bci, is_late_inline,
+                                 should_delay, hit_node_count_cutoff, reason)) {
     comp->record_inline_failure(scope_id, bci, callee, reason);
-    return false;
+    return static_cast<int>(hit_node_count_cutoff
+                                ? JeandleInlineDecision::HitNodeCountCutoff
+                                : JeandleInlineDecision::Deny);
   }
+  assert(!is_late_inline || !should_delay,
+         "a late inline decision must not be delayed again");
 
   JeandleInlineTree* callee_tree = comp->prepare_inline_tree_for_callee(scope_id, bci, callee);
   assert(callee_tree != nullptr, "callee inline tree must be prepared before LLVM inline");
   callee_tree->set_reason(reason);
-  return true;
+  callee_tree->set_late_inline(is_late_inline || should_delay);
+  return static_cast<int>(should_delay
+                              ? JeandleInlineDecision::InlineLater
+                              : JeandleInlineDecision::InlineNow);
 }
 
 bool JeandleVMCallback::record_inline_result(int scope_id, int bci, uintptr_t callee_method, int result) {
@@ -572,8 +588,9 @@ bool JeandleVMCallback::record_inline_result(int scope_id, int bci, uintptr_t ca
   llvm::jeandle::JeandleInlineReason llvm_reason =
       static_cast<llvm::jeandle::JeandleInlineReason>(result);
   if (llvm_reason == llvm::jeandle::JeandleInlineReason::InlineSuccess) {
-    // IsOkToInline has already prepared this tree, so a successful result only
-    // commits metadata in the same successful-inline order as LLVM's InlineScopes.
+    // GetInlineDecision has already prepared this tree, so a successful result
+    // only commits metadata in the same successful-inline order as LLVM's
+    // InlineScopes.
     comp->commit_inline_tree_for_callee(scope_id, bci, callee);
   } else {
     comp->record_inline_failure(scope_id,
@@ -1028,7 +1045,7 @@ void JeandleVMCallback::register_callbacks() {
   callbacks.GetJavaMirror = &JeandleVMCallback::get_java_mirror;
   callbacks.GetInlineCalleeIR = &JeandleVMCallback::get_inline_callee_ir;
   callbacks.GetNewStatepointID = &JeandleVMCallback::get_new_statepoint_id;
-  callbacks.IsOkToInline = &JeandleVMCallback::is_ok_to_inline;
+  callbacks.GetInlineDecision = &JeandleVMCallback::get_inline_decision;
   callbacks.RecordInlineResult = &JeandleVMCallback::record_inline_result;
   callbacks.RecordInliningComplete = &JeandleVMCallback::record_inlining_complete;
   callbacks.GetCHAOptInfo = &JeandleVMCallback::get_cha_opt_info;

--- a/src/hotspot/share/jeandle/jeandleVMCallback.hpp
+++ b/src/hotspot/share/jeandle/jeandleVMCallback.hpp
@@ -82,7 +82,9 @@ class JeandleVMCallback : public AllStatic {
   // Inlining.
   static bool      get_inline_callee_ir(uintptr_t callee_method);
   static int64_t   get_new_statepoint_id(int64_t old_statepoint_id);
-  static bool      is_ok_to_inline(int scope_id, int bci, uintptr_t callee_method);
+  static int       get_inline_decision(int scope_id, int bci,
+                                       uintptr_t callee_method,
+                                       bool is_late_inline);
   static bool      record_inline_result(int scope_id, int bci, uintptr_t callee_method, int result);
   static bool      record_inlining_complete();
 

--- a/src/hotspot/share/jeandle/jeandle_globals.hpp
+++ b/src/hotspot/share/jeandle/jeandle_globals.hpp
@@ -67,6 +67,10 @@
           "Use receiver type profile to devirtualize "                      \
           "invokevirtual/invokeinterface calls in Jeandle")                 \
                                                                             \
+  product(bool, JeandleIncrementalInline, true,                             \
+          "Delay @ForceInline methods that exceed normal depth or "         \
+          "bytecode-size limits for post-parse inlining")                   \
+                                                                            \
   product(intx, JeandleNodeCountInliningCutoff, 18000,                      \
           "If root LLVM IR instruction count exceeds limit stop inlining."  \
           "This value roughly follows C2's cutoff today; tune it later"     \


### PR DESCRIPTION
## Related issue(s):

issue #605 

## What this PR does / why we need it:

Replace the boolean inline-policy callback with a decision-based
interface that distinguishes immediate, delayed, denied, and
instruction-cutoff results.

Propagate late-inline state through the Jeandle inline policy and delay
selected string, boxing, vector, replay-directed, and oversized
@ForceInline candidates during eager inlining.

Track late-inline decisions in the inline tree and replay data, and
allow late candidates additional room in the root LLVM IR instruction
budget.

Report instruction-cutoff decisions to the LLVM inline driver so it
can stop eager scheduling or transition to the late-inline phase.