### PR TITLE
feat: add MD5 and multi-block digest intrinsics

### DIFF
--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -281,10 +281,12 @@ bool JeandleIntrinsicLowering::is_supported(vmIntrinsics::ID id) {
 
     // Single-block SHA compression. Availability is checked again by the
     // lowering because platform stubs are generated conditionally.
+    case vmIntrinsics::_md5_implCompress:
     case vmIntrinsics::_sha_implCompress:
     case vmIntrinsics::_sha2_implCompress:
     case vmIntrinsics::_sha5_implCompress:
     case vmIntrinsics::_sha3_implCompress:
+    case vmIntrinsics::_digestBase_implCompressMB:
       return true;
 
     default:
@@ -549,11 +551,15 @@ bool JeandleIntrinsicLowering::lower(vmIntrinsics::ID id, const ciMethod* target
     case vmIntrinsics::_arraycopy:
       return lower_arraycopy();
 
+    case vmIntrinsics::_md5_implCompress:
     case vmIntrinsics::_sha_implCompress:
     case vmIntrinsics::_sha2_implCompress:
     case vmIntrinsics::_sha5_implCompress:
     case vmIntrinsics::_sha3_implCompress:
       return lower_digestBase_implCompress(id);
+
+    case vmIntrinsics::_digestBase_implCompressMB:
+      return lower_digestBase_implCompressMB();
 
     default:
       return false;
@@ -661,7 +667,7 @@ bool JeandleIntrinsicLowering::lower_dual_path_libm(llvm::Intrinsic::ID llvm_id,
 }
 
 // =============================================================================
-// lower_digestBase_implCompress — single-block SHA compression
+// lower_digestBase_implCompress — single-block digest compression
 // =============================================================================
 
 bool JeandleIntrinsicLowering::lower_digestBase_implCompress(vmIntrinsics::ID id) {
@@ -678,6 +684,12 @@ bool JeandleIntrinsicLowering::lower_digestBase_implCompress(vmIntrinsics::ID id
   BasicType state_element_type = T_ILLEGAL;
   JeandleRuntimeCalleeFn callee_fn = nullptr;
   switch (id) {
+    case vmIntrinsics::_md5_implCompress:
+      state_signature = "[I";
+      state_element_type = T_INT;
+      stub_name = "StubRoutines_md5_implCompress";
+      callee_fn = &JeandleRuntimeRoutine::StubRoutines_md5_implCompress_callee;
+      break;
     case vmIntrinsics::_sha_implCompress:
       state_signature = "[I";
       state_element_type = T_INT;
@@ -783,6 +795,215 @@ bool JeandleIntrinsicLowering::lower_digestBase_implCompress(vmIntrinsics::ID id
                   {src_start, state_base, block_size}, attrs,
                   /*is_gc_leaf_entry=*/true);
   }
+  return true;
+}
+
+// =============================================================================
+// lower_digestBase_implCompressMB — multi-block digest compression
+// =============================================================================
+
+bool JeandleIntrinsicLowering::lower_digestBase_implCompressMB() {
+  ciSignature* sig = _target->signature();
+  if (sig->count() != 3 || sig->type_at(0)->basic_type() != T_ARRAY ||
+      sig->type_at(1)->basic_type() != T_INT ||
+      sig->type_at(2)->basic_type() != T_INT ||
+      sig->return_type()->basic_type() != T_INT ||
+      sig->type_at(0)->name() == nullptr ||
+      strcmp(sig->type_at(0)->name(), "[B") != 0) {
+    return false;
+  }
+  if (_interp->too_many_traps(const_cast<ciMethod*>(_interp->_method),
+                              _interp->_bytecodes.cur_bci(),
+                              Deoptimization::Reason_intrinsic)) {
+    return false;
+  }
+
+  struct Candidate {
+    const char* klass_name;
+    const char* state_signature;
+    BasicType state_element_type;
+    const char* stub_name;
+    bool is_sha3;
+    JeandleRuntimeCalleeFn callee_fn;
+    ciInstanceKlass* klass;
+    ciField* state_field;
+    ciField* block_size_field;
+  };
+
+  struct CandidateSpec {
+    const char* klass_name;
+    const char* state_signature;
+    BasicType state_element_type;
+    const char* stub_name;
+    bool is_sha3;
+    vmIntrinsics::ID intrinsic_id;
+    JeandleRuntimeCalleeFn callee_fn;
+  };
+
+  const CandidateSpec specs[] = {
+      {"sun/security/provider/MD5",  "[I", T_INT,
+       "StubRoutines_md5_implCompressMB", false, vmIntrinsics::_md5_implCompress,
+       &JeandleRuntimeRoutine::StubRoutines_md5_implCompressMB_callee},
+      {"sun/security/provider/SHA",  "[I", T_INT,
+       "StubRoutines_sha1_implCompressMB", false, vmIntrinsics::_sha_implCompress,
+       &JeandleRuntimeRoutine::StubRoutines_sha1_implCompressMB_callee},
+      {"sun/security/provider/SHA2", "[I", T_INT,
+       "StubRoutines_sha256_implCompressMB", false, vmIntrinsics::_sha2_implCompress,
+       &JeandleRuntimeRoutine::StubRoutines_sha256_implCompressMB_callee},
+      {"sun/security/provider/SHA5", "[J", T_LONG,
+       "StubRoutines_sha512_implCompressMB", false, vmIntrinsics::_sha5_implCompress,
+       &JeandleRuntimeRoutine::StubRoutines_sha512_implCompressMB_callee},
+      {"sun/security/provider/SHA3", "[B", T_BYTE,
+       "StubRoutines_sha3_implCompressMB", true, vmIntrinsics::_sha3_implCompress,
+       &JeandleRuntimeRoutine::StubRoutines_sha3_implCompressMB_callee},
+  };
+
+  ciInstanceKlass* digest_base = _target->holder();
+  llvm::SmallVector<Candidate, 5> candidates;
+  for (const CandidateSpec& spec : specs) {
+    if (!vmIntrinsics::is_intrinsic_available(spec.intrinsic_id) ||
+        JeandleRuntimeRoutine::find_routine_entry(spec.stub_name) == nullptr) {
+      continue;
+    }
+
+    ciKlass* klass = digest_base->find_klass(ciSymbol::make(spec.klass_name));
+    if (klass == nullptr || !klass->is_loaded() || !klass->is_instance_klass()) {
+      continue;
+    }
+
+    ciInstanceKlass* instance_klass = klass->as_instance_klass();
+    ciField* state_field = instance_klass->get_field_by_name(
+        ciSymbol::make("state"), ciSymbol::make(spec.state_signature), false);
+    if (state_field == nullptr) {
+      continue;
+    }
+
+    ciField* block_size_field = nullptr;
+    if (spec.is_sha3) {
+      block_size_field = instance_klass->get_field_by_name(
+          ciSymbol::make("blockSize"), ciSymbol::make("I"), false);
+      if (block_size_field == nullptr) {
+        continue;
+      }
+    }
+
+    candidates.push_back({spec.klass_name, spec.state_signature,
+                          spec.state_element_type, spec.stub_name, spec.is_sha3,
+                          spec.callee_fn, instance_klass, state_field,
+                          block_size_field});
+  }
+
+  // The generic DigestBase method can only use a fast path when at least one
+  // concrete digest class and its platform stub are available.
+  if (candidates.empty()) {
+    return false;
+  }
+
+  // Keep all values on the JVM stack until the unknown-subclass deopt bundle
+  // has captured the original invoke state.
+  llvm::Value* receiver = _interp->_jvm->raw_peek(3).value();
+  llvm::Value* src = _interp->_jvm->raw_peek(2).value();
+  llvm::Value* ofs = _interp->_jvm->raw_peek(1).value();
+  llvm::Value* limit = _interp->_jvm->raw_peek(0).value();
+  _interp->null_check(src);
+
+  llvm::IRBuilder<>& builder = _interp->_ir_builder;
+  llvm::LLVMContext& context = *_interp->_context;
+  llvm::Module& module = _interp->_module;
+  llvm::PointerType* java_heap_ptr_type =
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace);
+  llvm::PointerType* c_heap_ptr_type =
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+
+  llvm::Value* src_offset = builder.CreateAdd(
+      builder.getInt32(arrayOopDesc::base_offset_in_bytes(T_BYTE)), ofs,
+      "digest_mb_src_offset");
+  llvm::Value* src_start = builder.CreateInBoundsPtrAdd(
+      src, src_offset, "digest_mb_src_start");
+
+  llvm::BasicBlock* merge_bb =
+      llvm::BasicBlock::Create(context, "digest_mb_merge", _interp->_llvm_func);
+  llvm::SmallVector<std::pair<llvm::CallBase*, llvm::BasicBlock*>, 5> calls;
+  llvm::BasicBlock* dispatch_bb = builder.GetInsertBlock();
+
+  for (size_t i = 0; i < candidates.size(); ++i) {
+    const Candidate& candidate = candidates[i];
+    llvm::BasicBlock* fast_bb = llvm::BasicBlock::Create(
+        context, "digest_mb_" + std::to_string(i) + "_fast", _interp->_llvm_func);
+    llvm::BasicBlock* next_bb = llvm::BasicBlock::Create(
+        context, "digest_mb_" + std::to_string(i) + "_next", _interp->_llvm_func);
+
+    builder.SetInsertPoint(dispatch_bb);
+    Klass* klass = reinterpret_cast<Klass*>(candidate.klass->constant_encoding());
+    llvm::Value* klass_ptr = builder.CreateIntToPtr(
+        builder.getInt64(reinterpret_cast<intptr_t>(klass)), c_heap_ptr_type);
+    llvm::Value* is_instance = _interp->call_java_op(
+        "jeandle.instanceof", {klass_ptr, receiver});
+    llvm::Value* matches = builder.CreateICmpNE(
+        is_instance, builder.getInt32(0), "digest_mb_is_instance");
+    builder.CreateCondBr(matches, fast_bb, next_bb);
+
+    builder.SetInsertPoint(fast_bb);
+    BasicType state_ref_type = candidate.state_field->layout_type();
+    if (UseCompressedOops && is_reference_type(state_ref_type)) {
+      state_ref_type = T_NARROWOOP;
+    }
+    llvm::Value* state_field_addr = _interp->compute_instance_field_address(
+        receiver, candidate.state_field->offset_in_bytes());
+    llvm::Value* state_array = _interp->load_from_address(
+        state_field_addr, state_ref_type, false);
+    if (state_ref_type == T_NARROWOOP) {
+      state_array = builder.CreateAddrSpaceCast(
+          state_array, java_heap_ptr_type, "digest_mb_state_array");
+    }
+    llvm::Value* state_base = builder.CreateInBoundsPtrAdd(
+        state_array,
+        builder.getInt32(arrayOopDesc::base_offset_in_bytes(
+            candidate.state_element_type)),
+        "digest_mb_state_base");
+
+    llvm::SmallVector<llvm::Value*, 5> args = {src_start, state_base};
+    if (candidate.is_sha3) {
+      llvm::Value* block_size_addr = _interp->compute_instance_field_address(
+          receiver, candidate.block_size_field->offset_in_bytes());
+      args.push_back(_interp->load_from_address(block_size_addr, T_INT, false));
+    }
+    args.push_back(ofs);
+    args.push_back(limit);
+
+    static constexpr CallSiteAttributeMetadata attrs = {
+        CTRL_NONE, MEM_READ | MEM_WRITE};
+    llvm::CallBase* call = emit_callsite(
+        candidate.callee_fn(module), llvm::CallingConv::C, args, attrs,
+        /*is_gc_leaf_entry=*/true);
+    builder.CreateBr(merge_bb);
+    calls.push_back({call, builder.GetInsertBlock()});
+    dispatch_bb = next_bb;
+  }
+
+  // Other DigestBase implementations, such as MD2, need the Java path. Deopt
+  // once so the admission check above can decline this intrinsic when the
+  // method is recompiled, without calling a stub with an incompatible state.
+  llvm::BasicBlock* unknown_bb =
+      llvm::BasicBlock::Create(context, "digest_mb_unknown", _interp->_llvm_func);
+  builder.SetInsertPoint(dispatch_bb);
+  builder.CreateBr(unknown_bb);
+  _interp->uncommon_trap(Deoptimization::Reason_intrinsic,
+                         Deoptimization::Action_make_not_entrant, unknown_bb);
+
+  builder.SetInsertPoint(merge_bb);
+  _interp->_block->set_tail_llvm_block(merge_bb);
+  llvm::PHINode* result = builder.CreatePHI(
+      builder.getInt32Ty(), static_cast<unsigned>(calls.size()), "digest_mb_result");
+  for (const auto& entry : calls) {
+    result->addIncoming(entry.first, entry.second);
+  }
+
+  _interp->_jvm->ipop();  // limit
+  _interp->_jvm->ipop();  // ofs
+  _interp->_jvm->apop();  // src
+  _interp->_jvm->apop();  // receiver
+  _interp->_jvm->ipush(result);
   return true;
 }
 

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
@@ -194,6 +194,7 @@ class JeandleIntrinsicLowering : public StackObj {
   bool lower_remainder_unsigned(vmIntrinsics::ID id);
   bool lower_multiply_high(vmIntrinsics::ID id);
   bool lower_digestBase_implCompress(vmIntrinsics::ID id);
+  bool lower_digestBase_implCompressMB();
   bool lower_new_array();
   bool lower_unsafe_allocate_instance();
   bool lower_vectorized_mismatch();

--- a/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
+++ b/src/hotspot/share/jeandle/jeandleRuntimeRoutine.hpp
@@ -298,6 +298,14 @@
       llvm::Type::getInt32Ty(context),                                              \
       llvm::Type::getInt32Ty(context))                                              \
                                                                                     \
+  def(StubRoutines_md5_implCompress,                                                 \
+      StubRoutines::md5_implCompress(),                                              \
+      true,                                                                          \
+      true,                                                                          \
+      llvm::Type::getVoidTy(context),                                                \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace))  \
+                                                                                    \
   def(StubRoutines_sha1_implCompress,                                               \
       StubRoutines::sha1_implCompress(),                                            \
       true,                                                                         \
@@ -330,6 +338,57 @@
       llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
       llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace), \
       llvm::Type::getInt32Ty(context))                                              \
