### PR TITLE
feat: add Class intrinsics

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -96,6 +96,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     BIN := $(MICROBENCHMARK_CLASSES), \
     JAVAC_FLAGS := --add-exports java.base/sun.security.util=ALL-UNNAMED \
         --add-exports java.base/sun.invoke.util=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.classfile=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.classfile.attribute=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.classfile.constantpool=ALL-UNNAMED \

--- a/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
+++ b/src/hotspot/share/jeandle/jeandleAbstractInterpreter.cpp
@@ -42,6 +42,7 @@
 #include "jeandle/jeandleUtils.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "ci/ciInstance.hpp"
 #include "ci/ciMethodBlocks.hpp"
 #include "ci/ciMethodData.hpp"
 #include "ci/ciObjArrayKlass.hpp"
@@ -2630,6 +2631,19 @@ void JeandleAbstractInterpreter::do_field_access(bool is_get, bool is_static) {
 }
 
 void JeandleAbstractInterpreter::do_get_xxx(ciField* field, bool is_static) {
+  // Expose static final Class mirrors to Class intrinsic lowering. Keep other
+  // static constants as loads so the normal constant-field passes handle them.
+  if (field->is_static_constant() && field->layout_type() == T_OBJECT &&
+      field->type()->is_loaded()) {
+    ciConstant constant = field->constant_value();
+    ciObject* object = constant.is_valid() ? constant.as_object() : nullptr;
+    if (object != nullptr && object->is_instance() &&
+        object->as_instance()->java_mirror_type() != nullptr) {
+      _jvm->push(field->type()->basic_type(), constant_to_value(constant).value());
+      return;
+    }
+  }
+
   int offset = field->offset_in_bytes();
   llvm::Value* addr = nullptr;
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -92,6 +92,15 @@ ciObject* JeandleCompiledCode::oop_at(int oop_id) {
   return _oop_handle_info[oop_id].oop;
 }
 
+ciObject* JeandleCompiledCode::oop_for_handle_name(llvm::StringRef name) {
+  for (const OopHandleInfo& info : _oop_handle_info) {
+    if (name == info.name) {
+      return info.oop;
+    }
+  }
+  return nullptr;
+}
+
 std::string JeandleCompiledCode::oop_handle_name(int oop_id) {
   assert(oop_id >= 0 && (size_t)oop_id < _oop_handle_info.size(), "unknown oop id");
   return _oop_handle_info[oop_id].name;

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.hpp
@@ -258,6 +258,7 @@ class JeandleCompiledCode : public StackObj {
 
   int find_or_insert_oop(ciObject* oop);
   ciObject* oop_at(int oop_id);
+  ciObject* oop_for_handle_name(llvm::StringRef name);
   std::string oop_handle_name(int oop_id);
   // StringMap entries are individually heap-allocated and never relocated on
   // insertion, so their keys stay valid for the life of this JeandleCompiledCode

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -34,11 +34,15 @@
 #include "jeandle/jeandleUtils.hpp"
 
 #include "jeandle/__hotspotHeadersBegin__.hpp"
+#include "ci/ciEnv.hpp"
 #include "ci/ciField.hpp"
+#include "ci/ciInstance.hpp"
 #include "ci/ciInstanceKlass.hpp"
+#include "ci/ciKlass.hpp"
 #include "ci/ciMethod.hpp"
 #include "ci/ciSignature.hpp"
 #include "ci/ciSymbol.hpp"
+#include "classfile/vmClasses.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/vmIntrinsics.hpp"
 #include "jeandle/jeandle_globals.hpp"
@@ -78,6 +82,67 @@ void apply_memory_attr(llvm::CallBase* call, const CallSiteAttributeMetadata& at
   } else if (!reads && writes) {
     call->setOnlyWritesMemory();       // memory(write)
   }
+}
+
+static Klass* exact_java_klass_metadata(llvm::Value* value) {
+  llvm::Argument* argument = llvm::dyn_cast<llvm::Argument>(value);
+  if (argument != nullptr) {
+    llvm::AttributeList attrs = argument->getParent()->getAttributes();
+    unsigned arg_no = argument->getArgNo();
+    if (!attrs.hasParamAttr(arg_no, llvm::jeandle::Attribute::JavaKlassExact)) {
+      return nullptr;
+    }
+    llvm::Attribute klass_attr =
+        attrs.getParamAttr(arg_no, llvm::jeandle::Attribute::JavaKlass);
+    if (!klass_attr.isValid()) {
+      return nullptr;
+    }
+    uint64_t klass_value = 0;
+    if (klass_attr.getValueAsString().getAsInteger(10, klass_value)) {
+      return nullptr;
+    }
+    return reinterpret_cast<Klass*>(klass_value);
+  }
+
+  llvm::CallBase* call = llvm::dyn_cast<llvm::CallBase>(value);
+  if (call != nullptr) {
+    if (!call->hasRetAttr(llvm::jeandle::Attribute::JavaKlassExact)) {
+      return nullptr;
+    }
+    llvm::Attribute klass_attr =
+        call->getAttributeAtIndex(llvm::AttributeList::ReturnIndex,
+                                  llvm::jeandle::Attribute::JavaKlass);
+    if (!klass_attr.isValid()) {
+      return nullptr;
+    }
+    uint64_t klass_value = 0;
+    if (klass_attr.getValueAsString().getAsInteger(10, klass_value)) {
+      return nullptr;
+    }
+    return reinterpret_cast<Klass*>(klass_value);
+  }
+
+  llvm::LoadInst* load = llvm::dyn_cast<llvm::LoadInst>(value);
+  if (load == nullptr ||
+      load->getMetadata(llvm::jeandle::Metadata::JavaKlassExact) == nullptr) {
+    return nullptr;
+  }
+  llvm::MDNode* klass_md =
+      load->getMetadata(llvm::jeandle::Metadata::JavaKlass);
+  if (klass_md == nullptr || klass_md->getNumOperands() != 1) {
+    return nullptr;
+  }
+  llvm::Metadata* md = klass_md->getOperand(0).get();
+  llvm::ConstantAsMetadata* constant_md =
+      llvm::dyn_cast<llvm::ConstantAsMetadata>(md);
+  if (constant_md == nullptr) {
+    return nullptr;
+  }
+  llvm::ConstantInt* klass_value =
+      llvm::dyn_cast<llvm::ConstantInt>(constant_md->getValue());
+  return klass_value == nullptr
+      ? nullptr
+      : reinterpret_cast<Klass*>(klass_value->getZExtValue());
 }
 
 // =============================================================================
@@ -174,6 +239,18 @@ bool JeandleIntrinsicLowering::is_supported(vmIntrinsics::ID id) {
     // getClass
     case vmIntrinsics::_getClass:
 
+    // Class queries (the same family as C2's inline_native_Class_query)
+    case vmIntrinsics::_isInstance:
+    case vmIntrinsics::_getModifiers:
+    case vmIntrinsics::_isArray:
+    case vmIntrinsics::_isPrimitive:
+    case vmIntrinsics::_isInterface:
+    case vmIntrinsics::_isHidden:
+    case vmIntrinsics::_getSuperclass:
+    case vmIntrinsics::_getClassAccessFlags:
+    case vmIntrinsics::_Class_cast:
+    case vmIntrinsics::_isAssignableFrom:
+
     // currentThread
     case vmIntrinsics::_currentThread:
 
@@ -187,7 +264,7 @@ bool JeandleIntrinsicLowering::is_supported(vmIntrinsics::ID id) {
 
     // Unsafe.allocateInstance
     case vmIntrinsics::_allocateInstance:
-    
+
     // bitcast
     case vmIntrinsics::_floatToRawIntBits:
     case vmIntrinsics::_intBitsToFloat:
@@ -442,6 +519,21 @@ bool JeandleIntrinsicLowering::lower(vmIntrinsics::ID id, const ciMethod* target
     case vmIntrinsics::_currentThread:
       return lower_java_op("jeandle.current_thread_obj",
                            {CTRL_NONE, MEM_READ});
+
+    // Class queries
+    case vmIntrinsics::_isInstance:
+    case vmIntrinsics::_getModifiers:
+    case vmIntrinsics::_isArray:
+    case vmIntrinsics::_isPrimitive:
+    case vmIntrinsics::_isInterface:
+    case vmIntrinsics::_isHidden:
+    case vmIntrinsics::_getSuperclass:
+    case vmIntrinsics::_getClassAccessFlags:
+      return lower_class_query(id);
+    case vmIntrinsics::_Class_cast:
+      return lower_class_cast();
+    case vmIntrinsics::_isAssignableFrom:
+      return lower_class_is_assignable_from();
 
     // Reference*
     case vmIntrinsics::_Reference_get:
@@ -827,6 +919,689 @@ bool JeandleIntrinsicLowering::lower_java_op(const char* java_op_name,
 // =============================================================================
 // Per-intrinsic handlers
 // =============================================================================
+
+llvm::Value* JeandleIntrinsicLowering::emit_direct_mirror_from_klass(
+    llvm::Value* klass, const char* name_prefix) {
+  llvm::IRBuilder<>& b = _interp->_ir_builder;
+  llvm::PointerType* c_heap = llvm::PointerType::get(*_interp->_context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::PointerType* java_heap = llvm::PointerType::get(*_interp->_context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace);
+  llvm::GlobalVariable* offset_gv =
+      _interp->_module.getGlobalVariable("Klass.java_mirror_offset", true);
+  assert(offset_gv != nullptr, "Klass.java_mirror_offset global must exist");
+  llvm::Value* offset = b.CreateLoad(b.getInt32Ty(), offset_gv);
+  llvm::Value* handle_addr = b.CreateInBoundsGEP(b.getInt8Ty(), klass, offset,
+                                                 std::string(name_prefix) + ".handle_addr");
+  llvm::LoadInst* handle = b.CreateLoad(c_heap, handle_addr, std::string(name_prefix) + ".handle");
+  handle->setAtomic(llvm::AtomicOrdering::Unordered);
+  handle->setAlignment(llvm::Align(sizeof(void*)));
+  llvm::LoadInst* mirror = b.CreateLoad(java_heap, handle, std::string(name_prefix) + ".mirror");
+  mirror->setAtomic(llvm::AtomicOrdering::Unordered);
+  mirror->setAlignment(llvm::Align(sizeof(void*)));
+  return mirror;
+}
+
+ciObject* JeandleIntrinsicLowering::constant_oop(llvm::Value* value) const {
+  llvm::LoadInst* load = llvm::dyn_cast<llvm::LoadInst>(value);
+  if (load == nullptr) {
+    return nullptr;
+  }
+  llvm::Value* address = load->getPointerOperand()->stripPointerCasts();
+  llvm::GlobalVariable* handle = llvm::dyn_cast<llvm::GlobalVariable>(address);
+  if (handle == nullptr) {
+    return nullptr;
+  }
+  return _interp->_compiled_code.oop_for_handle_name(handle->getName());
+}
+
+ciType* JeandleIntrinsicLowering::constant_class_type(llvm::Value* mirror) const {
+  ciObject* mirror_object = constant_oop(mirror);
+  if (mirror_object == nullptr || !mirror_object->is_instance()) {
+    return nullptr;
+  }
+  return mirror_object->as_instance()->java_mirror_type();
+}
+
+llvm::Value* JeandleIntrinsicLowering::constant_klass_value(ciKlass* klass) const {
+  assert(klass != nullptr && klass->is_loaded(), "klass must be loaded");
+  ciEnv* env = ciEnv::current();
+  assert(env != nullptr && env->oop_recorder() != nullptr,
+         "constant klass requires an active oop recorder");
+  env->oop_recorder()->find_index(klass->constant_encoding());
+  llvm::PointerType* klass_type = llvm::PointerType::get(
+      *_interp->_context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  return _interp->_ir_builder.CreateIntToPtr(
+      _interp->_ir_builder.getInt64(
+          reinterpret_cast<intptr_t>(klass->constant_encoding())),
+      klass_type, "class.constant.klass");
+}
+
+bool JeandleIntrinsicLowering::try_fold_constant_class_query(
+    vmIntrinsics::ID id, llvm::Value* mirror, jint* result) const {
+  ciType* mirror_type = constant_class_type(mirror);
+  if (mirror_type == nullptr) {
+    return false;
+  }
+
+  if (mirror_type->is_primitive_type()) {
+    switch (id) {
+      case vmIntrinsics::_isPrimitive:
+        *result = 1;
+        return true;
+      case vmIntrinsics::_isArray:
+      case vmIntrinsics::_isInterface:
+      case vmIntrinsics::_isHidden:
+        *result = 0;
+        return true;
+      case vmIntrinsics::_getModifiers:
+      case vmIntrinsics::_getClassAccessFlags:
+        *result = JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC;
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  if (!mirror_type->is_klass() || !mirror_type->is_loaded()) {
+    return false;
+  }
+  ciKlass* klass = mirror_type->as_klass();
+  switch (id) {
+    case vmIntrinsics::_isPrimitive:
+      *result = 0;
+      return true;
+    case vmIntrinsics::_isArray:
+      *result = klass->is_array_klass() ? 1 : 0;
+      return true;
+    case vmIntrinsics::_isInterface:
+      *result = klass->is_interface() ? 1 : 0;
+      return true;
+    case vmIntrinsics::_isHidden:
+      *result = klass->is_instance_klass() &&
+                        klass->as_instance_klass()->is_hidden()
+                    ? 1
+                    : 0;
+      return true;
+    case vmIntrinsics::_getModifiers:
+      *result = klass->modifier_flags();
+      return true;
+    case vmIntrinsics::_getClassAccessFlags:
+      *result = klass->access_flags();
+      return true;
+    default:
+      return false;
+  }
+}
+
+// ---- lower_class_query ----
+//
+// Keep the C2 inline_native_Class_query family under one dispatcher, but split
+// the implementation by operand-stack shape and result type.  This avoids a
+// boolean-only monolith while preserving the shared Class-mirror model.
+bool JeandleIntrinsicLowering::lower_class_query(vmIntrinsics::ID id) {
+  switch (id) {
+    case vmIntrinsics::_isArray:
+    case vmIntrinsics::_isPrimitive:
+    case vmIntrinsics::_isInterface:
+    case vmIntrinsics::_isHidden:
+      return lower_class_boolean_query(id);
+    case vmIntrinsics::_getModifiers:
+    case vmIntrinsics::_getClassAccessFlags:
+      return lower_class_flags_query(id);
+    case vmIntrinsics::_isInstance:
+      return lower_class_is_instance();
+    case vmIntrinsics::_getSuperclass:
+      return lower_class_get_superclass();
+    default:
+      ShouldNotReachHere();
+      return false;
+  }
+}
+
+bool JeandleIntrinsicLowering::lower_class_cast() {
+  llvm::LLVMContext& ctx = *_interp->_context;
+  llvm::IRBuilder<>& builder = _interp->_ir_builder;
+  llvm::Value* object = _interp->_jvm->raw_peek(0).value();
+  llvm::Value* mirror = _interp->_jvm->raw_peek(1).value();
+  ciType* mirror_type = constant_class_type(mirror);
+  if (mirror_type != nullptr && mirror_type->is_primitive_type()) {
+    llvm::Value* is_null = builder.CreateICmpEQ(
+        object, llvm::ConstantPointerNull::get(
+                    llvm::cast<llvm::PointerType>(object->getType())),
+        "class.cast.is_null");
+    llvm::BasicBlock* pass =
+        llvm::BasicBlock::Create(ctx, "class_cast_pass", _interp->_llvm_func);
+    llvm::BasicBlock* fail =
+        llvm::BasicBlock::Create(ctx, "class_cast_fail", _interp->_llvm_func);
+    builder.CreateCondBr(is_null, pass, fail);
+    _interp->uncommon_trap(Deoptimization::Reason_intrinsic,
+                           Deoptimization::Action_maybe_recompile, fail);
+    builder.SetInsertPoint(pass);
+    _interp->_block->set_tail_llvm_block(pass);
+    _interp->_jvm->apop();
+    _interp->_jvm->apop();
+    _interp->_jvm->push(T_OBJECT, object);
+    return true;
+  }
+
+  if (mirror_type != nullptr && mirror_type->is_klass() && mirror_type->is_loaded()) {
+    Klass* target_klass = reinterpret_cast<Klass*>(mirror_type->as_klass()->constant_encoding());
+    Klass* object_klass = exact_java_klass_metadata(object);
+    if (object_klass != nullptr) {
+      if (object_klass->is_subtype_of(target_klass)) {
+        _interp->_jvm->apop();
+        _interp->_jvm->apop();
+        _interp->_jvm->push(T_OBJECT, object);
+        return true;
+      }
+      return false;
+    }
+  }
+
+  llvm::Value *klass =
+      mirror_type != nullptr && mirror_type->is_klass() &&
+              mirror_type->is_loaded()
+          ? constant_klass_value(mirror_type->as_klass())
+          : _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  llvm::PointerType* klass_ty =
+      llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::Value* is_primitive = builder.CreateICmpEQ(
+      klass, llvm::ConstantPointerNull::get(klass_ty), "class.cast.is_primitive");
+  llvm::Value* is_null = builder.CreateICmpEQ(
+      object, llvm::ConstantPointerNull::get(
+                  llvm::cast<llvm::PointerType>(object->getType())),
+      "class.cast.is_null");
+
+  llvm::BasicBlock* check =
+      llvm::BasicBlock::Create(ctx, "class_cast_check", _interp->_llvm_func);
+  llvm::BasicBlock* pass =
+      llvm::BasicBlock::Create(ctx, "class_cast_pass", _interp->_llvm_func);
+  llvm::BasicBlock* fail =
+      llvm::BasicBlock::Create(ctx, "class_cast_fail", _interp->_llvm_func);
+  llvm::BasicBlock* non_null =
+      llvm::BasicBlock::Create(ctx, "class_cast_non_null", _interp->_llvm_func);
+  builder.CreateCondBr(is_null, pass, non_null);
+
+  builder.SetInsertPoint(non_null);
+  builder.CreateCondBr(is_primitive, fail, check);
+
+  builder.SetInsertPoint(check);
+  llvm::Value* ok =
+      _interp->call_java_op("jeandle.check_instanceof", {klass, object});
+  builder.CreateCondBr(ok, pass, fail);
+
+  _interp->uncommon_trap(Deoptimization::Reason_intrinsic,
+                         Deoptimization::Action_maybe_recompile, fail);
+  builder.SetInsertPoint(pass);
+  _interp->_block->set_tail_llvm_block(pass);
+  _interp->_jvm->apop();
+  _interp->_jvm->apop();
+  _interp->_jvm->push(T_OBJECT, object);
+  return true;
+}
+
+bool JeandleIntrinsicLowering::lower_class_is_assignable_from() {
+  llvm::LLVMContext& ctx = *_interp->_context;
+  llvm::IRBuilder<>& builder = _interp->_ir_builder;
+  llvm::Value* sub_mirror = _interp->_jvm->raw_peek(0).value();
+  llvm::Value* super_mirror = _interp->_jvm->raw_peek(1).value();
+  // Both operands are dereferenced below. Preserve Class.isAssignableFrom's
+  // Java NPE contract before loading the mirror Klass fields.
+  _interp->null_check(super_mirror);
+  _interp->null_check(sub_mirror);
+  ciType* super_type = constant_class_type(super_mirror);
+  ciType* sub_type = constant_class_type(sub_mirror);
+  if (super_type != nullptr && sub_type != nullptr) {
+    bool foldable = true;
+    bool result = false;
+    if (super_type->is_primitive_type() || sub_type->is_primitive_type()) {
+      result = super_type == sub_type;
+    } else if (super_type->is_klass() && sub_type->is_klass() &&
+               super_type->is_loaded() && sub_type->is_loaded()) {
+      result = sub_type->as_klass()->is_subtype_of(super_type->as_klass());
+    } else {
+      foldable = false;
+    }
+    if (foldable) {
+      _interp->_jvm->apop();
+      _interp->_jvm->apop();
+      _interp->_jvm->ipush(builder.getInt32(result ? 1 : 0));
+      return true;
+    }
+  }
+
+  llvm::PointerType* klass_ty =
+      llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::Constant* null_klass = llvm::ConstantPointerNull::get(klass_ty);
+  llvm::Value *super_klass =
+      super_type != nullptr && super_type->is_primitive_type() ? null_klass
+      : super_type != nullptr && super_type->is_klass() &&
+              super_type->is_loaded()
+          ? constant_klass_value(super_type->as_klass())
+          : _interp->call_java_op("jeandle.load_mirror_klass",
+                                  {super_mirror});
+  llvm::Value *sub_klass =
+      sub_type != nullptr && sub_type->is_primitive_type() ? null_klass
+      : sub_type != nullptr && sub_type->is_klass() && sub_type->is_loaded()
+          ? constant_klass_value(sub_type->as_klass())
+          : _interp->call_java_op("jeandle.load_mirror_klass",
+                                  {sub_mirror});
+  llvm::Value* super_primitive = builder.CreateICmpEQ(
+      super_klass, null_klass,
+      "class.assignable.super_primitive");
+  llvm::Value* sub_primitive = builder.CreateICmpEQ(
+      sub_klass, null_klass,
+      "class.assignable.sub_primitive");
+  llvm::Value* any_primitive = builder.CreateOr(
+      super_primitive, sub_primitive, "class.assignable.any_primitive");
+  llvm::Value* same_mirror = builder.CreateICmpEQ(
+      super_mirror, sub_mirror, "class.assignable.same_primitive");
+  llvm::Value* both_primitive = builder.CreateAnd(
+      super_primitive, sub_primitive, "class.assignable.both_primitive");
+  llvm::Value* primitive_result = builder.CreateAnd(
+      both_primitive, same_mirror, "class.assignable.primitive_result");
+
+  llvm::BasicBlock* primitive = builder.GetInsertBlock();
+  llvm::BasicBlock* reference =
+      llvm::BasicBlock::Create(ctx, "class_assignable_reference", _interp->_llvm_func);
+  llvm::BasicBlock* merge =
+      llvm::BasicBlock::Create(ctx, "class_assignable_merge", _interp->_llvm_func);
+  builder.CreateCondBr(any_primitive, merge, reference);
+
+  builder.SetInsertPoint(reference);
+  llvm::Value* subtype = _interp->call_java_op(
+      "jeandle.check_klass_subtype", {sub_klass, super_klass});
+  builder.CreateBr(merge);
+  llvm::BasicBlock* reference_end = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(merge);
+  _interp->_block->set_tail_llvm_block(merge);
+  llvm::PHINode* result = builder.CreatePHI(builder.getInt1Ty(), 2,
+                                             "class.assignable.result");
+  result->addIncoming(primitive_result, primitive);
+  result->addIncoming(subtype, reference_end);
+  _interp->_jvm->apop();
+  _interp->_jvm->apop();
+  _interp->_jvm->ipush(builder.CreateZExt(result, builder.getInt32Ty()));
+  return true;
+}
+
+// Class mirrors for primitive types (including void.class) have a null
+// java_lang_Class::_klass field. Reference and array mirrors point to their
+// Klass metadata.
+bool JeandleIntrinsicLowering::lower_class_boolean_query(vmIntrinsics::ID id) {
+  assert(id == vmIntrinsics::_isArray ||
+         id == vmIntrinsics::_isPrimitive ||
+         id == vmIntrinsics::_isInterface ||
+         id == vmIntrinsics::_isHidden, "unexpected Class query intrinsic");
+
+  llvm::LLVMContext& ctx = *_interp->_context;
+  llvm::IRBuilder<>& builder = _interp->_ir_builder;
+
+  // Physical JVM slot map, top to bottom:
+  //   raw depth 0: java.lang.Class receiver
+  llvm::Value* mirror = _interp->_jvm->raw_peek(0).value();
+  jint constant_result = 0;
+  if (try_fold_constant_class_query(id, mirror, &constant_result)) {
+    _interp->_jvm->apop();
+    _interp->_jvm->ipush(builder.getInt32(constant_result));
+    return true;
+  }
+
+  llvm::CallInst* klass =
+      _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  klass->setName("class.query.klass");
+
+  llvm::PointerType* c_heap_ptr_ty =
+      llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::Value* is_primitive = builder.CreateICmpEQ(
+      klass, llvm::ConstantPointerNull::get(c_heap_ptr_ty), "class.query.is_primitive");
+
+  if (id == vmIntrinsics::_isPrimitive) {
+    _interp->_jvm->apop();
+    _interp->_jvm->ipush(builder.CreateZExt(is_primitive, builder.getInt32Ty(),
+                                            "class.query.result"));
+    return true;
+  }
+
+  _interp->_jvm->apop();
+  llvm::BasicBlock* primitive_bb = builder.GetInsertBlock();
+  llvm::BasicBlock* query_bb =
+      llvm::BasicBlock::Create(ctx, "class_query_non_primitive", _interp->_llvm_func);
+  llvm::BasicBlock* merge_bb =
+      llvm::BasicBlock::Create(ctx, "class_query_merge", _interp->_llvm_func);
+  builder.CreateCondBr(is_primitive, merge_bb, query_bb);
+
+  builder.SetInsertPoint(query_bb);
+  llvm::Value* query_result = nullptr;
+  switch (id) {
+    case vmIntrinsics::_isArray: {
+      llvm::CallInst* layout_helper =
+          _interp->call_java_op("jeandle.layout_helper", {klass});
+      layout_helper->setName("class.query.layout_helper");
+      query_result = builder.CreateICmpSLT(
+          layout_helper, builder.getInt32(Klass::_lh_neutral_value), "class.query.is_array");
+      break;
+    }
+    case vmIntrinsics::_isInterface:
+    case vmIntrinsics::_isHidden: {
+      llvm::Value* access_flags_addr = builder.CreateInBoundsGEP(
+          builder.getInt8Ty(), klass,
+          builder.getInt32(in_bytes(Klass::access_flags_offset())));
+      llvm::Value* access_flags =
+          builder.CreateLoad(builder.getInt32Ty(), access_flags_addr, "class.query.access_flags");
+      const jint flag = id == vmIntrinsics::_isInterface
+          ? static_cast<jint>(JVM_ACC_INTERFACE)
+          : static_cast<jint>(JVM_ACC_IS_HIDDEN_CLASS);
+      llvm::Value* masked = builder.CreateAnd(access_flags, builder.getInt32(flag));
+      query_result = builder.CreateICmpNE(masked, builder.getInt32(0), "class.query.flag_set");
+      break;
+    }
+    default:
+      ShouldNotReachHere();
+  }
+  llvm::Value* non_primitive_result =
+      builder.CreateZExt(query_result, builder.getInt32Ty(), "class.query.non_primitive_result");
+  builder.CreateBr(merge_bb);
+  llvm::BasicBlock* query_end_bb = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(merge_bb);
+  _interp->_block->set_tail_llvm_block(merge_bb);
+  llvm::PHINode* result = builder.CreatePHI(builder.getInt32Ty(), 2, "class.query.result");
+  result->addIncoming(builder.getInt32(0), primitive_bb);
+  result->addIncoming(non_primitive_result, query_end_bb);
+  _interp->_jvm->ipush(result);
+  return true;
+}
+
+// Class.getModifiers() and Reflection.getClassAccessFlags(Class) both return
+// an i32 flag word.  They share the primitive-mirror default and differ only
+// in the Klass field they expose.  The Reflection method is static, so it must
+// explicitly null-check its Class argument before directly loading from the
+// nonnull mirror.
+bool JeandleIntrinsicLowering::lower_class_flags_query(vmIntrinsics::ID id) {
+  assert(id == vmIntrinsics::_getModifiers ||
+         id == vmIntrinsics::_getClassAccessFlags,
+         "unexpected Class flags intrinsic");
+
+  llvm::LLVMContext& ctx = *_interp->_context;
+  llvm::IRBuilder<>& builder = _interp->_ir_builder;
+  llvm::Value* mirror = _interp->_jvm->raw_peek(0).value();
+
+  if (id == vmIntrinsics::_getClassAccessFlags) {
+    assert(_target->is_static(), "Reflection.getClassAccessFlags must be static");
+    _interp->null_check(mirror);
+  } else {
+    assert(!_target->is_static(), "Class.getModifiers must be an instance method");
+  }
+
+  jint constant_result = 0;
+  if (try_fold_constant_class_query(id, mirror, &constant_result)) {
+    _interp->_jvm->apop();
+    _interp->_jvm->ipush(builder.getInt32(constant_result));
+    return true;
+  }
+
+  llvm::CallInst* klass =
+      _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  klass->setName("class.flags.klass");
+  _interp->_jvm->apop();
+
+  llvm::PointerType* c_heap_ptr_ty =
+      llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::Value* is_primitive = builder.CreateICmpEQ(
+      klass, llvm::ConstantPointerNull::get(c_heap_ptr_ty),
+      "class.flags.is_primitive");
+
+  llvm::BasicBlock* primitive_bb = builder.GetInsertBlock();
+  llvm::BasicBlock* flags_bb =
+      llvm::BasicBlock::Create(ctx, "class_flags_non_primitive", _interp->_llvm_func);
+  llvm::BasicBlock* merge_bb =
+      llvm::BasicBlock::Create(ctx, "class_flags_merge", _interp->_llvm_func);
+  builder.CreateCondBr(is_primitive, merge_bb, flags_bb);
+
+  builder.SetInsertPoint(flags_bb);
+  const int flags_offset = id == vmIntrinsics::_getModifiers
+      ? in_bytes(Klass::modifier_flags_offset())
+      : in_bytes(Klass::access_flags_offset());
+  const char* addr_name = id == vmIntrinsics::_getModifiers
+      ? "class.modifiers.addr"
+      : "class.access_flags.addr";
+  const char* value_name = id == vmIntrinsics::_getModifiers
+      ? "class.modifiers.value"
+      : "class.access_flags.value";
+  llvm::Value* flags_addr = builder.CreateInBoundsGEP(
+      builder.getInt8Ty(), klass, builder.getInt32(flags_offset),
+      addr_name);
+  llvm::Value* flags =
+      builder.CreateLoad(builder.getInt32Ty(), flags_addr, value_name);
+  builder.CreateBr(merge_bb);
+  llvm::BasicBlock* flags_end_bb = builder.GetInsertBlock();
+
+  static constexpr jint primitive_flags =
+      static_cast<jint>(JVM_ACC_ABSTRACT) |
+      static_cast<jint>(JVM_ACC_FINAL) |
+      static_cast<jint>(JVM_ACC_PUBLIC);
+  builder.SetInsertPoint(merge_bb);
+  _interp->_block->set_tail_llvm_block(merge_bb);
+  llvm::PHINode* result =
+      builder.CreatePHI(builder.getInt32Ty(), 2, "class.flags.result");
+  result->addIncoming(builder.getInt32(primitive_flags), primitive_bb);
+  result->addIncoming(flags, flags_end_bb);
+  _interp->_jvm->ipush(result);
+  return true;
+}
+
+// Class.isInstance(Object) has a two-oop operand stack and a dynamic subtype
+// check. Its slow path may update Klass::_secondary_super_cache, but the
+// complete check is a GC leaf and cannot deopt or throw.
+bool JeandleIntrinsicLowering::lower_class_is_instance() {
+  assert(_target->intrinsic_id() == vmIntrinsics::_isInstance,
+         "unexpected Class.isInstance intrinsic");
+
+  llvm::LLVMContext& ctx = *_interp->_context;
+  llvm::IRBuilder<>& builder = _interp->_ir_builder;
+
+  // Physical JVM slot map, top to bottom:
+  //   raw depth 0: Object argument
+  //   raw depth 1: java.lang.Class receiver
+  llvm::Value* object = _interp->_jvm->raw_peek(0).value();
+  llvm::Value* mirror = _interp->_jvm->raw_peek(1).value();
+  ciType* mirror_type = constant_class_type(mirror);
+  if (mirror_type != nullptr && mirror_type->is_primitive_type()) {
+    _interp->_jvm->apop();
+    _interp->_jvm->apop();
+    _interp->_jvm->ipush(builder.getInt32(0));
+    return true;
+  }
+  if (mirror_type != nullptr && mirror_type->is_klass() && mirror_type->is_loaded()) {
+    Klass* target_klass = reinterpret_cast<Klass*>(mirror_type->as_klass()->constant_encoding());
+    Klass* object_klass = exact_java_klass_metadata(object);
+    if (object_klass != nullptr && object_klass->is_subtype_of(target_klass)) {
+      llvm::Value* is_null = builder.CreateICmpEQ(
+          object, llvm::ConstantPointerNull::get(
+                      llvm::cast<llvm::PointerType>(object->getType())),
+          "class.is_instance.is_null");
+      _interp->_jvm->apop();
+      _interp->_jvm->apop();
+      _interp->_jvm->ipush(builder.CreateZExt(
+          builder.CreateNot(is_null), builder.getInt32Ty(),
+          "class.is_instance.static_result"));
+      return true;
+    }
+    if (object_klass != nullptr) {
+      _interp->_jvm->apop();
+      _interp->_jvm->apop();
+      _interp->_jvm->ipush(builder.getInt32(0));
+      return true;
+    }
+  }
+  llvm::Value *klass =
+      mirror_type != nullptr && mirror_type->is_klass() &&
+              mirror_type->is_loaded()
+          ? constant_klass_value(mirror_type->as_klass())
+          : _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  klass->setName("class.is_instance.klass");
+
+  llvm::PointerType* c_heap_ptr_ty =
+      llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::Value* is_primitive = builder.CreateICmpEQ(
+      klass, llvm::ConstantPointerNull::get(c_heap_ptr_ty),
+      "class.is_instance.is_primitive");
+
+  llvm::BasicBlock* primitive_bb = builder.GetInsertBlock();
+  llvm::BasicBlock* instance_bb =
+      llvm::BasicBlock::Create(ctx, "class_is_instance_non_primitive", _interp->_llvm_func);
+  llvm::BasicBlock* merge_bb =
+      llvm::BasicBlock::Create(ctx, "class_is_instance_merge", _interp->_llvm_func);
+  builder.CreateCondBr(is_primitive, merge_bb, instance_bb);
+
+  builder.SetInsertPoint(instance_bb);
+  llvm::Value* instance_result =
+      _interp->call_java_op("jeandle.instanceof", {klass, object});
+  builder.CreateBr(merge_bb);
+  llvm::BasicBlock* instance_end_bb = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(merge_bb);
+  _interp->_block->set_tail_llvm_block(merge_bb);
+  llvm::PHINode* result =
+      builder.CreatePHI(builder.getInt32Ty(), 2, "class.is_instance.result");
+  result->addIncoming(builder.getInt32(0), primitive_bb);
+  result->addIncoming(instance_result, instance_end_bb);
+
+  _interp->_jvm->apop(); // object
+  _interp->_jvm->apop(); // Class receiver
+  _interp->_jvm->ipush(result);
+  return true;
+}
+
+// Class.getSuperclass() returns null for primitive/void mirrors, interfaces,
+// and Object; arrays report Object.class. Other classes expose the mirror of
+// Klass::_super through its OopHandle. The direct Java-heap load is relocated
+// by any later statepoint if its result remains live.
+bool JeandleIntrinsicLowering::lower_class_get_superclass() {
+  assert(_target->intrinsic_id() == vmIntrinsics::_getSuperclass,
+         "unexpected Class.getSuperclass intrinsic");
+
+  llvm::LLVMContext& ctx = *_interp->_context;
+  llvm::IRBuilder<>& builder = _interp->_ir_builder;
+  llvm::Value* mirror = _interp->_jvm->raw_peek(0).value();
+  ciType* mirror_type = constant_class_type(mirror);
+  if (mirror_type != nullptr) {
+    ciInstance* result_mirror = nullptr;
+    if (mirror_type->is_klass() && mirror_type->is_loaded()) {
+      ciKlass* klass = mirror_type->as_klass();
+      if (klass->is_array_klass()) {
+        result_mirror = ciEnv::current()->Object_klass()->java_mirror();
+      } else if (!klass->is_interface() && klass->is_instance_klass()) {
+        ciInstanceKlass* super = klass->as_instance_klass()->super();
+        if (super != nullptr) {
+          result_mirror = super->java_mirror();
+        }
+      }
+    }
+    llvm::Value* result = result_mirror == nullptr
+        ? llvm::ConstantPointerNull::get(llvm::PointerType::get(
+              ctx, llvm::jeandle::AddrSpace::JavaHeapAddrSpace))
+        : _interp->constant_to_value(ciConstant(T_OBJECT, result_mirror)).value();
+    _interp->_jvm->apop();
+    _interp->_jvm->apush(result);
+    return true;
+  }
+
+  llvm::CallInst *klass =
+      _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  klass->setName("class.super.klass_from_mirror");
+
+  llvm::PointerType* c_heap_ptr_ty =
+      llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::PointerType* java_heap_ptr_ty =
+      llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::JavaHeapAddrSpace);
+  llvm::Constant* null_klass = llvm::ConstantPointerNull::get(c_heap_ptr_ty);
+  llvm::Constant* null_mirror = llvm::ConstantPointerNull::get(java_heap_ptr_ty);
+  llvm::Value* is_primitive = builder.CreateICmpEQ(
+      klass, null_klass, "class.super.is_primitive");
+
+  llvm::BasicBlock* non_primitive_bb =
+      llvm::BasicBlock::Create(ctx, "class_super_non_primitive", _interp->_llvm_func);
+  llvm::BasicBlock* null_result_bb =
+      llvm::BasicBlock::Create(ctx, "class_super_null", _interp->_llvm_func);
+  llvm::BasicBlock* load_mirror_bb =
+      llvm::BasicBlock::Create(ctx, "class_super_load_mirror", _interp->_llvm_func);
+  llvm::BasicBlock* merge_bb =
+      llvm::BasicBlock::Create(ctx, "class_super_merge", _interp->_llvm_func);
+  builder.CreateCondBr(is_primitive, null_result_bb, non_primitive_bb);
+
+  builder.SetInsertPoint(non_primitive_bb);
+  llvm::Value* access_flags_addr = builder.CreateInBoundsGEP(
+      builder.getInt8Ty(), klass,
+      builder.getInt32(in_bytes(Klass::access_flags_offset())),
+      "class.super.access_flags_addr");
+  llvm::Value* access_flags = builder.CreateLoad(
+      builder.getInt32Ty(), access_flags_addr, "class.super.access_flags");
+  llvm::Value* interface_bits = builder.CreateAnd(
+      access_flags, builder.getInt32(static_cast<jint>(JVM_ACC_INTERFACE)),
+      "class.super.interface_bits");
+  llvm::Value* is_interface = builder.CreateICmpNE(
+      interface_bits, builder.getInt32(0), "class.super.is_interface");
+
+  llvm::CallInst* layout_helper =
+      _interp->call_java_op("jeandle.layout_helper", {klass});
+  layout_helper->setName("class.super.layout_helper");
+  llvm::Value* is_array = builder.CreateICmpSLT(
+      layout_helper, builder.getInt32(Klass::_lh_neutral_value),
+      "class.super.is_array");
+
+  // Match C2's generate_interface_guard/generate_array_guard shape: do not
+  // load Klass::_super on interface or array paths.  Besides avoiding an
+  // unnecessary memory access, this keeps the common ordinary-class path
+  // independent from the special-case result selection.
+  llvm::BasicBlock* array_bb =
+      llvm::BasicBlock::Create(ctx, "class_super_array", _interp->_llvm_func);
+  llvm::BasicBlock* ordinary_bb =
+      llvm::BasicBlock::Create(ctx, "class_super_ordinary", _interp->_llvm_func);
+  builder.CreateCondBr(is_interface, null_result_bb, array_bb);
+
+  builder.SetInsertPoint(array_bb);
+  llvm::Value* object_klass = builder.CreateIntToPtr(
+      builder.getInt64(reinterpret_cast<intptr_t>(vmClasses::Object_klass())),
+      c_heap_ptr_ty, "class.super.object_klass");
+  builder.CreateCondBr(is_array, load_mirror_bb, ordinary_bb);
+
+  builder.SetInsertPoint(ordinary_bb);
+  llvm::Value* super_addr = builder.CreateInBoundsGEP(
+      builder.getInt8Ty(), klass,
+      builder.getInt32(in_bytes(Klass::super_offset())),
+      "class.super.addr");
+  llvm::Value* super_klass =
+      builder.CreateLoad(c_heap_ptr_ty, super_addr, "class.super.klass");
+  llvm::Value* has_super = builder.CreateICmpNE(
+      super_klass, null_klass, "class.super.has_super");
+  builder.CreateCondBr(has_super, load_mirror_bb, null_result_bb);
+
+  builder.SetInsertPoint(load_mirror_bb);
+  llvm::PHINode* target_klass = builder.CreatePHI(c_heap_ptr_ty, 2,
+                                                  "class.super.target_klass");
+  target_klass->addIncoming(object_klass, array_bb);
+  target_klass->addIncoming(super_klass, ordinary_bb);
+  llvm::Value* superclass_mirror =
+      emit_direct_mirror_from_klass(target_klass, "class.super.mirror");
+  builder.CreateBr(merge_bb);
+  llvm::BasicBlock* mirror_end_bb = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(null_result_bb);
+  builder.CreateBr(merge_bb);
+
+  builder.SetInsertPoint(merge_bb);
+  _interp->_block->set_tail_llvm_block(merge_bb);
+  llvm::PHINode* result =
+      builder.CreatePHI(java_heap_ptr_ty, 2, "class.super.result");
+  result->addIncoming(null_mirror, null_result_bb);
+  result->addIncoming(superclass_mirror, mirror_end_bb);
+
+  _interp->_jvm->apop();
+  _interp->_jvm->apush(result);
+  return true;
+}
 
 // ---- lower_llvm_bitcast ----
 bool JeandleIntrinsicLowering::lower_llvm_bitcast() {

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.cpp
@@ -84,67 +84,6 @@ void apply_memory_attr(llvm::CallBase* call, const CallSiteAttributeMetadata& at
   }
 }
 
-static Klass* exact_java_klass_metadata(llvm::Value* value) {
-  llvm::Argument* argument = llvm::dyn_cast<llvm::Argument>(value);
-  if (argument != nullptr) {
-    llvm::AttributeList attrs = argument->getParent()->getAttributes();
-    unsigned arg_no = argument->getArgNo();
-    if (!attrs.hasParamAttr(arg_no, llvm::jeandle::Attribute::JavaKlassExact)) {
-      return nullptr;
-    }
-    llvm::Attribute klass_attr =
-        attrs.getParamAttr(arg_no, llvm::jeandle::Attribute::JavaKlass);
-    if (!klass_attr.isValid()) {
-      return nullptr;
-    }
-    uint64_t klass_value = 0;
-    if (klass_attr.getValueAsString().getAsInteger(10, klass_value)) {
-      return nullptr;
-    }
-    return reinterpret_cast<Klass*>(klass_value);
-  }
-
-  llvm::CallBase* call = llvm::dyn_cast<llvm::CallBase>(value);
-  if (call != nullptr) {
-    if (!call->hasRetAttr(llvm::jeandle::Attribute::JavaKlassExact)) {
-      return nullptr;
-    }
-    llvm::Attribute klass_attr =
-        call->getAttributeAtIndex(llvm::AttributeList::ReturnIndex,
-                                  llvm::jeandle::Attribute::JavaKlass);
-    if (!klass_attr.isValid()) {
-      return nullptr;
-    }
-    uint64_t klass_value = 0;
-    if (klass_attr.getValueAsString().getAsInteger(10, klass_value)) {
-      return nullptr;
-    }
-    return reinterpret_cast<Klass*>(klass_value);
-  }
-
-  llvm::LoadInst* load = llvm::dyn_cast<llvm::LoadInst>(value);
-  if (load == nullptr ||
-      load->getMetadata(llvm::jeandle::Metadata::JavaKlassExact) == nullptr) {
-    return nullptr;
-  }
-  llvm::MDNode* klass_md =
-      load->getMetadata(llvm::jeandle::Metadata::JavaKlass);
-  if (klass_md == nullptr || klass_md->getNumOperands() != 1) {
-    return nullptr;
-  }
-  llvm::Metadata* md = klass_md->getOperand(0).get();
-  llvm::ConstantAsMetadata* constant_md =
-      llvm::dyn_cast<llvm::ConstantAsMetadata>(md);
-  if (constant_md == nullptr) {
-    return nullptr;
-  }
-  llvm::ConstantInt* klass_value =
-      llvm::dyn_cast<llvm::ConstantInt>(constant_md->getValue());
-  return klass_value == nullptr
-      ? nullptr
-      : reinterpret_cast<Klass*>(klass_value->getZExtValue());
-}
-
 // =============================================================================
 // JeandleIntrinsicLowering — construction
 // =============================================================================
@@ -975,6 +914,21 @@ llvm::Value* JeandleIntrinsicLowering::constant_klass_value(ciKlass* klass) cons
       klass_type, "class.constant.klass");
 }
 
+llvm::Value* JeandleIntrinsicLowering::klass_value_for_mirror(
+    llvm::Value* mirror, ciType* mirror_type) const {
+  llvm::PointerType* klass_type = llvm::PointerType::get(
+      *_interp->_context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  if (mirror_type != nullptr) {
+    if (mirror_type->is_primitive_type()) {
+      return llvm::ConstantPointerNull::get(klass_type);
+    }
+    if (mirror_type->is_klass() && mirror_type->is_loaded()) {
+      return constant_klass_value(mirror_type->as_klass());
+    }
+  }
+  return _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+}
+
 bool JeandleIntrinsicLowering::try_fold_constant_class_query(
     vmIntrinsics::ID id, llvm::Value* mirror, jint* result) const {
   ciType* mirror_type = constant_class_type(mirror);
@@ -982,24 +936,6 @@ bool JeandleIntrinsicLowering::try_fold_constant_class_query(
     return false;
   }
 
-  if (mirror_type->is_primitive_type()) {
-    switch (id) {
-      case vmIntrinsics::_isPrimitive:
-        *result = 1;
-        return true;
-      case vmIntrinsics::_isArray:
-      case vmIntrinsics::_isInterface:
-      case vmIntrinsics::_isHidden:
-        *result = 0;
-        return true;
-      case vmIntrinsics::_getModifiers:
-      case vmIntrinsics::_getClassAccessFlags:
-        *result = JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC;
-        return true;
-      default:
-        return false;
-    }
-  }
 
   if (!mirror_type->is_klass() || !mirror_type->is_loaded()) {
     return false;
@@ -1063,45 +999,7 @@ bool JeandleIntrinsicLowering::lower_class_cast() {
   llvm::Value* object = _interp->_jvm->raw_peek(0).value();
   llvm::Value* mirror = _interp->_jvm->raw_peek(1).value();
   ciType* mirror_type = constant_class_type(mirror);
-  if (mirror_type != nullptr && mirror_type->is_primitive_type()) {
-    llvm::Value* is_null = builder.CreateICmpEQ(
-        object, llvm::ConstantPointerNull::get(
-                    llvm::cast<llvm::PointerType>(object->getType())),
-        "class.cast.is_null");
-    llvm::BasicBlock* pass =
-        llvm::BasicBlock::Create(ctx, "class_cast_pass", _interp->_llvm_func);
-    llvm::BasicBlock* fail =
-        llvm::BasicBlock::Create(ctx, "class_cast_fail", _interp->_llvm_func);
-    builder.CreateCondBr(is_null, pass, fail);
-    _interp->uncommon_trap(Deoptimization::Reason_intrinsic,
-                           Deoptimization::Action_maybe_recompile, fail);
-    builder.SetInsertPoint(pass);
-    _interp->_block->set_tail_llvm_block(pass);
-    _interp->_jvm->apop();
-    _interp->_jvm->apop();
-    _interp->_jvm->push(T_OBJECT, object);
-    return true;
-  }
-
-  if (mirror_type != nullptr && mirror_type->is_klass() && mirror_type->is_loaded()) {
-    Klass* target_klass = reinterpret_cast<Klass*>(mirror_type->as_klass()->constant_encoding());
-    Klass* object_klass = exact_java_klass_metadata(object);
-    if (object_klass != nullptr) {
-      if (object_klass->is_subtype_of(target_klass)) {
-        _interp->_jvm->apop();
-        _interp->_jvm->apop();
-        _interp->_jvm->push(T_OBJECT, object);
-        return true;
-      }
-      return false;
-    }
-  }
-
-  llvm::Value *klass =
-      mirror_type != nullptr && mirror_type->is_klass() &&
-              mirror_type->is_loaded()
-          ? constant_klass_value(mirror_type->as_klass())
-          : _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  llvm::Value* klass = klass_value_for_mirror(mirror, mirror_type);
   llvm::PointerType* klass_ty =
       llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::CHeapAddrSpace);
   llvm::Value* is_primitive = builder.CreateICmpEQ(
@@ -1172,19 +1070,10 @@ bool JeandleIntrinsicLowering::lower_class_is_assignable_from() {
   llvm::PointerType* klass_ty =
       llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::CHeapAddrSpace);
   llvm::Constant* null_klass = llvm::ConstantPointerNull::get(klass_ty);
-  llvm::Value *super_klass =
-      super_type != nullptr && super_type->is_primitive_type() ? null_klass
-      : super_type != nullptr && super_type->is_klass() &&
-              super_type->is_loaded()
-          ? constant_klass_value(super_type->as_klass())
-          : _interp->call_java_op("jeandle.load_mirror_klass",
-                                  {super_mirror});
-  llvm::Value *sub_klass =
-      sub_type != nullptr && sub_type->is_primitive_type() ? null_klass
-      : sub_type != nullptr && sub_type->is_klass() && sub_type->is_loaded()
-          ? constant_klass_value(sub_type->as_klass())
-          : _interp->call_java_op("jeandle.load_mirror_klass",
-                                  {sub_mirror});
+  llvm::Value* super_klass =
+      klass_value_for_mirror(super_mirror, super_type);
+  llvm::Value* sub_klass =
+      klass_value_for_mirror(sub_mirror, sub_type);
   llvm::Value* super_primitive = builder.CreateICmpEQ(
       super_klass, null_klass,
       "class.assignable.super_primitive");
@@ -1247,8 +1136,8 @@ bool JeandleIntrinsicLowering::lower_class_boolean_query(vmIntrinsics::ID id) {
     return true;
   }
 
-  llvm::CallInst* klass =
-      _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  ciType* mirror_type = constant_class_type(mirror);
+  llvm::Value* klass = klass_value_for_mirror(mirror, mirror_type);
   klass->setName("class.query.klass");
 
   llvm::PointerType* c_heap_ptr_ty =
@@ -1341,8 +1230,8 @@ bool JeandleIntrinsicLowering::lower_class_flags_query(vmIntrinsics::ID id) {
     return true;
   }
 
-  llvm::CallInst* klass =
-      _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  ciType* mirror_type = constant_class_type(mirror);
+  llvm::Value* klass = klass_value_for_mirror(mirror, mirror_type);
   klass->setName("class.flags.klass");
   _interp->_jvm->apop();
 
@@ -1407,39 +1296,7 @@ bool JeandleIntrinsicLowering::lower_class_is_instance() {
   llvm::Value* object = _interp->_jvm->raw_peek(0).value();
   llvm::Value* mirror = _interp->_jvm->raw_peek(1).value();
   ciType* mirror_type = constant_class_type(mirror);
-  if (mirror_type != nullptr && mirror_type->is_primitive_type()) {
-    _interp->_jvm->apop();
-    _interp->_jvm->apop();
-    _interp->_jvm->ipush(builder.getInt32(0));
-    return true;
-  }
-  if (mirror_type != nullptr && mirror_type->is_klass() && mirror_type->is_loaded()) {
-    Klass* target_klass = reinterpret_cast<Klass*>(mirror_type->as_klass()->constant_encoding());
-    Klass* object_klass = exact_java_klass_metadata(object);
-    if (object_klass != nullptr && object_klass->is_subtype_of(target_klass)) {
-      llvm::Value* is_null = builder.CreateICmpEQ(
-          object, llvm::ConstantPointerNull::get(
-                      llvm::cast<llvm::PointerType>(object->getType())),
-          "class.is_instance.is_null");
-      _interp->_jvm->apop();
-      _interp->_jvm->apop();
-      _interp->_jvm->ipush(builder.CreateZExt(
-          builder.CreateNot(is_null), builder.getInt32Ty(),
-          "class.is_instance.static_result"));
-      return true;
-    }
-    if (object_klass != nullptr) {
-      _interp->_jvm->apop();
-      _interp->_jvm->apop();
-      _interp->_jvm->ipush(builder.getInt32(0));
-      return true;
-    }
-  }
-  llvm::Value *klass =
-      mirror_type != nullptr && mirror_type->is_klass() &&
-              mirror_type->is_loaded()
-          ? constant_klass_value(mirror_type->as_klass())
-          : _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
+  llvm::Value* klass = klass_value_for_mirror(mirror, mirror_type);
   klass->setName("class.is_instance.klass");
 
   llvm::PointerType* c_heap_ptr_ty =
@@ -1486,7 +1343,7 @@ bool JeandleIntrinsicLowering::lower_class_get_superclass() {
   llvm::IRBuilder<>& builder = _interp->_ir_builder;
   llvm::Value* mirror = _interp->_jvm->raw_peek(0).value();
   ciType* mirror_type = constant_class_type(mirror);
-  if (mirror_type != nullptr) {
+  if (mirror_type != nullptr && !mirror_type->is_primitive_type()) {
     ciInstance* result_mirror = nullptr;
     if (mirror_type->is_klass() && mirror_type->is_loaded()) {
       ciKlass* klass = mirror_type->as_klass();
@@ -1508,12 +1365,10 @@ bool JeandleIntrinsicLowering::lower_class_get_superclass() {
     return true;
   }
 
-  llvm::CallInst *klass =
-      _interp->call_java_op("jeandle.load_mirror_klass", {mirror});
-  klass->setName("class.super.klass_from_mirror");
-
   llvm::PointerType* c_heap_ptr_ty =
       llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::Value* klass = klass_value_for_mirror(mirror, mirror_type);
+  klass->setName("class.super.klass_from_mirror");
   llvm::PointerType* java_heap_ptr_ty =
       llvm::PointerType::get(ctx, llvm::jeandle::AddrSpace::JavaHeapAddrSpace);
   llvm::Constant* null_klass = llvm::ConstantPointerNull::get(c_heap_ptr_ty);

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
@@ -36,7 +36,10 @@
 #define PROB_FAIR               (0.5f)
 
 class JeandleAbstractInterpreter;
+class ciKlass;
 class ciMethod;
+class ciObject;
+class ciType;
 
 // =============================================================================
 // Control-flow facts for a lowered intrinsic call site. Combined into
@@ -189,6 +192,21 @@ class JeandleIntrinsicLowering : public StackObj {
   bool lower_preconditions_check_index(BasicType bt);
   bool lower_spin_wait_hint();       // arch-specific
   bool lower_compare_unsigned(vmIntrinsics::ID id);
+  llvm::Value* emit_direct_mirror_from_klass(llvm::Value* klass,
+                                             const char* name_prefix);
+  ciObject* constant_oop(llvm::Value* value) const;
+  ciType* constant_class_type(llvm::Value* mirror) const;
+  llvm::Value* constant_klass_value(ciKlass* klass) const;
+  bool try_fold_constant_class_query(vmIntrinsics::ID id,
+                                     llvm::Value* mirror,
+                                     jint* result) const;
+  bool lower_class_query(vmIntrinsics::ID id);
+  bool lower_class_cast();
+  bool lower_class_is_assignable_from();
+  bool lower_class_boolean_query(vmIntrinsics::ID id);
+  bool lower_class_flags_query(vmIntrinsics::ID id);
+  bool lower_class_is_instance();
+  bool lower_class_get_superclass();
   bool lower_exact_arith(vmIntrinsics::ID id, llvm::Intrinsic::ID overflow_id);
   bool lower_divide_unsigned(vmIntrinsics::ID id);
   bool lower_remainder_unsigned(vmIntrinsics::ID id);

--- a/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
+++ b/src/hotspot/share/jeandle/jeandleIntrinsicLowering.hpp
@@ -197,6 +197,8 @@ class JeandleIntrinsicLowering : public StackObj {
   ciObject* constant_oop(llvm::Value* value) const;
   ciType* constant_class_type(llvm::Value* mirror) const;
   llvm::Value* constant_klass_value(ciKlass* klass) const;
+  llvm::Value* klass_value_for_mirror(llvm::Value* mirror,
+                                      ciType* mirror_type) const;
   bool try_fold_constant_class_query(vmIntrinsics::ID id,
                                      llvm::Value* mirror,
                                      jint* result) const;

--- a/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
+++ b/src/hotspot/share/jeandle/templatemodule/jeandleRuntimeDefinedJavaOps.cpp
@@ -227,6 +227,33 @@ DEF_JAVA_OP(post_barrier, 9, llvm::Type::getVoidTy(context),
   ir_builder.CreateRetVoid();
 JAVA_OP_END
 
+// Load the java.lang.Class mirror rooted in a non-null Klass::_java_mirror
+// OopHandle.  Class.getSuperclass() uses this after choosing the semantic
+// superclass Klass (including Object for arrays).
+DEF_JAVA_OP(load_mirror_from_klass, 1,
+            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace),
+            llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace))
+  llvm::Value* klass = func->getArg(0);
+  llvm::GlobalVariable* mirror_offset_gv =
+      template_module.getGlobalVariable("Klass.java_mirror_offset", /*AllowInternal=*/true);
+  if (!mirror_offset_gv) {
+    RuntimeDefinedJavaOps::set_failed("Klass.java_mirror_offset global not found in template module");
+    return;
+  }
+
+  llvm::Value* mirror_offset =
+      ir_builder.CreateLoad(ir_builder.getInt32Ty(), mirror_offset_gv);
+  llvm::Value* oop_handle_addr =
+      ir_builder.CreateInBoundsGEP(ir_builder.getInt8Ty(), klass, mirror_offset);
+  llvm::Type* c_heap_ptr_ty =
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::CHeapAddrSpace);
+  llvm::Value* oop_handle = ir_builder.CreateLoad(c_heap_ptr_ty, oop_handle_addr);
+  llvm::Type* mirror_ty =
+      llvm::PointerType::get(context, llvm::jeandle::AddrSpace::JavaHeapAddrSpace);
+  llvm::Value* mirror = ir_builder.CreateLoad(mirror_ty, oop_handle);
+  ir_builder.CreateRet(mirror);
+JAVA_OP_END
+
 // Object.getClass(): load the java.lang.Class mirror for an object.
 // Two-level load via the OopHandle stored in Klass::_java_mirror:
 //   1. Load klass from object header (jeandle.load_klass).
@@ -507,6 +534,7 @@ bool RuntimeDefinedJavaOps::define_all(llvm::Module& template_module) {
   define_card_table_barrier(template_module);
   define_pre_barrier(template_module);
   define_post_barrier(template_module);
+  define_load_mirror_from_klass(template_module);
   define_get_class(template_module);
   define_current_thread_obj(template_module);
   define_reference_refers_to(template_module);

--- a/src/hotspot/share/jeandle/templatemodule/template.ll
+++ b/src/hotspot/share/jeandle/templatemodule/template.ll
@@ -262,7 +262,7 @@ define hotspotcc ptr addrspace(0) @jeandle.load_array_element_klass(ptr addrspac
 }
 
 ; This is the slow path for subtype checking when the fast path fails.
-define hotspotcc i1 @jeandle.check_klass_subtype_slow_path(ptr addrspace(0) nocapture %sub_klass, ptr addrspace(0) nocapture %super_klass) "lower-phase"="0" #0 {
+define hotspotcc i1 @jeandle.check_klass_subtype_slow_path(ptr addrspace(0) nocapture %sub_klass, ptr addrspace(0) nocapture %super_klass) noinline "lower-phase"="1" #0 {
 entry:
   ; Load secondary_supers array and secondary_super_cache.
   %secondary_supers_offset = load i32, ptr @Klass.secondary_supers_offset
@@ -328,13 +328,17 @@ check_primary_supers:
   %super_check = load atomic ptr addrspace(0), ptr addrspace(0) %super_check_addr unordered, align 8
 
   %is_super_match = icmp eq ptr %super_klass, %super_check
-  br i1 %is_super_match, label %return_true, label %check_secondary_supers
+  ; Match C2's static subtype-check heuristic without adding branch_weights to
+  ; the pre-optimization module, where they would be confused with MDO profile.
+  %is_super_match_likely = call i1 @llvm.expect.with.probability.i1(i1 %is_super_match, i1 true, double 8.300000e-01)
+  br i1 %is_super_match_likely, label %return_true, label %check_secondary_supers
 
 check_secondary_supers:
   ; Check if there are secondary supers.
   %secondary_super_cache_offset = load i32, ptr @Klass.secondary_super_cache_offset
   %has_secondary = icmp eq i32 %super_check_offset, %secondary_super_cache_offset
-  br i1 %has_secondary, label %slow_path, label %return_false
+  %has_secondary_unlikely = call i1 @llvm.expect.with.probability.i1(i1 %has_secondary, i1 false, double 6.300000e-01)
+  br i1 %has_secondary_unlikely, label %slow_path, label %return_false
 
 slow_path:
   %is_subtype_slow = call hotspotcc i1 @jeandle.check_klass_subtype_slow_path(ptr addrspace(0) %sub_klass, ptr addrspace(0) %super_klass)
@@ -1329,5 +1333,7 @@ slow_path:
   call void %callee(ptr addrspace(1) %obj, ptr addrspace(0) %lock, ptr %current_thread) #0
   ret void
 }
+
+declare i1 @llvm.expect.with.probability.i1(i1, i1, double) nounwind readnone
 
 attributes #0 = { nounwind "gc-leaf-function" }

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestClassConstantUnloading.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestClassConstantUnloading.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/*
+ * @test
+ * @summary Stress raw Klass constants in Class intrinsics across class unloading
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI -XX:+ClassUnloading -XX:-BackgroundCompilation
+ *      -XX:-TieredCompilation -XX:+UseJeandleCompiler -XX:+InlineClassNatives
+ *      compiler.jeandle.intrinsic.TestClassConstantUnloading
+ */
+
+package compiler.jeandle.intrinsic;
+
+import compiler.whitebox.CompilerWhiteBoxTest;
+import jdk.test.whitebox.WhiteBox;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+public class TestClassConstantUnloading {
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static final String TARGET_NAME =
+            "compiler.jeandle.intrinsic.TestClassConstantUnloading$UnloadableTarget";
+    private static final String TARGET_RESOURCE =
+            "TestClassConstantUnloading$UnloadableTarget.class";
+    private static final int STRESS_ROUNDS = 10;
+
+    public static void main(String[] args) throws Exception {
+        byte[] targetBytes = readTargetBytes();
+        for (int i = 0; i < STRESS_ROUNDS; i++) {
+            awaitCustomClassUnloading(runCustomLoaderRound(targetBytes), i);
+            awaitHiddenClassUnloading(runHiddenClassRound(targetBytes), i);
+        }
+    }
+
+    private static byte[] readTargetBytes() throws IOException {
+        try (InputStream in = TestClassConstantUnloading.class.getResourceAsStream(
+                TARGET_RESOURCE)) {
+            return Objects.requireNonNull(in, TARGET_RESOURCE).readAllBytes();
+        }
+    }
+
+    private static CustomReferences runCustomLoaderRound(byte[] targetBytes)
+            throws Exception {
+        TargetLoader loader = new TargetLoader(targetBytes);
+        Class<?> target = Class.forName(TARGET_NAME, true, loader);
+        compileAndVerify(target);
+        return new CustomReferences(new WeakReference<>(loader),
+                                    new WeakReference<>(target));
+    }
+
+    private static WeakReference<Class<?>> runHiddenClassRound(byte[] targetBytes)
+            throws Exception {
+        Class<?> target = MethodHandles.lookup()
+                .defineHiddenClass(targetBytes, true)
+                .lookupClass();
+        compileAndVerify(target);
+        return new WeakReference<>(target);
+    }
+
+    private static void compileAndVerify(Class<?> target) throws Exception {
+        Constructor<?> constructor = target.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Object instance = constructor.newInstance();
+
+        Method isInstance = target.getDeclaredMethod("constantIsInstance", Object.class);
+        Method cast = target.getDeclaredMethod("constantCast", Object.class);
+        Method assignable = target.getDeclaredMethod("constantAssignable", Class.class);
+        Method assignableArgument = target.getDeclaredMethod(
+                "constantAssignableArgument", Class.class);
+        isInstance.setAccessible(true);
+        cast.setAccessible(true);
+        assignable.setAccessible(true);
+        assignableArgument.setAccessible(true);
+
+        compile(isInstance);
+        compile(cast);
+        compile(assignable);
+        compile(assignableArgument);
+
+        if (!((Boolean) isInstance.invoke(null, instance))) {
+            throw new RuntimeException("constant isInstance failed for " + target);
+        }
+        if (cast.invoke(null, instance) != instance) {
+            throw new RuntimeException("constant cast failed for " + target);
+        }
+        if (!((Boolean) assignable.invoke(null, target))) {
+            throw new RuntimeException("constant isAssignableFrom failed for " + target);
+        }
+        if (!((Boolean) assignableArgument.invoke(null, target))) {
+            throw new RuntimeException(
+                    "constant isAssignableFrom argument failed for " + target);
+        }
+    }
+
+    private static void compile(Method method) {
+        if (!WB.enqueueMethodForCompilation(
+                method, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION)
+                || !WB.isMethodCompiled(method)) {
+            throw new RuntimeException("Jeandle did not compile " + method);
+        }
+    }
+
+    private static void awaitCustomClassUnloading(CustomReferences refs, int round) {
+        for (int attempt = 0; attempt < 20; attempt++) {
+            WB.fullGC();
+            if (refs.loader().get() == null && refs.target().get() == null) {
+                return;
+            }
+        }
+        throw new RuntimeException("custom class did not unload in round " + round);
+    }
+
+    private static void awaitHiddenClassUnloading(WeakReference<Class<?>> target,
+                                                   int round) {
+        for (int attempt = 0; attempt < 20; attempt++) {
+            WB.fullGC();
+            if (target.get() == null) {
+                return;
+            }
+        }
+        throw new RuntimeException("hidden class did not unload in round " + round);
+    }
+
+    private record CustomReferences(WeakReference<ClassLoader> loader,
+                                    WeakReference<Class<?>> target) {}
+
+    private static final class TargetLoader extends ClassLoader {
+        private final byte[] targetBytes;
+
+        TargetLoader(byte[] targetBytes) {
+            super(TestClassConstantUnloading.class.getClassLoader());
+            this.targetBytes = targetBytes;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve)
+                throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null && name.equals(TARGET_NAME)) {
+                    loaded = defineClass(name, targetBytes, 0, targetBytes.length);
+                }
+                if (loaded == null) {
+                    loaded = super.loadClass(name, false);
+                }
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+        }
+    }
+
+    public static class UnloadableTarget {
+        public static boolean constantIsInstance(Object object) {
+            return UnloadableTarget.class.isInstance(object);
+        }
+
+        public static Object constantCast(Object object) {
+            return UnloadableTarget.class.cast(object);
+        }
+
+        public static boolean constantAssignable(Class<?> klass) {
+            return UnloadableTarget.class.isAssignableFrom(klass);
+        }
+
+        public static boolean constantAssignableArgument(Class<?> klass) {
+            return klass.isAssignableFrom(UnloadableTarget.class);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestClassQueries.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestClassQueries.java
@@ -1,0 +1,783 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/*
+ * @test
+ * @summary Test the Jeandle Class-query intrinsic family
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.reflect
+ * @library /test/lib /
+ * @build jdk.test.lib.Asserts
+ * @run main/othervm -XX:-UseJeandleCompiler compiler.jeandle.intrinsic.TestClassQueries
+ */
+
+package compiler.jeandle.intrinsic;
+
+import compiler.jeandle.fileCheck.FileCheck;
+
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.internal.reflect.Reflection;
+
+public class TestClassQueries {
+    private static final String IS_INSTANCE_LOG =
+            "Method `virtual jboolean java.lang.Class.isInstance(jobject)` is parsed as intrinsic";
+    private static final String GET_MODIFIERS_LOG =
+            "Method `virtual jint java.lang.Class.getModifiers()` is parsed as intrinsic";
+    private static final String IS_ARRAY_LOG =
+            "Method `virtual jboolean java.lang.Class.isArray()` is parsed as intrinsic";
+    private static final String IS_PRIMITIVE_LOG =
+            "Method `virtual jboolean java.lang.Class.isPrimitive()` is parsed as intrinsic";
+    private static final String IS_INTERFACE_LOG =
+            "Method `virtual jboolean java.lang.Class.isInterface()` is parsed as intrinsic";
+    private static final String IS_HIDDEN_LOG =
+            "Method `virtual jboolean java.lang.Class.isHidden()` is parsed as intrinsic";
+    private static final String GET_SUPERCLASS_LOG =
+            "Method `virtual jobject java.lang.Class.getSuperclass()` is parsed as intrinsic";
+    private static final String GET_CLASS_ACCESS_FLAGS_LOG =
+            "Method `static jint jdk.internal.reflect.Reflection.getClassAccessFlags(jobject)`"
+                    + " is parsed as intrinsic";
+    private static final String CAST_LOG =
+            "Method `virtual jobject java.lang.Class.cast(jobject)` is parsed as intrinsic";
+    private static final String IS_ASSIGNABLE_FROM_LOG =
+            "Method `virtual jboolean java.lang.Class.isAssignableFrom(jobject)`"
+                    + " is parsed as intrinsic";
+
+    public static void main(String[] args) throws Exception {
+        runChild(true);
+        runChild(false);
+    }
+
+    private static void runChild(boolean enabled) throws Exception {
+        String mode = enabled ? "enabled" : "disabled";
+        String dumpPath = Files.createTempDirectory("jeandle_class_queries_" + mode).toString();
+        ArrayList<String> commandArgs = new ArrayList<>(List.of(
+                "--add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED",
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+InlineClassNatives",
+                "-Xbatch",
+                "-XX:-TieredCompilation",
+                "-XX:+UseJeandleCompiler",
+                "-XX:CompileThreshold=100",
+                "-Xlog:jeandle=debug",
+                "-XX:+JeandleDumpIR",
+                "-XX:JeandleDumpDirectory=" + dumpPath,
+                compileOnly("queryIsInstance"),
+                compileOnly("queryGetModifiers"),
+                compileOnly("queryIsArray"),
+                compileOnly("queryIsPrimitive"),
+                compileOnly("queryIsInterface"),
+                compileOnly("queryIsHidden"),
+                compileOnly("constantIsArray"),
+                compileOnly("constantIsPrimitive"),
+                compileOnly("constantIsInterface"),
+                compileOnly("constantIsHidden"),
+                compileOnly("constantGetModifiers"),
+                compileOnly("constantArrayGetModifiers"),
+                compileOnly("constantObjectIsPrimitive"),
+                compileOnly("constantPrimitiveIsArray"),
+                compileOnly("constantPrimitiveIsInterface"),
+                compileOnly("constantPrimitiveIsHidden"),
+                compileOnly("constantPrimitiveGetModifiers"),
+                compileOnly("constantVoidIsPrimitive"),
+                compileOnly("constantVoidGetModifiers"),
+                compileOnly("constantPrimitiveIsInstance"),
+                compileOnly("constantStringIsInstance"),
+                compileOnly("constantStringGetSuperclass"),
+                compileOnly("constantObjectGetSuperclass"),
+                compileOnly("constantArrayGetSuperclass"),
+                compileOnly("constantPrimitiveGetSuperclass"),
+                compileOnly("constantGetClassAccessFlags"),
+                compileOnly("constantPrimitiveGetClassAccessFlags"),
+                compileOnly("constantStringCast"),
+                compileOnly("constantStringCastTyped"),
+                compileOnly("constantStringIsInstanceTyped"),
+                compileOnly("constantAssignableTrue"),
+                compileOnly("constantAssignableFalse"),
+                compileOnly("constantPrimitiveAssignableTrue"),
+                compileOnly("constantPrimitiveAssignableFalse"),
+                compileOnly("constantReceiverAssignable"),
+                compileOnly("queryGetSuperclass"),
+                compileOnly("queryGetClassAccessFlags"),
+                compileOnly("queryCast"),
+                compileOnly("queryIsAssignableFrom")));
+        if (!enabled) {
+            commandArgs.add("-XX:ControlIntrinsic=-_isInstance,-_getModifiers,-_isArray,"
+                    + "-_isPrimitive,-_isInterface,-_isHidden,-_getSuperclass,"
+                    + "-_getClassAccessFlags,-_Class_cast,-_isAssignableFrom");
+        }
+        commandArgs.add(TestWrapper.class.getName());
+
+        OutputAnalyzer output = ProcessTools.executeCommand(
+                ProcessTools.createLimitedTestJavaProcessBuilder(commandArgs));
+        output.shouldHaveExitValue(0);
+        checkLogs(output, enabled);
+        checkIR(dumpPath, enabled);
+    }
+
+    private static String compileOnly(String method) {
+        return "-XX:CompileCommand=compileonly," + TestWrapper.class.getName() + "::" + method;
+    }
+
+    private static void checkLogs(OutputAnalyzer output, boolean enabled) {
+        String[] logs = {
+                IS_INSTANCE_LOG, GET_MODIFIERS_LOG,
+                IS_ARRAY_LOG, IS_PRIMITIVE_LOG, IS_INTERFACE_LOG, IS_HIDDEN_LOG,
+                GET_SUPERCLASS_LOG, GET_CLASS_ACCESS_FLAGS_LOG, CAST_LOG,
+                IS_ASSIGNABLE_FROM_LOG
+        };
+        for (String log : logs) {
+            if (enabled) {
+                output.shouldContain(log);
+            } else {
+                output.shouldNotContain(log);
+            }
+        }
+    }
+
+    private static void checkIR(String dumpPath, boolean enabled) throws Exception {
+        checkMethodIR(dumpPath, enabled, "queryIsInstance", "java_lang_Class", "isInstance",
+                new Class<?>[] {Class.class, Object.class}, List.of(
+                        "%class\\.is_instance\\.is_primitive = icmp eq ptr "
+                                + "%class\\.is_instance\\.klass, null",
+                        "ret i32"));
+        checkMethodIR(dumpPath, enabled, "queryGetModifiers", "java_lang_Class", "getModifiers",
+                new Class<?>[] {Class.class}, List.of(
+                        "%class\\.flags\\.is_primitive = icmp eq ptr %class\\.flags\\.klass, null",
+                        "%class\\.modifiers\\.value = load i32",
+                        "%class\\.flags\\.result = phi i32"));
+        checkMethodIR(dumpPath, enabled, "queryIsArray", "java_lang_Class", "isArray",
+                new Class<?>[] {Class.class}, List.of(
+                        "%class\\.query\\.is_primitive = icmp eq ptr %class\\.query\\.klass, null",
+                        "%class\\.query\\.is_array = icmp slt i32 "
+                                + "%class\\.query\\.layout_helper, 0",
+                        "%class\\.query\\.non_primitive_result = zext i1 "
+                                + "%class\\.query\\.is_array to i32"));
+        checkMethodIR(dumpPath, enabled, "queryIsPrimitive", "java_lang_Class", "isPrimitive",
+                new Class<?>[] {Class.class}, List.of(
+                        "%class\\.query\\.is_primitive = icmp eq ptr %class\\.query\\.klass, null",
+                        "%class\\.query\\.result = zext i1 %class\\.query\\.is_primitive to i32"));
+        checkMethodIR(dumpPath, enabled, "queryIsInterface", "java_lang_Class", "isInterface",
+                new Class<?>[] {Class.class}, List.of(
+                        "%class\\.query\\.is_primitive = icmp eq ptr %class\\.query\\.klass, null",
+                        "and i32 %class\\.query\\.access_flags, 512",
+                        "%class\\.query\\.non_primitive_result = zext i1 "
+                                + "%class\\.query\\.flag_set to i32"));
+        checkMethodIR(dumpPath, enabled, "queryIsHidden", "java_lang_Class", "isHidden",
+                new Class<?>[] {Class.class}, List.of(
+                        "%class\\.query\\.is_primitive = icmp eq ptr %class\\.query\\.klass, null",
+                        "and i32 %class\\.query\\.access_flags, 67108864",
+                        "%class\\.query\\.non_primitive_result = zext i1 "
+                                + "%class\\.query\\.flag_set to i32"));
+        checkMethodIR(dumpPath, enabled, "queryGetSuperclass", "java_lang_Class", "getSuperclass",
+                new Class<?>[] {Class.class}, List.of(
+                        "%class\\.super\\.is_primitive = icmp eq ptr "
+                                + "%class\\.super\\.klass_from_mirror, null",
+                        "%class\\.super\\.is_interface = icmp ne i32",
+                        "%class\\.super\\.is_array = icmp slt i32",
+                        "%class\\.super\\.klass = load ptr"));
+        checkMethodIR(dumpPath, enabled, "queryGetClassAccessFlags",
+                "jdk_internal_reflect_Reflection", "getClassAccessFlags",
+                new Class<?>[] {Class.class}, List.of(
+                        "%class\\.flags\\.is_primitive = icmp eq ptr %class\\.flags\\.klass, null",
+                        "call hotspotcc i32 \\(\\.\\.\\.\\) "
+                                + "@llvm\\.experimental\\.deoptimize\\.i32\\(i32 -10\\)",
+                        "%class\\.access_flags\\.value = load i32",
+                        "%class\\.flags\\.result = phi i32"));
+        if (enabled) {
+            checkConstantIR(dumpPath, "constantIsArray", "ret i32 1");
+            checkConstantIR(dumpPath, "constantIsPrimitive", "ret i32 1");
+            checkConstantIR(dumpPath, "constantIsInterface", "ret i32 1");
+            checkConstantIR(dumpPath, "constantIsHidden", "ret i32 0");
+            checkConstantIR(dumpPath, "constantGetModifiers", "ret i32 17");
+            checkConstantIR(dumpPath, "constantArrayGetModifiers", "ret i32 1041");
+            checkConstantIR(dumpPath, "constantObjectIsPrimitive", "ret i32 0");
+            checkConstantIR(dumpPath, "constantPrimitiveIsArray", "ret i32 0");
+            checkConstantIR(dumpPath, "constantPrimitiveIsInterface", "ret i32 0");
+            checkConstantIR(dumpPath, "constantPrimitiveIsHidden", "ret i32 0");
+            checkConstantIR(dumpPath, "constantPrimitiveGetModifiers", "ret i32 1041");
+            checkConstantIR(dumpPath, "constantVoidIsPrimitive", "ret i32 1");
+            checkConstantIR(dumpPath, "constantVoidGetModifiers", "ret i32 1041");
+            checkConstantObjectResultIR(dumpPath, "constantPrimitiveIsInstance", "ret i32 0");
+            checkConstantIR(dumpPath, "constantGetClassAccessFlags", "ret i32 49");
+            checkConstantIR(dumpPath, "constantPrimitiveGetClassAccessFlags", "ret i32 1041");
+            checkConstantIR(dumpPath, "constantAssignableTrue", "ret i32 1");
+            checkConstantIR(dumpPath, "constantAssignableFalse", "ret i32 0");
+            checkConstantIR(dumpPath, "constantPrimitiveAssignableTrue", "ret i32 1");
+            checkConstantIR(dumpPath, "constantPrimitiveAssignableFalse", "ret i32 0");
+            checkKnownMirrorAssignableIR(dumpPath);
+            checkConstantSuperclassIR(dumpPath, "constantStringGetSuperclass", false);
+            checkConstantSuperclassIR(dumpPath, "constantObjectGetSuperclass", true);
+            checkConstantSuperclassIR(dumpPath, "constantArrayGetSuperclass", false);
+            checkConstantSuperclassIR(dumpPath, "constantPrimitiveGetSuperclass", true);
+            checkKnownMirrorObjectQueryIR(dumpPath, "constantStringIsInstance",
+                    "class_is_instance_merge");
+            checkKnownMirrorObjectQueryIR(dumpPath, "constantStringCast",
+                    "class_cast_pass");
+            checkConstantTypedObjectResultIR(dumpPath, "constantStringCastTyped", String.class, "ret ptr addrspace\\(1\\)");
+            checkConstantTypedIR(dumpPath, "constantStringIsInstanceTyped", Integer.class, "ret i32 0");
+        }
+        checkMethodIR(dumpPath, enabled, "queryCast", "java_lang_Class", "cast",
+                new Class<?>[] {Class.class, Object.class}, List.of(
+                        "%class\\.cast\\.is_primitive = icmp eq ptr",
+                        "%class\\.cast\\.is_null = icmp eq ptr addrspace\\(1\\)",
+                        "ret ptr addrspace\\(1\\)"));
+        checkMethodIR(dumpPath, enabled, "queryIsAssignableFrom", "java_lang_Class",
+                "isAssignableFrom", new Class<?>[] {Class.class, Class.class}, List.of(
+                        "%class\\.assignable\\.any_primitive = or i1",
+                        "ret i32"));
+    }
+
+    private static void checkConstantTypedIR(String dumpPath, String methodName,
+                                              Class<?> parameterType,
+                                              String resultPattern) throws Exception {
+        Method method = TestWrapper.class.getMethod(methodName, parameterType);
+        FileCheck optimized = new FileCheck(dumpPath, method, true);
+        optimized.checkPattern(resultPattern);
+        optimized.checkNotPattern("jeandle\\.load_mirror_klass");
+    }
+
+    private static void checkConstantIR(String dumpPath, String methodName,
+                                        String resultPattern) throws Exception {
+        Method method = TestWrapper.class.getMethod(methodName);
+        FileCheck optimized = new FileCheck(dumpPath, method, true);
+        optimized.checkPattern(resultPattern);
+        optimized.checkNotPattern("java_lang_Class_(isArray|isPrimitive|isInterface|isHidden|getModifiers)");
+        optimized.checkNotPattern("jeandle\\.load_mirror_klass");
+        optimized.checkNotPattern("(layout_helper|access_flags|modifier_flags)");
+    }
+
+    private static void checkConstantSuperclassIR(String dumpPath, String methodName,
+                                                   boolean returnsNull) throws Exception {
+        Method method = TestWrapper.class.getMethod(methodName);
+        FileCheck optimized = new FileCheck(dumpPath, method, true);
+        optimized.checkPattern(returnsNull
+                ? "ret ptr addrspace\\(1\\) null"
+                : "ret ptr addrspace\\(1\\) %[-A-Za-z$._0-9]+");
+        optimized.checkNotPattern("jeandle\\.(load_mirror_klass|load_mirror_from_klass)");
+        optimized.checkNotPattern("class\\.super\\.(access_flags|layout_helper|klass)");
+    }
+
+    private static void checkConstantObjectResultIR(String dumpPath, String methodName,
+                                                     String resultPattern) throws Exception {
+        Method method = TestWrapper.class.getMethod(methodName, Object.class);
+        FileCheck optimized = new FileCheck(dumpPath, method, true);
+        optimized.checkPattern(resultPattern);
+        optimized.checkNotPattern("jeandle\\.load_mirror_klass");
+    }
+
+    private static void checkConstantTypedObjectResultIR(String dumpPath, String methodName,
+                                                          Class<?> parameterType,
+                                                          String resultPattern) throws Exception {
+        Method method = TestWrapper.class.getMethod(methodName, parameterType);
+        FileCheck optimized = new FileCheck(dumpPath, method, true);
+        optimized.checkPattern(resultPattern);
+        optimized.checkNotPattern("jeandle\\.load_mirror_klass");
+    }
+
+    private static void checkKnownMirrorObjectQueryIR(String dumpPath, String methodName,
+                                                       String operation) throws Exception {
+        Method method = TestWrapper.class.getMethod(methodName, Object.class);
+        FileCheck optimized = new FileCheck(dumpPath, method, true);
+        optimized.checkPattern(operation);
+        optimized.checkNotPattern("jeandle\\.load_mirror_klass");
+        optimized.checkNotPattern("class\\.(is_instance|cast)\\.is_primitive");
+    }
+
+    private static void checkKnownMirrorAssignableIR(String dumpPath) throws Exception {
+        Method method = TestWrapper.class.getMethod("constantReceiverAssignable", Class.class);
+        FileCheck optimized = new FileCheck(dumpPath, method, true);
+        optimized.checkPattern("class_assignable_merge");
+        optimized.checkNotPattern("jeandle\\.load_mirror_klass");
+    }
+
+    private static void checkMethodIR(String dumpPath, boolean enabled,
+                                      String wrapperName, String targetOwner, String targetName,
+                                      Class<?>[] parameterTypes,
+                                      List<String> semanticPatterns) throws Exception {
+        Method wrapper = TestWrapper.class.getMethod(wrapperName, parameterTypes);
+        FileCheck checker = enabled && isDirectClassQuery(wrapperName)
+                ? new FileCheck(dumpPath, wrapper, false, 0)
+                : new FileCheck(dumpPath, wrapper, false);
+        checker.checkPattern("define hotspotcc .*" + wrapperName);
+
+        String nativeCall = "(call|invoke) hotspotcc [^\\r\\n]*" + targetOwner + "_"
+                + targetName;
+        if (enabled) {
+            if (isDirectClassQuery(wrapperName)) {
+                checker.checkPattern("call hotspotcc ptr @jeandle\\.load_mirror_klass"
+                        + "\\(ptr addrspace\\(1\\) %[-A-Za-z$._0-9]+\\)");
+                checker.checkNotPattern("call hotspotcc [^\\r\\n]*"
+                        + "@jeandle\\.load_mirror_klass[^\\r\\n]*"
+                        + "\\[ \"deopt\"");
+                checker.checkNotPattern("call hotspotcc [^\\r\\n]*\"java-klass\""
+                        + "[^\\r\\n]*@jeandle\\.load_mirror_klass");
+            } else {
+                if (wrapperName.equals("queryGetSuperclass")) {
+                    checker.checkNotPattern("call hotspotcc [^\\r\\n]*@jeandle\\.load_mirror_from_klass");
+                } else {
+                    // Loading Klass* from a nonnull mirror is a GC-leaf JavaOp. It
+                    // must not inherit the Class intrinsic's deopt state or Java
+                    // return-type metadata.
+                    checker.checkPattern("call hotspotcc ptr @jeandle\\.load_mirror_klass"
+                            + "\\(ptr addrspace\\(1\\) %[-A-Za-z$._0-9]+\\)");
+                    checker.checkNotPattern("call hotspotcc [^\\r\\n]*"
+                            + "@jeandle\\.load_mirror_klass[^\\r\\n]*"
+                            + "\\[ \\\"deopt\\\"");
+                    checker.checkNotPattern("call hotspotcc [^\\r\\n]*\\\"java-klass\\\""
+                            + "[^\\r\\n]*@jeandle\\.load_mirror_klass");
+                }
+            }
+            for (String pattern : semanticPatterns) {
+                checker.checkPattern(pattern);
+            }
+            if (wrapperName.equals("queryGetSuperclass")) {
+                checker.checkNotPattern("%class\\.super\\.klass_from_mirror = call hotspotcc "
+                        + "[^\\r\\n]*\\\"java-klass\\\"[^\\r\\n]*"
+                        + "@jeandle\\.load_mirror_klass");
+            }
+            if (wrapperName.equals("queryCast")) {
+                checker.checkNotPattern("call hotspotcc [^\\r\\n]*\\\"java-klass\\\""
+                        + "[^\\r\\n]*@jeandle\\.checkcast");
+            }
+            checker.checkNotPattern(nativeCall);
+        } else {
+            checker.checkPattern(nativeCall);
+            checker.checkNotPattern("(call|invoke)[^\\r\\n]*"
+                    + "@jeandle\\.load_mirror_klass\\(");
+            checker.checkNotPattern("(call|invoke)[^\\r\\n]*@jeandle\\.instanceof\\(");
+            checker.checkNotPattern("(call|invoke)[^\\r\\n]*"
+                    + "@jeandle\\.load_mirror_from_klass\\(");
+        }
+    }
+
+    private static boolean isDirectClassQuery(String wrapperName) {
+        return wrapperName.equals("queryGetModifiers")
+                || wrapperName.equals("queryGetClassAccessFlags")
+                || wrapperName.equals("queryIsArray")
+                || wrapperName.equals("queryIsPrimitive")
+                || wrapperName.equals("queryIsInterface")
+                || wrapperName.equals("queryIsHidden");
+    }
+
+    static class TestWrapper {
+        interface TestInterface {}
+
+        @interface TestAnnotation {}
+
+        static class Parent {}
+
+        static class Child extends Parent {}
+
+        static final class HiddenTemplate {}
+
+        interface HiddenInterfaceTemplate {}
+
+        public static void main(String[] args) throws Exception {
+            warmup();
+
+            Asserts.assertTrue(constantIsArray(), "constant isArray");
+            Asserts.assertTrue(constantIsPrimitive(), "constant isPrimitive");
+            Asserts.assertTrue(constantIsInterface(), "constant isInterface");
+            Asserts.assertFalse(constantIsHidden(), "constant isHidden");
+            Asserts.assertEquals(17, constantGetModifiers(), "constant getModifiers");
+            Asserts.assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL,
+                    constantArrayGetModifiers(), "constant array getModifiers");
+            Asserts.assertFalse(constantObjectIsPrimitive(), "constant object isPrimitive");
+            Asserts.assertFalse(constantPrimitiveIsArray(), "constant primitive isArray");
+            Asserts.assertFalse(constantPrimitiveIsInterface(), "constant primitive isInterface");
+            Asserts.assertFalse(constantPrimitiveIsHidden(), "constant primitive isHidden");
+            Asserts.assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL,
+                    constantPrimitiveGetModifiers(), "constant primitive getModifiers");
+            Asserts.assertTrue(constantVoidIsPrimitive(), "constant void isPrimitive");
+            Asserts.assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL,
+                    constantVoidGetModifiers(), "constant void getModifiers");
+            Asserts.assertFalse(constantPrimitiveIsInstance(Integer.valueOf(1)));
+            Asserts.assertTrue(constantStringIsInstance("value"));
+            Asserts.assertFalse(constantStringIsInstance(Integer.valueOf(1)));
+            Asserts.assertEquals(Object.class, constantStringGetSuperclass());
+            Asserts.assertEquals(null, constantObjectGetSuperclass());
+            Asserts.assertEquals(Object.class, constantArrayGetSuperclass());
+            Asserts.assertEquals(null, constantPrimitiveGetSuperclass());
+            Asserts.assertEquals(Reflection.getClassAccessFlags(String.class),
+                    constantGetClassAccessFlags());
+            Asserts.assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL,
+                    constantPrimitiveGetClassAccessFlags());
+            Asserts.assertSame("value", constantStringCast("value"));
+            Asserts.assertSame(null, constantStringCast(null));
+            expectCCE(() -> constantStringCast(Integer.valueOf(1)), "constant String cast");
+            Asserts.assertSame("value", constantStringCastTyped("value"));
+            Asserts.assertSame(null, constantStringCastTyped(null));
+            Asserts.assertFalse(constantStringIsInstanceTyped(Integer.valueOf(1)));
+            Asserts.assertTrue(constantAssignableTrue());
+            Asserts.assertFalse(constantAssignableFalse());
+            Asserts.assertTrue(constantPrimitiveAssignableTrue());
+            Asserts.assertFalse(constantPrimitiveAssignableFalse());
+            Asserts.assertTrue(constantReceiverAssignable(String.class));
+            Asserts.assertFalse(constantReceiverAssignable(int.class));
+
+            verify(Object.class, false, false, false, false, null);
+            verify(TestWrapper.class, false, false, false, false, Object.class);
+            verify(Child.class, false, false, false, false, Parent.class);
+            verify(TestInterface.class, false, false, true, false, null);
+            verify(TestAnnotation.class, false, false, true, false, null);
+
+            Class<?>[] primitives = {
+                    boolean.class, byte.class, char.class, short.class,
+                    int.class, long.class, float.class, double.class, void.class
+            };
+            for (Class<?> primitive : primitives) {
+                verify(primitive, false, true, false, false, null);
+            }
+
+            verify(Object[].class, true, false, false, false, Object.class);
+            verify(int[].class, true, false, false, false, Object.class);
+            verify(String[][].class, true, false, false, false, Object.class);
+
+            Class<?> hidden = defineHiddenClass(
+                    "TestClassQueries$TestWrapper$HiddenTemplate.class");
+            verify(hidden, false, false, false, true, Object.class);
+            verify(Array.newInstance(hidden, 0).getClass(),
+                    true, false, false, false, Object.class);
+
+            Class<?> hiddenInterface = defineHiddenClass(
+                    "TestClassQueries$TestWrapper$HiddenInterfaceTemplate.class");
+            verify(hiddenInterface, false, false, true, true, null);
+
+            verifyInstance(String.class, "value", true);
+            verifyInstance(String.class, new Object(), false);
+            verifyInstance(Runnable.class, (Runnable) () -> {}, true);
+            verifyInstance(Runnable.class, new Object(), false);
+            verifyInstance(Object[].class, new String[0], true);
+            verifyInstance(int[].class, new int[0], true);
+            verifyInstance(int[].class, new long[0], false);
+            verifyInstance(int.class, Integer.valueOf(1), false);
+            verifyInstance(Object.class, null, false);
+
+            expectNPE(() -> queryIsInstance(null, new Object()), "isInstance");
+            expectNPE(() -> queryGetModifiers(null), "getModifiers");
+            expectNPE(() -> queryIsArray(null), "isArray");
+            expectNPE(() -> queryIsPrimitive(null), "isPrimitive");
+            expectNPE(() -> queryIsInterface(null), "isInterface");
+            expectNPE(() -> queryIsHidden(null), "isHidden");
+            expectNPE(() -> queryGetSuperclass(null), "getSuperclass");
+
+            Asserts.assertSame("x", queryCast(String.class, "x"));
+            Asserts.assertSame(null, queryCast(String.class, null));
+            for (int i = 0; i < 20_000; i++) {
+                Asserts.assertSame(null, queryCast(int.class, null));
+                Asserts.assertSame(null, queryCast(void.class, null));
+            }
+            expectCCE(() -> queryCast(String.class, Integer.valueOf(1)), "cast");
+            expectCCE(() -> queryCast(int.class, Integer.valueOf(1)), "primitive cast");
+            Asserts.assertTrue(queryIsAssignableFrom(Object.class, String.class));
+            Asserts.assertTrue(queryIsAssignableFrom(int.class, int.class));
+            Asserts.assertFalse(queryIsAssignableFrom(int.class, long.class));
+            Asserts.assertFalse(queryIsAssignableFrom(String.class, Object.class));
+        }
+
+        private static void warmup() {
+            for (int i = 0; i < 1_000; i++) {
+                queryIsInstance(String.class, "value");
+                queryGetModifiers(String.class);
+                queryIsArray(String[].class);
+                queryIsPrimitive(Object.class);
+                queryIsInterface(TestInterface.class);
+                queryIsHidden(Object.class);
+                constantIsArray();
+                constantIsPrimitive();
+                constantIsInterface();
+                constantIsHidden();
+                constantGetModifiers();
+                constantArrayGetModifiers();
+                constantObjectIsPrimitive();
+                constantPrimitiveIsArray();
+                constantPrimitiveIsInterface();
+                constantPrimitiveIsHidden();
+                constantPrimitiveGetModifiers();
+                constantVoidIsPrimitive();
+                constantVoidGetModifiers();
+                constantPrimitiveIsInstance(Integer.valueOf(1));
+                constantStringIsInstance("value");
+                constantStringGetSuperclass();
+                constantObjectGetSuperclass();
+                constantArrayGetSuperclass();
+                constantPrimitiveGetSuperclass();
+                constantGetClassAccessFlags();
+                constantPrimitiveGetClassAccessFlags();
+                constantStringCast("value");
+                constantStringCastTyped("value");
+                constantStringIsInstanceTyped(Integer.valueOf(1));
+                constantAssignableTrue();
+                constantAssignableFalse();
+                constantPrimitiveAssignableTrue();
+                constantPrimitiveAssignableFalse();
+                constantReceiverAssignable(String.class);
+                queryGetSuperclass(String.class);
+                queryGetClassAccessFlags(String.class);
+                queryCast(String.class, "value");
+                queryIsAssignableFrom(Object.class, String.class);
+            }
+        }
+
+        private static Class<?> defineHiddenClass(String resourceName) throws Exception {
+            try (InputStream in = TestClassQueries.class.getResourceAsStream(
+                    resourceName)) {
+                byte[] bytes = Objects.requireNonNull(in, "hidden class bytes").readAllBytes();
+                return MethodHandles.lookup().defineHiddenClass(bytes, false).lookupClass();
+            }
+        }
+
+        private static void verify(Class<?> klass, boolean array, boolean primitive,
+                                   boolean iface, boolean hidden,
+                                   Class<?> expectedSuperclass) {
+            Asserts.assertEquals(array, queryIsArray(klass), klass + " isArray");
+            Asserts.assertEquals(primitive, queryIsPrimitive(klass), klass + " isPrimitive");
+            Asserts.assertEquals(iface, queryIsInterface(klass), klass + " isInterface");
+            Asserts.assertEquals(hidden, queryIsHidden(klass), klass + " isHidden");
+
+            int modifiers = queryGetModifiers(klass);
+            Asserts.assertEquals(oracleGetModifiers(klass), modifiers,
+                    klass + " getModifiers");
+            if (primitive) {
+                Asserts.assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL,
+                        modifiers, klass + " primitive modifiers");
+            }
+
+            Asserts.assertEquals(expectedSuperclass, queryGetSuperclass(klass),
+                    klass + " getSuperclass");
+            Asserts.assertEquals(oracleGetSuperclass(klass), queryGetSuperclass(klass),
+                    klass + " getSuperclass oracle");
+
+            // Reflection only guarantees the low 13 class-file flag bits.
+            int expectedAccessFlags = oracleGetClassAccessFlags(klass) & 0x1fff;
+            int actualAccessFlags = queryGetClassAccessFlags(klass) & 0x1fff;
+            Asserts.assertEquals(expectedAccessFlags, actualAccessFlags,
+                    klass + " getClassAccessFlags");
+            if (primitive) {
+                Asserts.assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL,
+                        actualAccessFlags, klass + " primitive access flags");
+            }
+        }
+
+        private static void verifyInstance(Class<?> klass, Object object, boolean expected) {
+            Asserts.assertEquals(expected, queryIsInstance(klass, object),
+                    klass + " isInstance(" + object + ")");
+            Asserts.assertEquals(oracleIsInstance(klass, object),
+                    queryIsInstance(klass, object), klass + " isInstance oracle");
+        }
+
+        private static void expectCCE(Runnable action, String name) {
+            try { action.run(); throw new AssertionError(name + " did not throw ClassCastException"); }
+            catch (ClassCastException expected) { }
+        }
+
+        private static void expectNPE(Runnable action, String name) {
+            try {
+                action.run();
+                throw new AssertionError(name + " did not throw NullPointerException");
+            } catch (NullPointerException expected) {
+                // Expected.
+            }
+        }
+
+        public static boolean queryIsArray(Class<?> klass) {
+            return klass.isArray();
+        }
+
+        public static boolean queryIsInstance(Class<?> klass, Object object) {
+            return klass.isInstance(object);
+        }
+
+        public static int queryGetModifiers(Class<?> klass) {
+            return klass.getModifiers();
+        }
+
+        public static boolean queryIsPrimitive(Class<?> klass) {
+            return klass.isPrimitive();
+        }
+
+        public static boolean queryIsInterface(Class<?> klass) {
+            return klass.isInterface();
+        }
+
+        public static boolean queryIsHidden(Class<?> klass) {
+            return klass.isHidden();
+        }
+
+        public static boolean constantIsArray() {
+            return String[].class.isArray();
+        }
+
+        public static boolean constantIsPrimitive() {
+            return int.class.isPrimitive();
+        }
+
+        public static boolean constantIsInterface() {
+            return TestInterface.class.isInterface();
+        }
+
+        public static boolean constantIsHidden() {
+            return Object.class.isHidden();
+        }
+
+        public static int constantGetModifiers() {
+            return String.class.getModifiers();
+        }
+
+        public static int constantArrayGetModifiers() {
+            return String[].class.getModifiers();
+        }
+
+        public static boolean constantObjectIsPrimitive() {
+            return Object.class.isPrimitive();
+        }
+
+        public static boolean constantPrimitiveIsArray() {
+            return int.class.isArray();
+        }
+
+        public static boolean constantPrimitiveIsInterface() {
+            return int.class.isInterface();
+        }
+
+        public static boolean constantPrimitiveIsHidden() {
+            return int.class.isHidden();
+        }
+
+        public static int constantPrimitiveGetModifiers() {
+            return int.class.getModifiers();
+        }
+
+        public static boolean constantVoidIsPrimitive() {
+            return void.class.isPrimitive();
+        }
+
+        public static int constantVoidGetModifiers() {
+            return void.class.getModifiers();
+        }
+
+        public static boolean constantPrimitiveIsInstance(Object object) {
+            return int.class.isInstance(object);
+        }
+
+        public static boolean constantStringIsInstance(Object object) {
+            return String.class.isInstance(object);
+        }
+
+        public static Class<?> constantStringGetSuperclass() {
+            return String.class.getSuperclass();
+        }
+
+        public static Class<?> constantObjectGetSuperclass() {
+            return Object.class.getSuperclass();
+        }
+
+        public static Class<?> constantArrayGetSuperclass() {
+            return String[].class.getSuperclass();
+        }
+
+        public static Class<?> constantPrimitiveGetSuperclass() {
+            return int.class.getSuperclass();
+        }
+
+        public static int constantGetClassAccessFlags() {
+            return Reflection.getClassAccessFlags(String.class);
+        }
+
+        public static int constantPrimitiveGetClassAccessFlags() {
+            return Reflection.getClassAccessFlags(int.class);
+        }
+
+        public static Object constantStringCast(Object object) {
+            return String.class.cast(object);
+        }
+
+        public static Object constantStringCastTyped(String object) {
+            return String.class.cast(object);
+        }
+
+        public static boolean constantStringIsInstanceTyped(Integer object) {
+            return String.class.isInstance(object);
+        }
+
+        public static boolean constantAssignableTrue() {
+            return Object.class.isAssignableFrom(String.class);
+        }
+
+        public static boolean constantAssignableFalse() {
+            return String.class.isAssignableFrom(Object.class);
+        }
+
+        public static boolean constantPrimitiveAssignableTrue() {
+            return int.class.isAssignableFrom(int.class);
+        }
+
+        public static boolean constantPrimitiveAssignableFalse() {
+            return int.class.isAssignableFrom(long.class);
+        }
+
+        public static boolean constantReceiverAssignable(Class<?> other) {
+            return Object.class.isAssignableFrom(other);
+        }
+
+        public static Class<?> queryGetSuperclass(Class<?> klass) {
+            return klass.getSuperclass();
+        }
+
+        public static Object queryCast(Class<?> klass, Object object) {
+            return klass.cast(object);
+        }
+
+        public static boolean queryIsAssignableFrom(Class<?> klass, Class<?> other) {
+            return klass.isAssignableFrom(other);
+        }
+
+        public static int queryGetClassAccessFlags(Class<?> klass) {
+            return Reflection.getClassAccessFlags(klass);
+        }
+
+        private static boolean oracleIsInstance(Class<?> klass, Object object) {
+            return klass.isInstance(object);
+        }
+
+        private static int oracleGetModifiers(Class<?> klass) {
+            return klass.getModifiers();
+        }
+
+        private static Class<?> oracleGetSuperclass(Class<?> klass) {
+            return klass.getSuperclass();
+        }
+
+        private static int oracleGetClassAccessFlags(Class<?> klass) {
+            return Reflection.getClassAccessFlags(klass);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestClassQueries.java
+++ b/test/hotspot/jtreg/compiler/jeandle/intrinsic/TestClassQueries.java
@@ -109,6 +109,7 @@ public class TestClassQueries {
                 compileOnly("constantVoidIsPrimitive"),
                 compileOnly("constantVoidGetModifiers"),
                 compileOnly("constantPrimitiveIsInstance"),
+                compileOnly("constantPrimitiveCastNull"),
                 compileOnly("constantStringIsInstance"),
                 compileOnly("constantStringGetSuperclass"),
                 compileOnly("constantObjectGetSuperclass"),
@@ -226,6 +227,8 @@ public class TestClassQueries {
             checkConstantIR(dumpPath, "constantVoidIsPrimitive", "ret i32 1");
             checkConstantIR(dumpPath, "constantVoidGetModifiers", "ret i32 1041");
             checkConstantObjectResultIR(dumpPath, "constantPrimitiveIsInstance", "ret i32 0");
+            checkConstantIR(dumpPath, "constantPrimitiveCastNull",
+                    "ret ptr addrspace\\(1\\) null");
             checkConstantIR(dumpPath, "constantGetClassAccessFlags", "ret i32 49");
             checkConstantIR(dumpPath, "constantPrimitiveGetClassAccessFlags", "ret i32 1041");
             checkConstantIR(dumpPath, "constantAssignableTrue", "ret i32 1");
@@ -420,6 +423,7 @@ public class TestClassQueries {
             Asserts.assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL,
                     constantVoidGetModifiers(), "constant void getModifiers");
             Asserts.assertFalse(constantPrimitiveIsInstance(Integer.valueOf(1)));
+            Asserts.assertSame(null, constantPrimitiveCastNull());
             Asserts.assertTrue(constantStringIsInstance("value"));
             Asserts.assertFalse(constantStringIsInstance(Integer.valueOf(1)));
             Asserts.assertEquals(Object.class, constantStringGetSuperclass());
@@ -525,6 +529,7 @@ public class TestClassQueries {
                 constantVoidIsPrimitive();
                 constantVoidGetModifiers();
                 constantPrimitiveIsInstance(Integer.valueOf(1));
+                constantPrimitiveCastNull();
                 constantStringIsInstance("value");
                 constantStringGetSuperclass();
                 constantObjectGetSuperclass();
@@ -686,6 +691,10 @@ public class TestClassQueries {
 
         public static boolean constantPrimitiveIsInstance(Object object) {
             return int.class.isInstance(object);
+        }
+
+        public static Object constantPrimitiveCastNull() {
+            return int.class.cast(null);
         }
 
         public static boolean constantStringIsInstance(Object object) {

--- a/test/micro/org/openjdk/bench/java/lang/ClassQueries.java
+++ b/test/micro/org/openjdk/bench/java/lang/ClassQueries.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2026, the Jeandle-JDK Authors. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openjdk.bench.java.lang;
+
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import jdk.internal.reflect.Reflection;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3, jvmArgsAppend = {
+        "--add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED"
+})
+public class ClassQueries {
+    private static final int LOOP_COUNT = 1_000_000;
+
+    public enum Kind {
+        OBJECT,
+        INTERFACE,
+        OBJECT_ARRAY,
+        PRIMITIVE_ARRAY,
+        PRIMITIVE,
+        VOID,
+        HIDDEN,
+        CHILD
+    }
+
+    @Param({"OBJECT", "INTERFACE", "OBJECT_ARRAY", "PRIMITIVE_ARRAY",
+            "PRIMITIVE", "VOID", "HIDDEN", "CHILD"})
+    public Kind kind;
+
+    private Class<?> klass;
+    private Object object;
+    private Class<?> alternateKlass;
+    private Object alternateObject;
+    private Object castObject;
+    private Object alternateCastObject;
+
+    @Setup
+    public void setup() throws Exception {
+        klass = switch (kind) {
+            case OBJECT -> Object.class;
+            case INTERFACE -> Runnable.class;
+            case OBJECT_ARRAY -> Object[].class;
+            case PRIMITIVE_ARRAY -> int[].class;
+            case PRIMITIVE -> int.class;
+            case VOID -> void.class;
+            case HIDDEN -> defineHiddenClass();
+            case CHILD -> Child.class;
+        };
+        object = switch (kind) {
+            case OBJECT -> new Object();
+            case INTERFACE -> new Object();
+            case OBJECT_ARRAY -> new String[0];
+            case PRIMITIVE_ARRAY -> new int[0];
+            case PRIMITIVE -> Integer.valueOf(1);
+            case VOID, HIDDEN -> null;
+            case CHILD -> new Child();
+        };
+        alternateKlass = switch (kind) {
+            case OBJECT -> Class.class;
+            case INTERFACE -> CharSequence.class;
+            case OBJECT_ARRAY -> String[].class;
+            case PRIMITIVE_ARRAY -> long[].class;
+            case PRIMITIVE -> long.class;
+            case VOID -> int.class;
+            case HIDDEN -> defineHiddenClass();
+            case CHILD -> Parent.class;
+        };
+        alternateObject = switch (kind) {
+            case OBJECT, INTERFACE -> new Object();
+            case OBJECT_ARRAY -> new String[0];
+            case PRIMITIVE_ARRAY -> new long[0];
+            case PRIMITIVE -> Long.valueOf(1);
+            case VOID, HIDDEN -> null;
+            case CHILD -> new Parent();
+        };
+        castObject = switch (kind) {
+            case OBJECT -> Class.class;
+            case INTERFACE -> (Runnable) () -> { };
+            case OBJECT_ARRAY -> new String[0];
+            case PRIMITIVE_ARRAY -> new int[0];
+            case PRIMITIVE, VOID, HIDDEN -> null;
+            case CHILD -> new Child();
+        };
+        alternateCastObject = switch (kind) {
+            case OBJECT -> Class.class;
+            case INTERFACE -> "";
+            case OBJECT_ARRAY -> new String[0];
+            case PRIMITIVE_ARRAY -> new long[0];
+            case PRIMITIVE, VOID, HIDDEN -> null;
+            case CHILD -> new Parent();
+        };
+    }
+
+    private static Class<?> defineHiddenClass() throws Exception {
+        try (InputStream in = ClassQueries.class.getResourceAsStream(
+                "ClassQueries$HiddenTemplate.class")) {
+            byte[] bytes = Objects.requireNonNull(in, "hidden class bytes").readAllBytes();
+            return MethodHandles.lookup().defineHiddenClass(bytes, false).lookupClass();
+        }
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean isInstance() {
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= ((i & 1) == 0 ? klass : alternateKlass)
+                    .isInstance((i & 1) == 0 ? object : alternateObject);
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public int getModifiers() {
+        int result = 0;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result += ((i & 1) == 0 ? klass : alternateKlass).getModifiers();
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean isArray() {
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= ((i & 1) == 0 ? klass : alternateKlass).isArray();
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean isPrimitive() {
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= ((i & 1) == 0 ? klass : alternateKlass).isPrimitive();
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean isInterface() {
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= ((i & 1) == 0 ? klass : alternateKlass).isInterface();
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean isHidden() {
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= ((i & 1) == 0 ? klass : alternateKlass).isHidden();
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public void getSuperclass(Blackhole bh) {
+        Object v1 = null, v2 = null;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            Object value = ((i & 1) == 0 ? klass : alternateKlass).getSuperclass();
+            if ((i & 5) == 1) v1 = value; else v2 = value;
+        }
+        bh.consume(v1); bh.consume(v2);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public int getClassAccessFlags() {
+        int result = 0;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result += Reflection.getClassAccessFlags(
+                    (i & 1) == 0 ? klass : alternateKlass);
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public void cast(Blackhole bh) {
+        Object v1 = null, v2 = null;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            Object value = ((i & 1) == 0 ? klass : alternateKlass)
+                    .cast((i & 1) == 0 ? castObject : alternateCastObject);
+            if ((i & 5) == 1) v1 = value; else v2 = value;
+        }
+        bh.consume(v1); bh.consume(v2);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean isAssignableFrom() {
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= ((i & 1) == 0 ? klass : alternateKlass)
+                    .isAssignableFrom(alternateKlass);
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean constantIsInstanceHit() {
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= String.class.isInstance("value");
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean constantIsInstanceMiss() {
+        Object value = Integer.valueOf(1);
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= String.class.isInstance(value);
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean constantIsInstanceNull() {
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= String.class.isInstance(null);
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public void constantCastTyped(Blackhole bh) {
+        String value = "value";
+        Object v1 = null, v2 = null;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            Object result = String.class.cast(value);
+            if ((i & 5) == 1) v1 = result; else v2 = result;
+        }
+        bh.consume(v1); bh.consume(v2);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public void constantCastObject(Blackhole bh) {
+        Object value = "value";
+        Object v1 = null, v2 = null;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            Object result = String.class.cast(value);
+            if ((i & 5) == 1) v1 = result; else v2 = result;
+        }
+        bh.consume(v1); bh.consume(v2);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public void constantCastNull(Blackhole bh) {
+        Object v1 = null, v2 = null;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            Object value = String.class.cast(null);
+            if ((i & 5) == 1) v1 = value; else v2 = value;
+        }
+        bh.consume(v1); bh.consume(v2);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public void constantGetSuperclass(Blackhole bh) {
+        Object v1 = null, v2 = null;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            Object value = String.class.getSuperclass();
+            if ((i & 5) == 1) v1 = value; else v2 = value;
+        }
+        bh.consume(v1); bh.consume(v2);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public int constantGetClassAccessFlags() {
+        int result = 0;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result += Reflection.getClassAccessFlags(String.class);
+        }
+        return result;
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    @OperationsPerInvocation(LOOP_COUNT)
+    public boolean constantAssignableFrom() {
+        boolean result = false;
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            result ^= Object.class.isAssignableFrom(String.class);
+        }
+        return result;
+    }
+
+    static class Parent {}
+
+    static class Child extends Parent {}
+
+    static final class HiddenTemplate {}
+}


### PR DESCRIPTION
## Related issue(s):

issue #

## What this PR does / why we need it:

This PR adds Jeandle intrinsic lowering for frequently used `java.lang.Class`
queries and adapts the lowering to the current Jeandle JavaOp and type-analysis
infrastructure.

### What this PR does

The following Class operations are lowered through Jeandle intrinsics:

- `Class.cast`
- `Class.isInstance`
- `Class.isAssignableFrom`
- `Class.getSuperclass`
- `Class.getModifiers`
- `Class.getClassAccessFlags`
- `Class.isArray`
- `Class.isPrimitive`
- `Class.isInterface`
- `Class.isHidden`

The implementation handles constant Class mirrors, primitive and `void`
mirrors, arrays, hidden classes, interfaces, unloaded classes, dynamic mirror
queries, null arguments, and class unloading.

A shared `klass_value_for_mirror` helper centralizes conversion from a Class
mirror to its corresponding Klass value. Static final Class mirrors are exposed
directly to Class intrinsic lowering, while unrelated static constants remain
normal loads so that downstream LLVM constant-field folding and type-analysis
passes can optimize them.

The frontend no longer duplicates generic constant folding already handled by
LLVM. Remaining frontend folds are limited to cases required for Java semantics
or intrinsic metadata construction.

### Why we need it

Class queries are common in reflection, serialization, framework dispatch, and
runtime type-checking paths. Without intrinsic lowering, these operations pay
the full Java call and metadata access overhead.

This change provides:

- lower latency for dynamic Class queries;
- direct handling of constant Class mirrors;
- better optimization opportunities for LLVM;
- a clear separation between Java semantic lowering and LLVM optimization;
- explicit coverage for primitive, hidden, unloaded, and class-unloading cases.

The implementation relies on the existing infrastructure in
`jeandle-llvm/main`, including Class mirror/Klass metadata folding and the
updated JavaType analysis. No additional LLVM patch is required in this PR.

### Testing

Fastdebug validation was performed with the matching LLVM configuration:

- LLVM: `MinSizeRel`, `LLVM_ENABLE_ASSERTIONS=ON`
- JDK: fastdebug

Results:

- `TestClassQueries.java`: passed
- `TestClassConstantUnloading.java`: passed
- LLVM constant-field-folding tests: 35/35 passed
- LLVM type-check-elimination tests: 7/7 passed

Release JDK and LLVM builds were also completed successfully.

### Performance

JMH was run with:

- release JDK and release LLVM;
- `ClassQueries` benchmarks;
- `kind=OBJECT`;
- one fork;
- two warmup iterations;
- three measurement iterations;
- single thread;
- unit: ns/op, lower is better.

| Benchmark | C2 | Jeandle intrinsic off | Jeandle intrinsic on |
|---|---:|---:|---:|
| Dynamic-query geometric mean (10 benchmarks) | 0.839 | 47.03 | 1.069 |
| `cast` | 1.604 | 45.71 | 1.444 |
| `isInstance` | 1.295 | 51.50 | 1.406 |
| `getSuperclass` | 1.328 | 46.72 | 1.505 |
| `constantCastObject` | 0.371 | 45.14 | 0.662 |
| `constantGetSuperclass` | 0.371 | 47.44 | 0.668 |
| `constantIsInstanceHit` | ≈0 | 44.55 | 0.354 |

With Class intrinsics enabled, the dynamic-query geometric mean improves by
approximately 44x compared with Jeandle with the Class intrinsics disabled.
It is approximately 27% slower than C2 on this dynamic subset.

Most constant Class queries are folded to near-zero cost. The remaining
non-folded constant cases are below 1 ns/op with the intrinsic enabled.
