### PR TITLE
fix: poll only on taken conditional back-edges

### DIFF
--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -817,6 +817,8 @@ JeandleAbstractInterpreter::JeandleAbstractInterpreter(const JeandleParseContext
                                                        _block(nullptr),
                                                        _jvm(nullptr),
                                                        _pruned_successor(nullptr),
+                                                       _backedge_safepoint_successor(nullptr),
+                                                       _backedge_safepoint_block(nullptr),
                                                        _work_list(),
                                                        _sync_lock(LockValue()),
                                                        _trap_hist(trap_hist) {
@@ -1176,6 +1178,8 @@ void JeandleAbstractInterpreter::interpret_block(JeandleBasicBlock* block) {
   _block = block;
   _jvm = block->VM_state();
   _pruned_successor = nullptr;
+  _backedge_safepoint_successor = nullptr;
+  _backedge_safepoint_block = nullptr;
 
   // Skip blocks that are unreachable.
   if (_jvm == nullptr) {
@@ -1536,8 +1540,15 @@ void JeandleAbstractInterpreter::interpret_block(JeandleBasicBlock* block) {
     if (suc == _pruned_successor) {
       continue;
     }
+    llvm::BasicBlock* incoming_block = block->tail_llvm_block();
+    if (suc == _backedge_safepoint_successor) {
+      assert(_backedge_safepoint_block != nullptr, "missing back-edge safepoint block");
+      incoming_block = _backedge_safepoint_block;
+    }
+
     // Don't update handlers' VM state here. They are updated by exception throwers.
-    if (!suc->is_exception_handler() && !suc->merge_VM_state_from(block->VM_state(), block->tail_llvm_block(), _method, is_osr())) {
+    if (!suc->is_exception_handler() &&
+        !suc->merge_VM_state_from(block->VM_state(), incoming_block, _method, is_osr())) {
       JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(false, "failed to merge VM state into successor block");
     }
 
@@ -1739,6 +1750,30 @@ void JeandleAbstractInterpreter::do_if_branch(llvm::Value* cond, unsigned operan
     return;
   }
 
+  bool taken_is_backedge = _bytecodes.get_dest() <= bci;
+  auto get_taken_branch_target = [&]() -> llvm::BasicBlock* {
+    if (!taken_is_backedge) {
+      return taken_block;
+    }
+
+    assert(_backedge_safepoint_successor == nullptr &&
+           _backedge_safepoint_block == nullptr,
+           "back-edge safepoint block already created");
+    llvm::BasicBlock* branch_block = _ir_builder.GetInsertBlock();
+    llvm::BasicBlock* poll_block =
+        llvm::BasicBlock::Create(*_context,
+                                 "bci_" + std::to_string(bci) + "_backedge_safepoint",
+                                 _llvm_func);
+    _ir_builder.SetInsertPoint(poll_block);
+    add_safepoint_poll();
+    _ir_builder.CreateBr(taken_block);
+    _ir_builder.SetInsertPoint(branch_block);
+
+    _backedge_safepoint_successor = taken_jbb;
+    _backedge_safepoint_block = poll_block;
+    return poll_block;
+  };
+
   // Unstable-if prune: strict-zero one-side prune into uncommon_trap(Reason_unstable_if).
   // Operands are still on the stack here so the trap deopt bundle sees the
   // pre-if state, same effect as C2's repush_if_args() without re-pushing.
@@ -1779,12 +1814,13 @@ void JeandleAbstractInterpreter::do_if_branch(llvm::Value* cond, unsigned operan
       return;
     }
     if (counts.not_taken == 0 && counts.taken > 0) {
-      emit_pruned_branch(taken_jbb, taken_block, /*cond_true_is_hot=*/true,
+      emit_pruned_branch(taken_jbb, get_taken_branch_target(), /*cond_true_is_hot=*/true,
                          bci2block()[_bytecodes.next_bci()]);
       return;
     }
   }
 
+  llvm::BasicBlock* actual_taken_block = get_taken_branch_target();
   consume_operands();
   if (taken_jbb->is_exception_handler()) {
     merge_into_exception_handler(taken_jbb);
@@ -1792,14 +1828,11 @@ void JeandleAbstractInterpreter::do_if_branch(llvm::Value* cond, unsigned operan
   if (fallthrough_jbb->is_exception_handler()) {
     merge_into_exception_handler(fallthrough_jbb);
   }
-  llvm::BranchInst* br = _ir_builder.CreateCondBr(cond, taken_block, fallthrough_block);
+  llvm::BranchInst* br = _ir_builder.CreateCondBr(cond, actual_taken_block, fallthrough_block);
   attach_branch_weights(br, bci);
 }
 
 void JeandleAbstractInterpreter::if_zero(llvm::CmpInst::Predicate p) {
-  if (_bytecodes.get_dest() <= _bytecodes.cur_bci()) {
-    add_safepoint_poll();
-  }
   // Peek (do not pop): a pruned uncommon_trap must see the operand on the stack.
   llvm::Value* v = _jvm->raw_peek(0).value();
   llvm::Value* cond = _ir_builder.CreateICmp(p, v, JeandleType::int_const(_ir_builder, 0));
@@ -1807,9 +1840,6 @@ void JeandleAbstractInterpreter::if_zero(llvm::CmpInst::Predicate p) {
 }
 
 void JeandleAbstractInterpreter::if_icmp(llvm::CmpInst::Predicate p) {
-  if (_bytecodes.get_dest() <= _bytecodes.cur_bci()) {
-    add_safepoint_poll();
-  }
   // Peek (do not pop): a pruned uncommon_trap must see both operands on the stack.
   llvm::Value* r = _jvm->raw_peek(0).value();
   llvm::Value* l = _jvm->raw_peek(1).value();
@@ -1828,9 +1858,6 @@ void JeandleAbstractInterpreter::lcmp() {
 }
 
 void JeandleAbstractInterpreter::if_acmp(llvm::CmpInst::Predicate p) {
-  if (_bytecodes.get_dest() <= _bytecodes.cur_bci()) {
-    add_safepoint_poll();
-  }
   // Peek (do not pop): a pruned uncommon_trap must see both operands on the stack.
   llvm::Value* r = _jvm->raw_peek(0).value();
   llvm::Value* l = _jvm->raw_peek(1).value();
@@ -1839,9 +1866,6 @@ void JeandleAbstractInterpreter::if_acmp(llvm::CmpInst::Predicate p) {
 }
 
 void JeandleAbstractInterpreter::if_null(llvm::CmpInst::Predicate p) {
-  if (_bytecodes.get_dest() <= _bytecodes.cur_bci()) {
-    add_safepoint_poll();
-  }
   // Peek (do not pop): a pruned uncommon_trap must see the operand on the stack.
   llvm::Value* v = _jvm->raw_peek(0).value();
   llvm::Value* cond = _ir_builder.CreateICmp(p, v, llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(v->getType())));
@@ -1880,7 +1904,12 @@ void JeandleAbstractInterpreter::merge_into_exception_handler(JeandleBasicBlock*
   // to merge the current VMState into the handler, bypassing the is_exception_handler()
   // skip in the successor loop of interpret_block().
   JeandleVMState* adjusted_state = _jvm->copy();
-  if (!handler_block->merge_VM_state_from(adjusted_state, _ir_builder.GetInsertBlock(), _method, is_osr())) {
+  llvm::BasicBlock* incoming_block = _ir_builder.GetInsertBlock();
+  if (handler_block == _backedge_safepoint_successor) {
+    assert(_backedge_safepoint_block != nullptr, "missing back-edge safepoint block");
+    incoming_block = _backedge_safepoint_block;
+  }
+  if (!handler_block->merge_VM_state_from(adjusted_state, incoming_block, _method, is_osr())) {
     JEANDLE_ERROR_ASSERT_AND_RET_VOID_ON_FAIL(false, "failed to merge VM state into exception handler block from normal flow");
   }
 }

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.hpp
@@ -330,6 +330,11 @@ class JeandleAbstractInterpreter : public StackObj {
   // block.
   JeandleBasicBlock* _pruned_successor;
 
+  // Records the logical successor and actual LLVM predecessor when a taken
+  // back-edge is split through a safepoint poll block.
+  JeandleBasicBlock* _backedge_safepoint_successor;
+  llvm::BasicBlock* _backedge_safepoint_block;
+
   // Contains all blocks to interpret. Sorted by reverse-post-order.
   llvm::SmallVector<JeandleBasicBlock*> _work_list;
 

--- a/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestBackedgeSafepointPoll.java
+++ b/test/hotspot/jtreg/compiler/jeandle/bytecodeTranslate/safepoint/TestBackedgeSafepointPoll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Jeandle-JDK Authors. All Rights Reserved.
+ * Copyright (c) 2025, 2026, the Jeandle-JDK Authors. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,15 @@
 /*
  * @test
  * @summary the back edge of the `if*` bytecode should have safepoint poll
- * @library /test/lib
- * @build jdk.test.whitebox.WhiteBox
+ * @library /test/lib /
+ * @build jdk.test.whitebox.WhiteBox compiler.jeandle.fileCheck.FileCheck
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *      -XX:-TieredCompilation -Xcomp -XX:+UseJeandleCompiler
+ *      -XX:-TieredCompilation -Xcomp -Xbatch -XX:+UseJeandleCompiler
  *      -XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.safepoint.TestBackedgeSafepointPoll::loopTest
  *      -XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.safepoint.TestBackedgeSafepointPoll::add
+ *      -XX:CompileCommand=compileonly,compiler.jeandle.bytecodeTranslate.safepoint.TestBackedgeSafepointPoll::countedLoop
+ *      -XX:+JeandleDumpIR
  *      compiler.jeandle.bytecodeTranslate.safepoint.TestBackedgeSafepointPoll
  */
 
@@ -35,12 +37,34 @@ package compiler.jeandle.bytecodeTranslate.safepoint;
 
 import java.lang.reflect.Method;
 
+import compiler.jeandle.fileCheck.FileCheck;
+import jdk.test.lib.Asserts;
 import jdk.test.whitebox.WhiteBox;
 
 public class TestBackedgeSafepointPoll {
     private final static WhiteBox wb = WhiteBox.getWhiteBox();
 
     public static void main(String[] args) throws Exception {
+        if (countedLoop(10) != 10) {
+            throw new RuntimeException("countedLoop returned an unexpected result");
+        }
+
+        Method countedLoop = TestBackedgeSafepointPoll.class.getDeclaredMethod("countedLoop", int.class);
+        Asserts.assertTrue(wb.isMethodCompiled(countedLoop), "countedLoop must be compiled");
+
+        FileCheck fileCheck = new FileCheck(System.getProperty("user.dir"), countedLoop, false);
+        fileCheck.checkPattern("define hotspotcc i32 .*TestBackedgeSafepointPoll_countedLoop");
+        // No poll may remain before the conditional branch.
+        fileCheck.checkPattern(" = add i32 ");
+        fileCheck.checkNextPattern(" = icmp slt i32 ");
+        // The taken back-edge must enter the dedicated poll block. The
+        // fallthrough target must remain an ordinary bytecode block.
+        fileCheck.checkNextPattern(
+                "br i1 [^,]+, label %bci_[0-9]+_backedge_safepoint, label %bci_[0-9]+(?:,.*)?$");
+        fileCheck.checkPattern("bci_[0-9]+_backedge_safepoint:");
+        fileCheck.checkNextPattern("call hotspotcc void @jeandle\\.safepoint_poll\\(\\)");
+        fileCheck.checkNextPattern("br label %bci_[0-9]+$");
+
         for (int i =0; i < 10; i++) {
             runThread();
         }
@@ -52,6 +76,14 @@ public class TestBackedgeSafepointPoll {
 
         Thread.sleep(100);
         System.out.println("Main thread ends");
+    }
+
+    public static int countedLoop(int limit) {
+        int count = 0;
+        do {
+            count++;
+        } while (count < limit);
+        return count;
     }
 
     public static void runThread() {


### PR DESCRIPTION
## Summary

Closes #550.

- Move the safepoint poll for a taken conditional back-edge into a dedicated LLVM block between the conditional branch and its original target. The fallthrough path skips this back-edge poll; existing return, goto, and switch polls are unchanged.
- Preserve pre-if operands in the safepoint deoptimization state, branch weights, and unstable-if pruning. Do not create a poll block when the taken edge is pruned.
- Use the poll block as the actual LLVM predecessor when merging the back-edge successor's VM state, including normal control flow into exception handlers.
- Extend `TestBackedgeSafepointPoll` with an unoptimized-IR check that rejects a pre-branch poll and requires the taken edge to pass through the poll block. Retain the existing loop runtime test.

## Validation

Locally validated on Linux x64 in Docker, rebased onto `main` at `d1b7f5077e99a78599ae093268ec1e83424c0c47`:

- `git diff --check`: passed.
- Release HotSpot build: `make CONF=issue550-aug31 JOBS=7 hotspot` passed.
- Red/green regression: the updated `TestBackedgeSafepointPoll` fails on the unmodified baseline because the poll still appears between the increment and comparison, and passes with the rebuilt HotSpot.
- All 6 selected tests passed using jtreg 7.5.2:
  - `compiler/jeandle/bytecodeTranslate/safepoint/TestBackedgeSafepointPoll.java`
  - `compiler/jeandle/bytecodeTranslate/safepoint/TestSafepointPoll.java`
  - `compiler/jeandle/pgo/TestUnstableIf.java`
  - `compiler/jeandle/pgo/TestBranchWeights.java`
  - `compiler/jeandle/pgo/TestSameTargetCondBr.java`
  - `compiler/jeandle/pgo/TestUnstableIfPruneBoundaries.java`

The local test JDK used the rebuilt `libjvm.so` over the matching CI JDK bundle from run 33152299842. The bundle's JDK source tree matches the base commit, and its LLVM source tree matches Jeandle-LLVM `main` at `2d6e773ce770ccd2fec0f7d05eb8438b1d6f9914`. This is a targeted HotSpot/jtreg validation, not a full JDK test-suite or cross-platform run.

## Follow-up: paired LLVM fix for strip mining

The first [CI run](https://github.com/jeandle/jeandle-jdk/actions/runs/33374145438) passed the Release/Debug builds and the other 14 test jobs, but the Jeandle job reported 310 passes and two failures: `TestStripMinedLoopShapes.java#id0` and `#id1`.

Both failures were reproduced locally with the exact CI Fastdebug bundle and original LLVM. Loop rotation can turn the new taken-edge poll into a header-entry poll, which the current LLVM strip-mining pass rejects. The companion fix is **[jeandle/jeandle-llvm#109](https://github.com/jeandle/jeandle-llvm/pull/109)**, with functional commit `86cdfea8419efece3e25aa2b6631c42d03275c83` and formatting follow-up `35048f26775931864a8223c18ec05e1e246dc7d8`. It preserves header-entry deoptimization state at guarded batch entry and handles the widened inclusive bound proof without weakening existing safety checks.

The latest metadata-only JDK commit selects that LLVM branch through the workflow's existing mechanism:

```text
CO_REPO: https://github.com/lkxdsb/jeandle-llvm.git
CO_BRANCH: codex/issue550-header-poll
```

This is a temporary paired-CI dependency until the LLVM fix lands upstream; it should be removed before the final JDK merge once upstream LLVM contains the fix. The JDK implementation and test assertions are unchanged by this follow-up.

### Expanded local validation with the companion fix

- New LLVM regression: fails with original LLVM, passes with the fix.
- Safepoint LLVM lit suite: **105/105 passed** in Release and **105/105 passed** with assertions enabled.
- Entire JDK safepoint directory plus the four PGO tests listed above: **17 passed / 8 debug-only configurations excluded** in Release; **25/25 passed** in Fastdebug, including both original CI failures.

These tests ran on Linux x64 via Docker on macOS. LLVM validation used an incremental rebuild of the changed translation units and relinking against matching CI archives, with opt/FileCheck linked against the derived shared library; it was not a clean full-source CMake build. Full clean builds and broader integration validation remain for the new CI run. Both PRs remain in draft pending that validation.