+                                                                                    \
+  def(StubRoutines_md5_implCompressMB,                                               \
+      StubRoutines::md5_implCompressMB(),                                            \
+      true,                                                                          \
+      true,                                                                          \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::Type::getInt32Ty(context))                                               \
+                                                                                    \
+  def(StubRoutines_sha1_implCompressMB,                                              \
+      StubRoutines::sha1_implCompressMB(),                                           \
+      true,                                                                          \
+      true,                                                                          \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::Type::getInt32Ty(context))                                               \
+                                                                                    \
+  def(StubRoutines_sha256_implCompressMB,                                            \
+      StubRoutines::sha256_implCompressMB(),                                         \
+      true,                                                                          \
+      true,                                                                          \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::Type::getInt32Ty(context))                                               \
+                                                                                    \
+  def(StubRoutines_sha512_implCompressMB,                                            \
+      StubRoutines::sha512_implCompressMB(),                                         \
+      true,                                                                          \
+      true,                                                                          \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::Type::getInt32Ty(context))                                               \
+                                                                                    \
+  def(StubRoutines_sha3_implCompressMB,                                              \
+      StubRoutines::sha3_implCompressMB(),                                           \
+      true,                                                                          \
+      true,                                                                          \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),  \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::Type::getInt32Ty(context),                                                \
+      llvm::Type::getInt32Ty(context))                                               \
                                                                                     \
   def(SharedRuntime_OSR_migration_end,                                              \
       SharedRuntime::OSR_migration_end,                                             \

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java
@@ -9,7 +9,7 @@
 
 /*
  * @test
- * @summary Test Jeandle lowering of single-block SHA compression intrinsics.
+ * @summary Test Jeandle lowering of single- and multi-block digest compression intrinsics.
  * @requires os.arch == "amd64" | os.arch == "x86_64" | os.arch == "aarch64"
  * @library /test/lib /
  * @build jdk.test.lib.Asserts
@@ -34,7 +34,7 @@ import jdk.test.lib.process.ProcessTools;
 public class TestShaCompress {
     private static final HexFormat HEX = HexFormat.of();
     private static final String[] INTRINSIC_FLAGS = {
-            "UseSHA1Intrinsics", "UseSHA256Intrinsics",
+            "UseMD5Intrinsics", "UseSHA1Intrinsics", "UseSHA256Intrinsics",
             "UseSHA512Intrinsics", "UseSHA3Intrinsics"
     };
     private static final int[] TEST_LENGTHS = {
@@ -45,19 +45,66 @@ public class TestShaCompress {
         OutputAnalyzer reference = ProcessTools.executeCommand(
                 ProcessTools.createLimitedTestJavaProcessBuilder(
                         "-XX:+UnlockDiagnosticVMOptions",
-                        "-XX:-UseSHA1Intrinsics", "-XX:-UseSHA256Intrinsics",
+                        "-XX:-UseMD5Intrinsics", "-XX:-UseSHA1Intrinsics", "-XX:-UseSHA256Intrinsics",
                         "-XX:-UseSHA512Intrinsics", "-XX:-UseSHA3Intrinsics",
                         TestWrapper.class.getName()));
         reference.shouldHaveExitValue(0).shouldContain("TestShaCompress PASSED");
 
         Path dumpPath = Files.createTempDirectory("jeandle_sha_compress");
+        OutputAnalyzer output = runJeandle(dumpPath, List.of());
+        assertDigestResults(reference, output);
+
+        String ir = readIR(dumpPath);
+        assertRoutineMatchesFlag(output, ir, "UseSHA1Intrinsics",
+                "StubRoutines_sha1_implCompress", "SHA-1");
+        assertRoutineMatchesFlag(output, ir, "UseMD5Intrinsics",
+                "StubRoutines_md5_implCompress", "MD5");
+        assertRoutineMatchesFlag(output, ir, "UseSHA256Intrinsics",
+                "StubRoutines_sha256_implCompress", "SHA-256");
+        assertRoutineMatchesFlag(output, ir, "UseSHA512Intrinsics",
+                "StubRoutines_sha512_implCompress", "SHA-512");
+        assertRoutineMatchesFlag(output, ir, "UseSHA3Intrinsics",
+                "StubRoutines_sha3_implCompress", "SHA-3");
+        assertRoutineMatchesFlag(output, ir, "UseMD5Intrinsics",
+                "StubRoutines_md5_implCompressMB", "MD5 multi-block");
+        assertRoutineMatchesFlag(output, ir, "UseSHA1Intrinsics",
+                "StubRoutines_sha1_implCompressMB", "SHA-1 multi-block");
+        assertRoutineMatchesFlag(output, ir, "UseSHA256Intrinsics",
+                "StubRoutines_sha256_implCompressMB", "SHA-256 multi-block");
+        assertRoutineMatchesFlag(output, ir, "UseSHA512Intrinsics",
+                "StubRoutines_sha512_implCompressMB", "SHA-512 multi-block");
+        assertRoutineMatchesFlag(output, ir, "UseSHA3Intrinsics",
+                "StubRoutines_sha3_implCompressMB", "SHA-3 multi-block");
+        Asserts.assertTrue(containsCall(ir,
+                        "@\"sun_security_provider_DigestBase_implCompressMultiBlock0([BII)I"),
+                "MD2 must recompile the multi-block method with a stable Java fallback");
+
+        Path md5DisabledDumpPath = Files.createTempDirectory("jeandle_md5_disabled");
+        OutputAnalyzer md5Disabled = runJeandle(md5DisabledDumpPath,
+                List.of("-XX:DisableIntrinsic=_md5_implCompress"));
+        assertDigestResults(reference, md5Disabled);
+        String md5DisabledIR = readIR(md5DisabledDumpPath);
+        Asserts.assertFalse(containsRoutineCall(md5DisabledIR,
+                        "StubRoutines_md5_implCompress"),
+                "Disabled MD5 intrinsic must not emit a single-block stub call");
+        Asserts.assertFalse(containsRoutineCall(md5DisabledIR,
+                        "StubRoutines_md5_implCompressMB"),
+                "Disabled MD5 intrinsic must not emit a multi-block stub call");
+    }
+
+    private static OutputAnalyzer runJeandle(Path dumpPath, List<String> extraOptions)
+            throws Exception {
         List<String> commandArgs = new java.util.ArrayList<>(List.of(
-                "-Xbatch", "-XX:-TieredCompilation", "-XX:+UseJeandleCompiler", "-Xcomp",
+                "-Xbatch", "-XX:-TieredCompilation", "-XX:CompileThreshold=1",
+                "-XX:+UseJeandleCompiler", "-Xcomp",
                 "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSHA1Intrinsics",
+                "-XX:+UseMD5Intrinsics",
                 "-XX:+UseSHA256Intrinsics", "-XX:+UseSHA512Intrinsics", "-XX:+UseSHA3Intrinsics",
                 "-Xlog:jeandle=debug", "-XX:+JeandleDumpIR",
                 "-XX:JeandleDumpDirectory=" + dumpPath,
-                "-XX:CompileCommand=compileonly,sun/security/provider/DigestBase.implCompressMultiBlock0",
+                "-XX:CompileCommand=compileonly,sun/security/provider/DigestBase.implCompressMultiBlock",
+                "-XX:CompileCommand=compileonly,sun/security/provider/MD5.implCompress0",
+                "-XX:CompileCommand=compileonly,sun/security/provider/MD5.implCompress",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA.implCompress0",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA.implCompress",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA2.implCompress0",
@@ -65,37 +112,37 @@ public class TestShaCompress {
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA5.implCompress0",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA5.implCompress",
                 "-XX:CompileCommand=compileonly,sun/security/provider/SHA3.implCompress0",
-                "-XX:CompileCommand=compileonly,sun/security/provider/SHA3.implCompress",
-                TestWrapper.class.getName()));
+                "-XX:CompileCommand=compileonly,sun/security/provider/SHA3.implCompress"));
+        commandArgs.addAll(extraOptions);
+        commandArgs.add(TestWrapper.class.getName());
 
         OutputAnalyzer output = ProcessTools.executeCommand(
                 ProcessTools.createLimitedTestJavaProcessBuilder(commandArgs));
         output.shouldHaveExitValue(0).shouldContain("TestShaCompress PASSED");
-        List<String> referenceDigests = digestLines(reference);
-        Asserts.assertEquals(7 * TEST_LENGTHS.length, referenceDigests.size(),
-                "Unexpected number of reference SHA digests");
-        Asserts.assertEquals(referenceDigests, digestLines(output),
-                "SHA digests differ from the all-intrinsics-disabled reference run");
+        return output;
+    }
 
-        String ir = Files.walk(dumpPath)
-                .filter(Files::isRegularFile)
-                .filter(path -> path.toString().endsWith(".ll"))
-                .map(path -> {
-                    try {
-                        return Files.readString(path);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                })
-                .reduce("", String::concat);
-        assertRoutineMatchesFlag(output, ir, "UseSHA1Intrinsics",
-                "StubRoutines_sha1_implCompress", "SHA-1");
-        assertRoutineMatchesFlag(output, ir, "UseSHA256Intrinsics",
-                "StubRoutines_sha256_implCompress", "SHA-256");
-        assertRoutineMatchesFlag(output, ir, "UseSHA512Intrinsics",
-                "StubRoutines_sha512_implCompress", "SHA-512");
-        assertRoutineMatchesFlag(output, ir, "UseSHA3Intrinsics",
-                "StubRoutines_sha3_implCompress", "SHA-3");
+    private static void assertDigestResults(OutputAnalyzer reference, OutputAnalyzer output) {
+        List<String> referenceDigests = digestLines(reference);
+        Asserts.assertEquals(11 * TEST_LENGTHS.length, referenceDigests.size(),
+                "Unexpected number of reference digests");
+        Asserts.assertEquals(referenceDigests, digestLines(output),
+                "Digest results differ from the all-intrinsics-disabled reference run");
+    }
+
+    private static String readIR(Path dumpPath) throws Exception {
+        try (var paths = Files.walk(dumpPath)) {
+            return paths.filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".ll"))
+                    .map(path -> {
+                        try {
+                            return Files.readString(path);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .reduce("", String::concat);
+        }
     }
 
     private static List<String> digestLines(OutputAnalyzer output) {
@@ -113,22 +160,44 @@ public class TestShaCompress {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Missing effective VM flag: " + flag));
         boolean enabled = Boolean.parseBoolean(flagLine.substring(prefix.length()));
-        Asserts.assertEquals(enabled, ir.contains(routine),
+        Asserts.assertEquals(enabled, containsRoutineCall(ir, routine),
                 algorithm + " direct routine presence must match effective " + flag);
+    }
+
+    private static boolean containsRoutineCall(String ir, String routine) {
+        return containsCall(ir, "@" + routine + "(");
+    }
+
+    private static boolean containsCall(String ir, String callee) {
+        return ir.lines().anyMatch(line ->
+                (line.contains("call ") || line.contains("invoke ")) && line.contains(callee));
     }
 
     static class TestWrapper {
         public static void main(String[] args) throws Exception {
+            // Load every accelerated DigestBase implementation before the
+            // intrinsic root is compiled; MD2 exercises the Java fallback.
+            for (String algorithm : List.of("MD2", "MD5", "SHA-1", "SHA-224", "SHA-256",
+                    "SHA-384", "SHA-512", "SHA3-256")) {
+                MessageDigest.getInstance(algorithm, "SUN");
+            }
+
             HotSpotDiagnosticMXBean diagnostic = ManagementFactory.getPlatformMXBean(
                     HotSpotDiagnosticMXBean.class);
             for (String flag : INTRINSIC_FLAGS) {
                 System.out.println("FLAG " + flag + "=" + diagnostic.getVMOption(flag).getValue());
             }
 
+            check("MD5", "d41d8cd98f00b204e9800998ecf8427e",
+                    "d1ae06bbf9128955a34bedb6231eee62");
             check("SHA-1", "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                     "4fd6558b2a93925fb7129447e1d1fac8cff56287");
+            check("SHA-224", "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
+                    "8baa263ee929dd49b84e560cc7b79ba111f032a0c9216d279e675184");
             check("SHA-256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                     "4f1757ae4bffbae86d775b831765b75af154d52f7deaa46dd378051a2d3ad57f");
+            check("SHA-384", "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
+                    "f07f92376b47fb9d34ff613a44f18b04b55fb1c480b07de4e08a0e9bd484ffa765c21671c341c70b4024e6bdcda709e4");
             check("SHA-512", "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
                     "1809db04d02717483e04bc4333a14308bd2d0213ba7bf2c63f11eb1b8a0af8252e67fd104fd466fb95f945539824d8e4183155fa5ced0bee3dad46d9384a0bd5");
             check("SHA3-224", "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7",
@@ -139,7 +208,15 @@ public class TestShaCompress {
                     "a6f86672297e96e989aa3eff04b0c927be7ac2a072040ac2a9017e329cdb614b6fa7760d0f31ac970e3591d7cf4d90e3");
             check("SHA3-512", "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",
                     "c4148471d4c463929e5af7df25fb4f66875ddf1c473e277e0170665afef3363984e9be12b11949f87a1d00b9e9c330b0fb3f64f31496037ca153f33fc2a5f382");
+            checkFallback("MD2", "8350e5a3e24c153df2275c9f80692773");
             System.out.println("TestShaCompress PASSED");
+        }
+
+        private static void checkFallback(String algorithm, String emptyExpected)
+                throws Exception {
+            byte[] empty = digest(algorithm, new byte[0], 0);
+            Asserts.assertEquals(emptyExpected, HEX.formatHex(empty), algorithm + " empty digest");
+            printDigestVectors(algorithm);
         }
 
         private static void check(String algorithm, String emptyExpected,
@@ -157,6 +234,10 @@ public class TestShaCompress {
             Asserts.assertEquals(vectorExpected, HEX.formatHex(actual),
                     algorithm + " boundary/non-aligned digest");
 
+            printDigestVectors(algorithm);
+        }
+
+        private static void printDigestVectors(String algorithm) throws Exception {
             for (int length : TEST_LENGTHS) {
                 byte[] data = new byte[length + 2];
                 for (int i = 0; i < length; i++) {


### PR DESCRIPTION
## Related issue(s):

Closes #616

## What this PR does / why we need it:

- Adds Jeandle lowering for the MD5 single-block intrinsic _md5_implCompress.
- Adds multi-block DigestBase lowering for MD5, SHA-1, SHA-256, SHA-512, and SHA-3 using the matching HotSpot stubs.
- Preserves intrinsic flags, platform-stub availability checks, and Java fallback/deoptimization behavior.
- Extends TestShaCompress.java with digest-result, IR, fallback, and disabled-MD5 coverage.

## Test plan

- git diff --check (passed).
- make test TEST=hotspot/jtreg/compiler/jeandle/intrinsic/TestShaCompress.java: currently blocked by an LLVM/JDK version mismatch because the installed LLVM lacks VMCallbacks::GetSecondarySupers; the test passed previously with a matching LLVM installation.
