### PR TITLE
feat: Implement SHA compression intrinsics in Jeandle

### DIFF
--- a/src/hotspot/share/jeandle/jeandleCompiler.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiler.cpp
@@ -39,6 +39,8 @@
 #include "runtime/arguments.hpp"
 #include "runtime/globals_extension.hpp"
 
+void compiler_stubs_init(bool in_compiler_thread);
+
 namespace {
 
 void jeandle_llvm_fatal_error_handler(void* user_data, const char* reason, bool gen_crash_diag) {
@@ -118,6 +120,10 @@ void JeandleCompiler::initialize() {
       set_state(failed);
       return;
     }
+    // Jeandle can be the only compiler in a VM configured with delayed
+    // compiler-stub generation. Generate the platform StubRoutines before
+    // registering direct runtime entries (including SHA compression stubs).
+    compiler_stubs_init(true /* in_compiler_thread */);
     if (!JeandleRuntimeRoutine::generate(target_machine(), data_layout())) {
       set_state(failed);
       return;

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -677,31 +677,26 @@ bool JeandleIntrinsicLowering::lower_digestBase_implCompress(vmIntrinsics::ID id
   const char* stub_name = nullptr;
   BasicType state_element_type = T_ILLEGAL;
   JeandleRuntimeCalleeFn callee_fn = nullptr;
-  bool enabled = false;
   switch (id) {
     case vmIntrinsics::_sha_implCompress:
-      enabled = UseSHA1Intrinsics;
       state_signature = "[I";
       state_element_type = T_INT;
       stub_name = "StubRoutines_sha1_implCompress";
       callee_fn = &JeandleRuntimeRoutine::StubRoutines_sha1_implCompress_callee;
       break;
     case vmIntrinsics::_sha2_implCompress:
-      enabled = UseSHA256Intrinsics;
       state_signature = "[I";
       state_element_type = T_INT;
       stub_name = "StubRoutines_sha256_implCompress";
       callee_fn = &JeandleRuntimeRoutine::StubRoutines_sha256_implCompress_callee;
       break;
     case vmIntrinsics::_sha5_implCompress:
-      enabled = UseSHA512Intrinsics;
       state_signature = "[J";
       state_element_type = T_LONG;
       stub_name = "StubRoutines_sha512_implCompress";
       callee_fn = &JeandleRuntimeRoutine::StubRoutines_sha512_implCompress_callee;
       break;
     case vmIntrinsics::_sha3_implCompress:
-      enabled = UseSHA3Intrinsics;
       state_signature = "[B";
       state_element_type = T_BYTE;
       stub_name = "StubRoutines_sha3_implCompress";
@@ -712,8 +707,8 @@ bool JeandleIntrinsicLowering::lower_digestBase_implCompress(vmIntrinsics::ID id
   }
 
   // StubRoutines entries are generated only on supported platforms. Never
-  // materialize a direct call when either the flag or the entry is absent.
-  if (!enabled || JeandleRuntimeRoutine::find_routine_entry(stub_name) == nullptr) {
+  // materialize a direct call when the entry is absent.
+  if (JeandleRuntimeRoutine::find_routine_entry(stub_name) == nullptr) {
     return false;
   }
 
@@ -768,10 +763,6 @@ bool JeandleIntrinsicLowering::lower_digestBase_implCompress(vmIntrinsics::ID id
   llvm::Value* state_base = builder.CreateInBoundsPtrAdd(
       state_array, builder.getInt32(arrayOopDesc::base_offset_in_bytes(state_element_type)),
       "sha_state_base");
-  llvm::Type* state_element_llvm_type =
-      JeandleType::java2llvm(state_element_type, context);
-  llvm::Value* state_start = builder.CreateInBoundsGEP(
-      state_element_llvm_type, state_base, builder.getInt32(0), "sha_state_start");
 
   _interp->_jvm->ipop();  // ofs
   _interp->_jvm->apop();  // src
@@ -781,7 +772,7 @@ bool JeandleIntrinsicLowering::lower_digestBase_implCompress(vmIntrinsics::ID id
       CTRL_NONE, MEM_READ | MEM_WRITE};
   if (block_size_field == nullptr) {
     emit_callsite(callee_fn(_interp->_module), llvm::CallingConv::C,
-                  {src_start, state_start}, attrs,
+                  {src_start, state_base}, attrs,
                   /*is_gc_leaf_entry=*/true);
   } else {
     llvm::Value* block_size_addr = _interp->compute_instance_field_address(
@@ -789,7 +780,7 @@ bool JeandleIntrinsicLowering::lower_digestBase_implCompress(vmIntrinsics::ID id
     llvm::Value* block_size = _interp->load_from_address(block_size_addr,
                                                          T_INT, false);
     emit_callsite(callee_fn(_interp->_module), llvm::CallingConv::C,
-                  {src_start, state_start, block_size}, attrs,
+                  {src_start, state_base, block_size}, attrs,
                   /*is_gc_leaf_entry=*/true);
   }
   return true;

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -34,8 +34,11 @@
 #include "jeandle/jeandleUtils.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "ci/ciField.hpp"
+#include "ci/ciInstanceKlass.hpp"
 #include "ci/ciMethod.hpp"
 #include "ci/ciSignature.hpp"
+#include "ci/ciSymbol.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/vmIntrinsics.hpp"
 #include "jeandle/jeandle_globals.hpp"
@@ -46,6 +49,8 @@
 #include "runtime/globals.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/globalDefinitions.hpp"
+
+#include <cstring>
 
 // =============================================================================
 // Call-site IR annotation helpers (migrated from JeandleIntrinsicIRSemantics)
@@ -272,6 +277,14 @@ bool JeandleIntrinsicLowering::is_supported(vmIntrinsics::ID id) {
 
     // arraycopy
     case vmIntrinsics::_arraycopy:
+      return true;
+
+    // Single-block SHA compression. Availability is checked again by the
+    // lowering because platform stubs are generated conditionally.
+    case vmIntrinsics::_sha_implCompress:
+    case vmIntrinsics::_sha2_implCompress:
+    case vmIntrinsics::_sha5_implCompress:
+    case vmIntrinsics::_sha3_implCompress:
       return true;
 
     default:
@@ -536,6 +549,12 @@ bool JeandleIntrinsicLowering::lower(vmIntrinsics::ID id, const ciMethod* target
     case vmIntrinsics::_arraycopy:
       return lower_arraycopy();
 
+    case vmIntrinsics::_sha_implCompress:
+    case vmIntrinsics::_sha2_implCompress:
+    case vmIntrinsics::_sha5_implCompress:
+    case vmIntrinsics::_sha3_implCompress:
+      return lower_digestBase_implCompress(id);
+
     default:
       return false;
   }
@@ -639,6 +658,141 @@ bool JeandleIntrinsicLowering::lower_dual_path_libm(llvm::Intrinsic::ID llvm_id,
   } else {
     return emit_llvm_builtin(llvm_id);
   }
+}
+
+// =============================================================================
+// lower_digestBase_implCompress — single-block SHA compression
+// =============================================================================
+
+bool JeandleIntrinsicLowering::lower_digestBase_implCompress(vmIntrinsics::ID id) {
+  ciSignature* sig = _target->signature();
+  if (sig->count() != 2 || sig->type_at(0)->basic_type() != T_ARRAY ||
+      sig->type_at(1)->basic_type() != T_INT ||
+      sig->type_at(0)->name() == nullptr ||
+      strcmp(sig->type_at(0)->name(), "[B") != 0) {
+    return false;
+  }
+
+  const char* state_signature = nullptr;
+  const char* stub_name = nullptr;
+  BasicType state_element_type = T_ILLEGAL;
+  JeandleRuntimeCalleeFn callee_fn = nullptr;
+  bool enabled = false;
+  switch (id) {
+    case vmIntrinsics::_sha_implCompress:
+      enabled = UseSHA1Intrinsics;
+      state_signature = "[I";
+      state_element_type = T_INT;
+      stub_name = "StubRoutines_sha1_implCompress";
+      callee_fn = &JeandleRuntimeRoutine::StubRoutines_sha1_implCompress_callee;
+      break;
+    case vmIntrinsics::_sha2_implCompress:
+      enabled = UseSHA256Intrinsics;
+      state_signature = "[I";
+      state_element_type = T_INT;
+      stub_name = "StubRoutines_sha256_implCompress";
+      callee_fn = &JeandleRuntimeRoutine::StubRoutines_sha256_implCompress_callee;
+      break;
+    case vmIntrinsics::_sha5_implCompress:
+      enabled = UseSHA512Intrinsics;
+      state_signature = "[J";
+      state_element_type = T_LONG;
+      stub_name = "StubRoutines_sha512_implCompress";
+      callee_fn = &JeandleRuntimeRoutine::StubRoutines_sha512_implCompress_callee;
+      break;
+    case vmIntrinsics::_sha3_implCompress:
+      enabled = UseSHA3Intrinsics;
+      state_signature = "[B";
+      state_element_type = T_BYTE;
+      stub_name = "StubRoutines_sha3_implCompress";
+      callee_fn = &JeandleRuntimeRoutine::StubRoutines_sha3_implCompress_callee;
+      break;
+    default:
+      return false;
+  }
+
+  // StubRoutines entries are generated only on supported platforms. Never
+  // materialize a direct call when either the flag or the entry is absent.
+  if (!enabled || JeandleRuntimeRoutine::find_routine_entry(stub_name) == nullptr) {
+    return false;
+  }
+
+  ciInstanceKlass* holder = _target->holder();
+  ciField* state_field = holder->get_field_by_name(ciSymbol::make("state"),
+                                                   ciSymbol::make(state_signature),
+                                                   false);
+  if (state_field == nullptr) {
+    return false;
+  }
+
+  ciField* block_size_field = nullptr;
+  if (id == vmIntrinsics::_sha3_implCompress) {
+    block_size_field = holder->get_field_by_name(ciSymbol::make("blockSize"),
+                                                 ciSymbol::make("I"), false);
+    if (block_size_field == nullptr) {
+      return false;
+    }
+  }
+
+  // The intrinsic is entered with receiver, byte[] and offset on the JVM
+  // stack. Peek until all optional checks and field lookups have succeeded so
+  // a false return leaves the stack untouched for the normal invoke path.
+  llvm::Value* receiver = _interp->_jvm->raw_peek(2).value();
+  llvm::Value* src = _interp->_jvm->raw_peek(1).value();
+  llvm::Value* ofs = _interp->_jvm->raw_peek(0).value();
+  _interp->null_check(src);
+
+  llvm::IRBuilder<>& builder = _interp->_ir_builder;
+  llvm::LLVMContext& context = *_interp->_context;
+  llvm::Type* java_oop_type = JeandleType::java2llvm(T_OBJECT, context);
+
+  llvm::Value* src_offset = builder.CreateAdd(
+      builder.getInt32(arrayOopDesc::base_offset_in_bytes(T_BYTE)), ofs,
+      "sha_src_offset");
+  llvm::Value* src_start = builder.CreateInBoundsPtrAdd(src, src_offset,
+                                                        "sha_src_start");
+
+  llvm::Value* state_field_addr = _interp->compute_instance_field_address(
+      receiver, state_field->offset_in_bytes());
+  BasicType state_ref_type = state_field->layout_type();
+  if (UseCompressedOops && is_reference_type(state_ref_type)) {
+    state_ref_type = T_NARROWOOP;
+  }
+  llvm::Value* state_array = _interp->load_from_address(state_field_addr,
+                                                        state_ref_type, false);
+  if (state_ref_type == T_NARROWOOP) {
+    state_array = builder.CreateAddrSpaceCast(state_array, java_oop_type,
+                                              "sha_state_array");
+  }
+
+  llvm::Value* state_base = builder.CreateInBoundsPtrAdd(
+      state_array, builder.getInt32(arrayOopDesc::base_offset_in_bytes(state_element_type)),
+      "sha_state_base");
+  llvm::Type* state_element_llvm_type =
+      JeandleType::java2llvm(state_element_type, context);
+  llvm::Value* state_start = builder.CreateInBoundsGEP(
+      state_element_llvm_type, state_base, builder.getInt32(0), "sha_state_start");
+
+  _interp->_jvm->ipop();  // ofs
+  _interp->_jvm->apop();  // src
+  _interp->_jvm->apop();  // receiver
+
+  static constexpr CallSiteAttributeMetadata attrs = {
+      CTRL_NONE, MEM_READ | MEM_WRITE};
+  if (block_size_field == nullptr) {
+    emit_callsite(callee_fn(_interp->_module), llvm::CallingConv::C,
+                  {src_start, state_start}, attrs,
+                  /*is_gc_leaf_entry=*/true);
+  } else {
+    llvm::Value* block_size_addr = _interp->compute_instance_field_address(
+        receiver, block_size_field->offset_in_bytes());
+    llvm::Value* block_size = _interp->load_from_address(block_size_addr,
+                                                         T_INT, false);
+    emit_callsite(callee_fn(_interp->_module), llvm::CallingConv::C,
+                  {src_start, state_start, block_size}, attrs,
+                  /*is_gc_leaf_entry=*/true);
+  }
+  return true;
 }
 
 // =============================================================================

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
@@ -193,6 +193,7 @@ class JeandleIntrinsicLowering : public StackObj {
   bool lower_divide_unsigned(vmIntrinsics::ID id);
   bool lower_remainder_unsigned(vmIntrinsics::ID id);
   bool lower_multiply_high(vmIntrinsics::ID id);
+  bool lower_digestBase_implCompress(vmIntrinsics::ID id);
   bool lower_new_array();
   bool lower_unsafe_allocate_instance();
   bool lower_vectorized_mismatch();

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -298,6 +298,39 @@
       llvm::Type::getInt32Ty(context),                                              \
       llvm::Type::getInt32Ty(context))                                              \
                                                                                     \
+  def(StubRoutines_sha1_implCompress,                                               \
+      StubRoutines::sha1_implCompress(),                                            \
+      true,                                                                         \
+      true,                                                                         \
+      llvm::Type::getVoidTy(context),                                               \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace)) \
+                                                                                    \
+  def(StubRoutines_sha256_implCompress,                                             \
+      StubRoutines::sha256_implCompress(),                                          \
+      true,                                                                         \
+      true,                                                                         \
+      llvm::Type::getVoidTy(context),                                               \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace)) \
+                                                                                    \
+  def(StubRoutines_sha512_implCompress,                                             \
+      StubRoutines::sha512_implCompress(),                                          \
+      true,                                                                         \
+      true,                                                                         \
+      llvm::Type::getVoidTy(context),                                               \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace)) \
+                                                                                    \
+  def(StubRoutines_sha3_implCompress,                                               \
+      StubRoutines::sha3_implCompress(),                                            \
+      true,                                                                         \
+      true,                                                                         \
+      llvm::Type::getVoidTy(context),                                               \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
+      llvm::Type::getInt32Ty(context))                                              \
+                                                                                    \
   def(SharedRuntime_OSR_migration_end,                                              \
       SharedRuntime::OSR_migration_end,                                             \
       false,                                                                        \

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java
@@ -39,9 +39,14 @@ public class TestShaCompress {
                 "-XX:+UseSHA256Intrinsics", "-XX:+UseSHA512Intrinsics",
                 "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
                 "-XX:JeandleDumpDirectory=" + dumpPath,
+                "-XX:CompileCommand=compileonly,sun/security/provider/DigestBase.implCompressMultiBlock0",
+                "-XX:CompileCommand=compileonly,sun/security/provider/SHA.implCompress0",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA.implCompress",
+                "-XX:CompileCommand=compileonly,sun/security/provider/SHA2.implCompress0",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA2.implCompress",
+                "-XX:CompileCommand=compileonly,sun/security/provider/SHA5.implCompress0",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA5.implCompress",
+                "-XX:CompileCommand=compileonly,sun/security/provider/SHA3.implCompress0",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA3.implCompress",
                 TestWrapper.class.getName()));
         if (System.getProperty("os.arch").equals("aarch64")) {

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java
@@ -18,11 +18,14 @@
 
 package compiler.jeandle.intrinsic;
 
+import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.HexFormat;
 import java.util.List;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -30,13 +33,28 @@ import jdk.test.lib.process.ProcessTools;
 
 public class TestShaCompress {
     private static final HexFormat HEX = HexFormat.of();
+    private static final String[] INTRINSIC_FLAGS = {
+            "UseSHA1Intrinsics", "UseSHA256Intrinsics",
+            "UseSHA512Intrinsics", "UseSHA3Intrinsics"
+    };
+    private static final int[] TEST_LENGTHS = {
+            1, 55, 56, 63, 64, 65, 127, 128, 255, 256
+    };
 
     public static void main(String[] args) throws Exception {
+        OutputAnalyzer reference = ProcessTools.executeCommand(
+                ProcessTools.createLimitedTestJavaProcessBuilder(
+                        "-XX:+UnlockDiagnosticVMOptions",
+                        "-XX:-UseSHA1Intrinsics", "-XX:-UseSHA256Intrinsics",
+                        "-XX:-UseSHA512Intrinsics", "-XX:-UseSHA3Intrinsics",
+                        TestWrapper.class.getName()));
+        reference.shouldHaveExitValue(0).shouldContain("TestShaCompress PASSED");
+
         Path dumpPath = Files.createTempDirectory("jeandle_sha_compress");
         List<String> commandArgs = new java.util.ArrayList<>(List.of(
                 "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
                 "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSHA1Intrinsics",
-                "-XX:+UseSHA256Intrinsics", "-XX:+UseSHA512Intrinsics",
+                "-XX:+UseSHA256Intrinsics", "-XX:+UseSHA512Intrinsics", "-XX:+UseSHA3Intrinsics",
                 "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
                 "-XX:JeandleDumpDirectory=" + dumpPath,
                 "-XX:CompileCommand=compileonly,sun/security/provider/DigestBase.implCompressMultiBlock0",
@@ -49,13 +67,15 @@ public class TestShaCompress {
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA3.implCompress0",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA3.implCompress",
                 TestWrapper.class.getName()));
-        if (System.getProperty("os.arch").equals("aarch64")) {
-            commandArgs.add("-XX:+UseSHA3Intrinsics");
-        }
 
         OutputAnalyzer output = ProcessTools.executeCommand(
                 ProcessTools.createLimitedTestJavaProcessBuilder(commandArgs));
         output.shouldHaveExitValue(0).shouldContain("TestShaCompress PASSED");
+        List<String> referenceDigests = digestLines(reference);
+        Asserts.assertEquals(7 * TEST_LENGTHS.length, referenceDigests.size(),
+                "Unexpected number of reference SHA digests");
+        Asserts.assertEquals(referenceDigests, digestLines(output),
+                "SHA digests differ from the all-intrinsics-disabled reference run");
 
         String ir = Files.walk(dumpPath)
                 .filter(Files::isRegularFile)
@@ -68,20 +88,43 @@ public class TestShaCompress {
                     }
                 })
                 .reduce("", String::concat);
-        Asserts.assertTrue(ir.contains("StubRoutines_sha1_implCompress"),
-                "SHA-1 single-block direct routine missing from Jeandle IR");
-        Asserts.assertTrue(ir.contains("StubRoutines_sha256_implCompress"),
-                "SHA-256 single-block direct routine missing from Jeandle IR");
-        Asserts.assertTrue(ir.contains("StubRoutines_sha512_implCompress"),
-                "SHA-512 single-block direct routine missing from Jeandle IR");
-        if (System.getProperty("os.arch").equals("aarch64")) {
-            Asserts.assertTrue(ir.contains("StubRoutines_sha3_implCompress"),
-                    "SHA-3 single-block direct routine missing from Jeandle IR");
-        }
+        assertRoutineMatchesFlag(output, ir, "UseSHA1Intrinsics",
+                "StubRoutines_sha1_implCompress", "SHA-1");
+        assertRoutineMatchesFlag(output, ir, "UseSHA256Intrinsics",
+                "StubRoutines_sha256_implCompress", "SHA-256");
+        assertRoutineMatchesFlag(output, ir, "UseSHA512Intrinsics",
+                "StubRoutines_sha512_implCompress", "SHA-512");
+        assertRoutineMatchesFlag(output, ir, "UseSHA3Intrinsics",
+                "StubRoutines_sha3_implCompress", "SHA-3");
+    }
+
+    private static List<String> digestLines(OutputAnalyzer output) {
+        return output.getOutput().lines()
+                .filter(line -> line.startsWith("DIGEST "))
+                .toList();
+    }
+
+    private static void assertRoutineMatchesFlag(OutputAnalyzer output, String ir,
+                                                  String flag, String routine,
+                                                  String algorithm) {
+        String prefix = "FLAG " + flag + "=";
+        String flagLine = output.getOutput().lines()
+                .filter(line -> line.startsWith(prefix))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing effective VM flag: " + flag));
+        boolean enabled = Boolean.parseBoolean(flagLine.substring(prefix.length()));
+        Asserts.assertEquals(enabled, ir.contains(routine),
+                algorithm + " direct routine presence must match effective " + flag);
     }
 
     static class TestWrapper {
         public static void main(String[] args) throws Exception {
+            HotSpotDiagnosticMXBean diagnostic = ManagementFactory.getPlatformMXBean(
+                    HotSpotDiagnosticMXBean.class);
+            for (String flag : INTRINSIC_FLAGS) {
+                System.out.println("FLAG " + flag + "=" + diagnostic.getVMOption(flag).getValue());
+            }
+
             check("SHA-1", "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                     "4fd6558b2a93925fb7129447e1d1fac8cff56287");
             check("SHA-256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -114,12 +157,13 @@ public class TestShaCompress {
             Asserts.assertEquals(vectorExpected, HEX.formatHex(actual),
                     algorithm + " boundary/non-aligned digest");
 
-            for (int length : new int[] {1, 55, 56, 63, 64, 65, 127, 128, 255, 256}) {
+            for (int length : TEST_LENGTHS) {
                 byte[] data = new byte[length + 2];
                 for (int i = 0; i < length; i++) {
                     data[i + 2] = (byte) (i * 37 + 11);
                 }
-                digest(algorithm, data, 2);
+                System.out.println("DIGEST " + algorithm + " " + length + " "
+                        + HEX.formatHex(digest(algorithm, data, 2)));
             }
         }
 

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ */
+
+/*
+ * @test
+ * @summary Test Jeandle lowering of single-block SHA compression intrinsics.
+ * @requires os.arch == "amd64" | os.arch == "x86_64" | os.arch == "aarch64"
+ * @library /test/lib /
+ * @build jdk.test.lib.Asserts
+ * @run main/othervm compiler.jeandle.intrinsic.TestShaCompress
+ */
+
+package compiler.jeandle.intrinsic;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestShaCompress {
+    private static final HexFormat HEX = HexFormat.of();
+
+    public static void main(String[] args) throws Exception {
+        Path dumpPath = Files.createTempDirectory("jeandle_sha_compress");
+        List<String> commandArgs = new java.util.ArrayList<>(List.of(
+                "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
+                "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSHA1Intrinsics",
+                "-XX:+UseSHA256Intrinsics", "-XX:+UseSHA512Intrinsics",
+                "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
+                "-XX:JeandleDumpDirectory=" + dumpPath,
+                "-XX:CompileCommand=compileonly,sun/security/provider/SHA.implCompress",
+                "-XX:CompileCommand=compileonly,sun/security/provider/SHA2.implCompress",
+                "-XX:CompileCommand=compileonly,sun/security/provider/SHA5.implCompress",
+                "-XX:CompileCommand=compileonly,sun/security/provider/SHA3.implCompress",
+                TestWrapper.class.getName()));
+        if (System.getProperty("os.arch").equals("aarch64")) {
+            commandArgs.add("-XX:+UseSHA3Intrinsics");
+        }
+
+        OutputAnalyzer output = ProcessTools.executeCommand(
+                ProcessTools.createLimitedTestJavaProcessBuilder(commandArgs));
+        output.shouldHaveExitValue(0).shouldContain("TestShaCompress PASSED");
+
+        String ir = Files.walk(dumpPath)
+                .filter(Files::isRegularFile)
+                .filter(path -> path.toString().endsWith(".ll"))
+                .map(path -> {
+                    try {
+                        return Files.readString(path);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .reduce("", String::concat);
+        Asserts.assertTrue(ir.contains("StubRoutines_sha1_implCompress"),
+                "SHA-1 single-block direct routine missing from Jeandle IR");
+        Asserts.assertTrue(ir.contains("StubRoutines_sha256_implCompress"),
+                "SHA-256 single-block direct routine missing from Jeandle IR");
+        Asserts.assertTrue(ir.contains("StubRoutines_sha512_implCompress"),
+                "SHA-512 single-block direct routine missing from Jeandle IR");
+        if (System.getProperty("os.arch").equals("aarch64")) {
+            Asserts.assertTrue(ir.contains("StubRoutines_sha3_implCompress"),
+                    "SHA-3 single-block direct routine missing from Jeandle IR");
+        }
+    }
+
+    static class TestWrapper {
+        public static void main(String[] args) throws Exception {
+            check("SHA-1", "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                    "4fd6558b2a93925fb7129447e1d1fac8cff56287");
+            check("SHA-256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                    "4f1757ae4bffbae86d775b831765b75af154d52f7deaa46dd378051a2d3ad57f");
+            check("SHA-512", "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+                    "1809db04d02717483e04bc4333a14308bd2d0213ba7bf2c63f11eb1b8a0af8252e67fd104fd466fb95f945539824d8e4183155fa5ced0bee3dad46d9384a0bd5");
+            check("SHA3-224", "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7",
+                    "f34ec2c74ce29ecef3b5ff52f89fd5adf62c840cdc2c5ccdb93523f9");
+            check("SHA3-256", "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",
+                    "fe8077efdd5ceeabbdc158395484c5d553489b9718fe4a1f28b6821c358f4aca");
+            check("SHA3-384", "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004",
+                    "a6f86672297e96e989aa3eff04b0c927be7ac2a072040ac2a9017e329cdb614b6fa7760d0f31ac970e3591d7cf4d90e3");
+            check("SHA3-512", "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",
+                    "c4148471d4c463929e5af7df25fb4f66875ddf1c473e277e0170665afef3363984e9be12b11949f87a1d00b9e9c330b0fb3f64f31496037ca153f33fc2a5f382");
+            System.out.println("TestShaCompress PASSED");
+        }
+
+        private static void check(String algorithm, String emptyExpected,
+                                  String vectorExpected) throws Exception {
+            byte[] empty = digest(algorithm, new byte[0], 0);
+            Asserts.assertEquals(emptyExpected, HEX.formatHex(empty), algorithm + " empty digest");
+
+            byte[] vector = new byte[129];
+            for (int i = 0; i < vector.length; i++) {
+                vector[i] = (byte) (i * 37 + 11);
+            }
+            byte[] padded = new byte[vector.length + 3];
+            System.arraycopy(vector, 0, padded, 3, vector.length);
+            byte[] actual = digest(algorithm, padded, 3);
+            Asserts.assertEquals(vectorExpected, HEX.formatHex(actual),
+                    algorithm + " boundary/non-aligned digest");
+
+            for (int length : new int[] {1, 55, 56, 63, 64, 65, 127, 128, 255, 256}) {
+                byte[] data = new byte[length + 2];
+                for (int i = 0; i < length; i++) {
+                    data[i + 2] = (byte) (i * 37 + 11);
+                }
+                digest(algorithm, data, 2);
+            }
+        }
+
+        private static byte[] digest(String algorithm, byte[] data, int offset) throws Exception {
+            MessageDigest md = MessageDigest.getInstance(algorithm, "SUN");
+            md.update(data, offset, data.length - offset);
+            return md.digest();
+        }
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #604

## Summary

- Implement Jeandle lowering for the four single-block SHA compression intrinsics: SHA-1, SHA-256, SHA-512, and SHA-3.
- Reuse HotSpot `StubRoutines`, with effective `UseSHA*Intrinsics` flag and non-null stub gating, correct state/block-size loads, and read/write direct-leaf metadata.
- Fall back to the normal Java invoke when the platform flag or stub is unavailable.
- Add focused semantic and Jeandle IR coverage for empty, boundary, non-aligned, cross-block, and fixed random inputs.

This change does not include the multi-block intrinsic `_digestBase_implCompressMB`.

## Test plan

- `make CONF=linux-x86_64-server-fastdebug hotspot`
- `make CONF=linux-x86_64-server-fastdebug images`
- `make CONF=linux-x86_64-server-fastdebug test TEST=hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java`
- `make CONF=linux-x86_64-server-fastdebug test TEST=hotspot/jtreg/compiler/jeandle/intrinsic`
- SHA sanity single-block and multi-block tests: 8/8
- `git diff --check origin/main...HEAD`